### PR TITLE
add: build configuration for platform and editor

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+[target.'cfg(target_os = "windows")']
+rustflags = [ "--cfg", "platform_windows"]
+
+[target.'cfg(target_os = "linux")']
+rustflags = [ "--cfg", "platform_linux"]
+
+[target.'cfg(target_os = "macos")']
+rustflags = [ "--cfg", "platform_macos"]
+
+[target.'cfg(target_os = "android")']
+rustflags = [ "--cfg", "platform_android"]
+
+[target.'cfg(target_os = "ios")']
+rustflags = [ "--cfg", "platform_ios"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ name = "platform"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "build",
  "log",
  "thiserror 2.0.18",
  "winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "build"
+version = "0.1.0"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["Engine/Source/engine","Engine/Source/logging", "Engine/Source/platform","Engine/Source/run"]
+members = ["Engine/Source/build","Engine/Source/engine","Engine/Source/logging", "Engine/Source/platform","Engine/Source/run"]
 
 [workspace.package]
 edition = "2024"
@@ -17,6 +17,7 @@ time = { version = "0.3", features = ["formatting"] }
 thiserror = "2"
 anyhow = "1"
 # Engine modules
+build = { path = "Engine/Source/build" }
 logging = { path = "Engine/Source/logging" }
 engine = { path = "Engine/Source/engine" }
 platform = { path = "Engine/Source/platform" }

--- a/Engine/Source/build/Cargo.toml
+++ b/Engine/Source/build/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "build"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]

--- a/Engine/Source/build/src/lib.rs
+++ b/Engine/Source/build/src/lib.rs
@@ -1,0 +1,11 @@
+/// Setup build for platform configuration.
+/// Run this function in build.rs of a crate that
+/// runs platform specific code.
+pub fn configure_platform() {
+    // declare the config keys for platform specific conditional compilation
+    println!("cargo:rustc-check-cfg=cfg(platform_windows)");
+    println!("cargo:rustc-check-cfg=cfg(platform_linux)");
+    println!("cargo:rustc-check-cfg=cfg(platform_macos)");
+    println!("cargo:rustc-check-cfg=cfg(platform_android)");
+    println!("cargo:rustc-check-cfg=cfg(platform_ios)");
+}

--- a/Engine/Source/build/src/lib.rs
+++ b/Engine/Source/build/src/lib.rs
@@ -17,6 +17,6 @@ pub fn configure_editor() {
     // declare editor config keys
     println!("cargo:rustc-check-cfg=cfg(editor)");
 
-    // build as editor
+    // always build as editor for now
     println!("cargo:rustc-cfg=editor");
 }

--- a/Engine/Source/build/src/lib.rs
+++ b/Engine/Source/build/src/lib.rs
@@ -9,3 +9,14 @@ pub fn configure_platform() {
     println!("cargo:rustc-check-cfg=cfg(platform_android)");
     println!("cargo:rustc-check-cfg=cfg(platform_ios)");
 }
+
+/// Setup build for editor configuration.
+/// Run this function in build.rs of a create that
+/// runs editor (or not) specific code.
+pub fn configure_editor() {
+    // declare editor config keys
+    println!("cargo:rustc-check-cfg=cfg(editor)");
+
+    // build as editor
+    println!("cargo:rustc-cfg=editor");
+}

--- a/Engine/Source/platform/Cargo.toml
+++ b/Engine/Source/platform/Cargo.toml
@@ -11,3 +11,6 @@ log.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 winit.workspace = true
+
+[build-dependencies]
+build.workspace = true

--- a/Engine/Source/platform/build.rs
+++ b/Engine/Source/platform/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    build::configure_platform();
+}


### PR DESCRIPTION
- Add `build` package. This has utility functions to be used in `build.rs`.
  - `platform`
  - `editor`
- Add global Cargo `cfg` directives for platforms.