### PR TITLE
fix: issues with `Event` derive macro formatting

### DIFF
--- a/Engine/Source/events/src/lib.rs
+++ b/Engine/Source/events/src/lib.rs
@@ -125,7 +125,7 @@ impl<T: Event> Consumer<T> {
     }
 
     /// Returns an iterator that drains all currently pending events.
-    pub fn consume_all(&self) -> impl Iterator<Item = T> + '_ {
+    pub fn consume_all(&self) -> impl Iterator<Item = T> {
         std::iter::from_fn(|| self.receiver.try_recv().ok())
     }
 }

--- a/Engine/Source/events/src/lib.rs
+++ b/Engine/Source/events/src/lib.rs
@@ -48,9 +48,9 @@ impl EventManager {
     }
     /// Drains all producers and forwards their pending events to matching subscribers.
     /// Call this once per frame / tick in your engine loop.
-    pub fn dispatch_all(&self) {
+    pub fn dispatch_all(&mut self) {
         for producer in &self.producers {
-            producer.forward_pending(&self.subscribers);
+            producer.forward_pending(&mut self.subscribers);
         }
     }
 }
@@ -58,7 +58,7 @@ impl EventManager {
 /// The Type Erasure Trait
 /// Allows the EventManager to forward pending events without knowing `T`.
 trait AnyProducer: Send {
-    fn forward_pending(&self, subscribers: &HashMap<TypeId, Vec<Subscriber>>);
+    fn forward_pending(&self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>);
 }
 
 /// A producer is an object that will be queried for events.
@@ -74,18 +74,17 @@ struct TypedProducer<T: Event> {
 }
 
 impl<T: Event> AnyProducer for TypedProducer<T> {
-    fn forward_pending(&self, subscribers: &HashMap<TypeId, Vec<Subscriber>>) {
-        let Some(subscribers) = subscribers.get(&self.type_id) else {
+    fn forward_pending(&self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>) {
+        let Some(subscribers) = subscribers.get_mut(&self.type_id) else {
             return;
         };
 
         while let Ok(event) = self.receiver.try_recv() {
-            subscribers.iter().for_each(|sub| {
+            subscribers.retain(|sub| {
                 let Some(sender) = sub.sender.downcast_ref::<Sender<T>>() else {
-                    return;
+                    return true;
                 };
-                // Ignore send errors: it just means the Consumer was dropped.
-                let _ = sender.send(event.clone());
+                sender.send(event.clone()).is_ok()
             });
         }
     }

--- a/Engine/Source/events/src/lib.rs
+++ b/Engine/Source/events/src/lib.rs
@@ -99,6 +99,7 @@ struct Subscriber {
 
 /// This struct is created by the envent manager.
 /// It allows dispatching of events to subscribers.
+#[derive(Clone)]
 pub struct Dispatcher<T: Event> {
     sender: Sender<T>,
 }

--- a/Engine/Source/events/src/lib.rs
+++ b/Engine/Source/events/src/lib.rs
@@ -99,7 +99,6 @@ struct Subscriber {
 
 /// This struct is created by the envent manager.
 /// It allows dispatching of events to subscribers.
-#[derive(Clone)]
 pub struct Dispatcher<T: Event> {
     sender: Sender<T>,
 }

--- a/Engine/Source/events/src/tests.rs
+++ b/Engine/Source/events/src/tests.rs
@@ -168,6 +168,9 @@ enum NoAttrEnum {
     Beta(i32),
 }
 
+// can't really be tested as it doesn't have any fields.
+// just an easy feature to have when in development
+#[allow(unused)]
 #[derive(Debug, Clone, Event)]
 #[event("empty enum")]
 enum EmptyEnum {}

--- a/Engine/Source/events/src/tests.rs
+++ b/Engine/Source/events/src/tests.rs
@@ -168,6 +168,10 @@ enum NoAttrEnum {
     Beta(i32),
 }
 
+#[derive(Debug, Clone, Event)]
+#[event("empty enum")]
+enum EmptyEnum {}
+
 // =========================================================================
 // Section 2 – Derive-macro: `debug()` output assertions
 // =========================================================================

--- a/Engine/Source/events/src/tests.rs
+++ b/Engine/Source/events/src/tests.rs
@@ -1,458 +1,708 @@
+//! Unit tests for the `events` crate.
+//!
+//! Covers:
+//!   • `EventManager`: register, subscribe, dispatch_all, multi-type, multi-subscriber,
+//!     dropped-consumer pruning, buffering, zero-subscriber robustness.
+//!   • `#[derive(Event)]` macro: every combination of struct / enum × unit / named / unnamed
+//!     fields, with and without `#[event("…")]` format strings, partial field references,
+//!     and fields that appear in the format string vs. those that are silently ignored.
+
 #![cfg(test)]
 
-use super::*;
 use macros::Event;
-use std::thread;
-use std::time::Duration;
 
-// -------------------------------------------------------------------------
-// Test event types
-// -------------------------------------------------------------------------
+use crate::{Consumer, Dispatcher, Event, EventManager};
 
-#[derive(Event, Clone, Debug, PartialEq)]
-struct KeyEvent {
-    key: String,
-    pressed: bool,
+// =========================================================================
+// Helper: drain every pending event from a Consumer into a Vec.
+// =========================================================================
+
+fn collect<T: Event>(consumer: &Consumer<T>) -> Vec<T> {
+    consumer.consume_all().collect()
 }
 
-#[derive(Event, Clone, Debug, PartialEq)]
-struct MouseEvent {
-    x: f32,
-    y: f32,
+// =========================================================================
+// Section 1 – Derive-macro test types
+//
+// Rule: the macro must compile and `debug()` must return the expected string.
+// Every combination of struct / enum shape and attribute presence is exercised.
+// =========================================================================
+
+// ── 1.1  Unit struct ─────────────────────────────────────────────────────
+
+/// No `#[event]` attribute → falls back to `format!("{self:?}")`.
+#[derive(Debug, Clone, Event)]
+struct UnitStructDefault;
+
+/// Explicit static message.
+#[derive(Debug, Clone, Event)]
+#[event("unit-struct-event")]
+struct UnitStructWithAttr;
+
+// ── 1.2  Named-field struct ───────────────────────────────────────────────
+
+/// No attribute → `{self:?}`.
+#[derive(Debug, Clone, Event)]
+struct NamedStructDefault {
+    x: i32,
+    y: i32,
 }
 
-#[derive(Event, Clone, Debug, PartialEq)]
-struct WindowResizeEvent {
-    width: u32,
-    height: u32,
+/// All fields referenced in the format string.
+#[derive(Debug, Clone, Event)]
+#[event("moved to ({x}, {y})")]
+struct NamedStructAllFields {
+    x: i32,
+    y: i32,
 }
 
-// A zero-sized event used to test that marker-like events work.
-#[derive(Event, Clone, Debug, PartialEq)]
-struct TickEvent;
-
-// -------------------------------------------------------------------------
-// Unit tests — Dispatcher & Consumer basics
-// -------------------------------------------------------------------------
-
-#[test]
-fn dispatched_event_is_received_by_consumer() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<KeyEvent>();
-    let consumer = manager.subscribe::<KeyEvent>();
-
-    dispatcher.dispatch(KeyEvent {
-        key: "A".into(),
-        pressed: true,
-    });
-    manager.dispatch_all();
-
-    let received = consumer.try_consume();
-    assert_eq!(
-        received,
-        Some(KeyEvent {
-            key: "A".into(),
-            pressed: true
-        })
-    );
+/// Only *some* fields referenced – the rest must be silently allowed (the
+/// macro uses `..` in the destructure pattern).
+#[derive(Debug, Clone, Event)]
+#[event("x only: {x}")]
+struct NamedStructPartialFields {
+    x: i32,
+    _y: i32,
 }
 
-#[test]
-fn try_consume_returns_none_when_queue_is_empty() {
-    let mut manager = EventManager::new();
-    let _dispatcher = manager.register::<KeyEvent>();
-    let consumer = manager.subscribe::<KeyEvent>();
-
-    // No dispatch — queue must be empty.
-    manager.dispatch_all();
-    assert_eq!(consumer.try_consume(), None);
+/// Static string (no field interpolation), but struct *has* fields.
+#[derive(Debug, Clone, Event)]
+#[event("something happened")]
+struct NamedStructStaticMessage {
+    _payload: String,
 }
 
-#[test]
-fn try_consume_returns_none_before_dispatch_all() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<KeyEvent>();
-    let consumer = manager.subscribe::<KeyEvent>();
+// ── 1.3  Unnamed-field struct ─────────────────────────────────────────────
 
-    // Event queued but dispatch_all not called yet.
-    dispatcher.dispatch(KeyEvent {
-        key: "B".into(),
-        pressed: false,
-    });
-    assert_eq!(consumer.try_consume(), None);
+/// No attribute → `{self:?}`.
+#[derive(Debug, Clone, Event)]
+struct UnnamedStructDefault(i32, String);
+
+/// All positional fields referenced.
+#[derive(Debug, Clone, Event)]
+#[event("code={0} label={1}")]
+struct UnnamedStructAllFields(i32, String);
+
+/// Only the first field referenced; the second must not cause a compile error.
+#[derive(Debug, Clone, Event)]
+#[event("first={0}")]
+struct UnnamedStructFirstOnly(i32, String, f64);
+
+/// Only the last field of three referenced.
+#[derive(Debug, Clone, Event)]
+#[event("last={2}")]
+struct UnnamedStructLastOnly(i32, String, f64);
+
+/// Static string, no positional references.
+#[derive(Debug, Clone, Event)]
+#[event("unnamed static")]
+struct UnnamedStructStatic(u8, u8);
+
+// ── 1.4  Unit enum ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Event)]
+enum UnitEnum {
+    #[event("alpha occurred")]
+    Alpha,
+    #[event("beta occurred")]
+    Beta,
 }
 
-#[test]
-fn multiple_events_are_forwarded_in_order() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<KeyEvent>();
-    let consumer = manager.subscribe::<KeyEvent>();
-
-    let events = vec![
-        KeyEvent {
-            key: "A".into(),
-            pressed: true,
-        },
-        KeyEvent {
-            key: "B".into(),
-            pressed: true,
-        },
-        KeyEvent {
-            key: "A".into(),
-            pressed: false,
-        },
-    ];
-
-    for e in &events {
-        dispatcher.dispatch(e.clone());
-    }
-    manager.dispatch_all();
-
-    let received: Vec<KeyEvent> = consumer.consume_all().collect();
-    assert_eq!(received, events);
+/// No attribute on variants → `{self:?}`.
+#[derive(Debug, Clone, Event)]
+enum UnitEnumDefault {
+    Foo,
+    Bar,
 }
 
-#[test]
-fn consume_all_drains_the_queue_completely() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<TickEvent>();
-    let consumer = manager.subscribe::<TickEvent>();
+// ── 1.5  Named-field enum ─────────────────────────────────────────────────
 
-    for _ in 0..5 {
-        dispatcher.dispatch(TickEvent);
-    }
-    manager.dispatch_all();
+#[derive(Debug, Clone, Event)]
+enum NamedEnum {
+    #[event("resized to {width}×{height}")]
+    Resized { width: u32, height: u32 },
 
-    let count = consumer.consume_all().count();
-    assert_eq!(count, 5);
+    /// Only one field used; `_z` is bound but then ignored.
+    #[event("moved to ({x}, {y})")]
+    Moved { x: f32, y: f32, _z: f32 },
 
-    // A second call on the same frame should yield nothing.
-    assert_eq!(consumer.consume_all().count(), 0);
+    /// Static message, all fields ignored.
+    #[event("reset")]
+    Reset { _dummy: bool },
 }
 
-// -------------------------------------------------------------------------
-// Unit tests — multiple subscribers
-// -------------------------------------------------------------------------
+// ── 1.6  Unnamed-field enum ───────────────────────────────────────────────
 
-#[test]
-fn event_is_cloned_to_all_subscribers() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<MouseEvent>();
-    let consumer_a = manager.subscribe::<MouseEvent>();
-    let consumer_b = manager.subscribe::<MouseEvent>();
+#[derive(Debug, Clone, Event)]
+enum UnnamedEnum {
+    #[event("single={0}")]
+    Single(i32),
 
-    dispatcher.dispatch(MouseEvent { x: 1.0, y: 2.0 });
-    manager.dispatch_all();
+    #[event("pair: {0} / {1}")]
+    Pair(String, String),
 
-    assert_eq!(
-        consumer_a.try_consume(),
-        Some(MouseEvent { x: 1.0, y: 2.0 })
-    );
-    assert_eq!(
-        consumer_b.try_consume(),
-        Some(MouseEvent { x: 1.0, y: 2.0 })
-    );
+    /// First field only, second silently discarded.
+    #[event("head={0}")]
+    Head(u8, u8),
 }
 
-#[test]
-fn multiple_events_reach_all_subscribers() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<TickEvent>();
-    let consumer_a = manager.subscribe::<TickEvent>();
-    let consumer_b = manager.subscribe::<TickEvent>();
-    let consumer_c = manager.subscribe::<TickEvent>();
+// ── 1.7  Mixed enum (unit + named + unnamed variants) ────────────────────
 
-    for _ in 0..3 {
-        dispatcher.dispatch(TickEvent);
-    }
-    manager.dispatch_all();
+#[derive(Debug, Clone, Event)]
+enum MixedEnum {
+    #[event("just a unit")]
+    Unit,
 
-    for consumer in [&consumer_a, &consumer_b, &consumer_c] {
-        assert_eq!(consumer.consume_all().count(), 3);
-    }
+    #[event("named: id={id}")]
+    Named { id: u64 },
+
+    #[event("unnamed: {0}")]
+    Unnamed(String),
 }
 
-// -------------------------------------------------------------------------
-// Unit tests — type isolation
-// -------------------------------------------------------------------------
+// ── 1.8  Enum – no attributes at all (every variant defaults to {self:?}) ─
 
-#[test]
-fn different_event_types_are_isolated() {
-    let mut manager = EventManager::new();
-    let key_dispatcher = manager.register::<KeyEvent>();
-    let mouse_dispatcher = manager.register::<MouseEvent>();
-
-    let key_consumer = manager.subscribe::<KeyEvent>();
-    let mouse_consumer = manager.subscribe::<MouseEvent>();
-
-    key_dispatcher.dispatch(KeyEvent {
-        key: "Space".into(),
-        pressed: true,
-    });
-    mouse_dispatcher.dispatch(MouseEvent { x: 0.5, y: 0.5 });
-    manager.dispatch_all();
-
-    // Key consumer receives only key events.
-    assert!(key_consumer.try_consume().is_some());
-    assert!(key_consumer.try_consume().is_none()); // No mouse event leaked in.
-
-    // Mouse consumer receives only mouse events.
-    assert!(mouse_consumer.try_consume().is_some());
-    assert!(mouse_consumer.try_consume().is_none());
+#[derive(Debug, Clone, Event)]
+enum NoAttrEnum {
+    Alpha,
+    Beta(i32),
 }
 
-#[test]
-fn subscriber_without_matching_producer_never_receives_events() {
-    let mut manager = EventManager::new();
-    // Register a producer for KeyEvent, but subscribe to MouseEvent instead.
-    let _key_dispatcher = manager.register::<KeyEvent>();
-    let mouse_consumer = manager.subscribe::<MouseEvent>();
+// =========================================================================
+// Section 2 – Derive-macro: `debug()` output assertions
+// =========================================================================
 
-    _key_dispatcher.dispatch(KeyEvent {
-        key: "X".into(),
-        pressed: true,
-    });
-    manager.dispatch_all();
+mod macro_debug_output {
+    use super::*;
 
-    assert_eq!(mouse_consumer.try_consume(), None);
-}
+    // ── Unit structs ─────────────────────────────────────────────────────
 
-// -------------------------------------------------------------------------
-// Unit tests — multiple dispatchers for the same type
-// -------------------------------------------------------------------------
-
-#[test]
-fn two_dispatchers_for_same_type_both_reach_subscriber() {
-    let mut manager = EventManager::new();
-    let dispatcher_a = manager.register::<TickEvent>();
-    let dispatcher_b = manager.register::<TickEvent>();
-    let consumer = manager.subscribe::<TickEvent>();
-
-    dispatcher_a.dispatch(TickEvent);
-    dispatcher_b.dispatch(TickEvent);
-    manager.dispatch_all();
-
-    assert_eq!(consumer.consume_all().count(), 2);
-}
-
-// -------------------------------------------------------------------------
-// Unit tests — dropped handles
-// -------------------------------------------------------------------------
-
-#[test]
-fn dispatch_after_consumer_dropped_does_not_panic() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<TickEvent>();
-    {
-        let _consumer = manager.subscribe::<TickEvent>();
-        // Consumer dropped at end of this scope.
+    #[test]
+    fn unit_struct_default_uses_debug_repr() {
+        let e = UnitStructDefault;
+        // The default branch produces `format!("{self:?}")`.
+        assert_eq!(e.debug(), format!("{:?}", UnitStructDefault));
     }
 
-    // Should silently discard the event instead of panicking.
-    dispatcher.dispatch(TickEvent);
-    manager.dispatch_all(); // Must not panic.
-}
+    #[test]
+    fn unit_struct_with_attr_returns_literal() {
+        assert_eq!(UnitStructWithAttr.debug(), "unit-struct-event");
+    }
 
-#[test]
-fn dispatch_after_manager_dropped_does_not_panic() {
-    let dispatcher = {
-        let mut manager = EventManager::new();
-        let d = manager.register::<TickEvent>();
-        let _consumer = manager.subscribe::<TickEvent>();
-        d
-        // manager (and therefore the receiver) dropped here.
-    };
+    // ── Named-field structs ───────────────────────────────────────────────
 
-    // Sending to a disconnected channel should be silently ignored.
-    dispatcher.dispatch(TickEvent); // Must not panic.
-}
+    #[test]
+    fn named_struct_default_uses_debug_repr() {
+        let e = NamedStructDefault { x: 3, y: 7 };
+        assert_eq!(e.debug(), format!("{:?}", e));
+    }
 
-// -------------------------------------------------------------------------
-// Unit tests — zero-sized / marker events
-// -------------------------------------------------------------------------
+    #[test]
+    fn named_struct_all_fields_interpolated() {
+        let e = NamedStructAllFields { x: 10, y: -5 };
+        assert_eq!(e.debug(), "moved to (10, -5)");
+    }
 
-#[test]
-fn zero_sized_event_round_trips_correctly() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<TickEvent>();
-    let consumer = manager.subscribe::<TickEvent>();
+    #[test]
+    fn named_struct_partial_fields_only_referenced_one() {
+        let e = NamedStructPartialFields { x: 42, _y: 99 };
+        assert_eq!(e.debug(), "x only: 42");
+    }
 
-    dispatcher.dispatch(TickEvent);
-    manager.dispatch_all();
+    #[test]
+    fn named_struct_static_message_ignores_fields() {
+        let e = NamedStructStaticMessage {
+            _payload: "ignored".into(),
+        };
+        assert_eq!(e.debug(), "something happened");
+    }
 
-    assert_eq!(consumer.try_consume(), Some(TickEvent));
-}
+    // ── Unnamed-field structs ─────────────────────────────────────────────
 
-// -------------------------------------------------------------------------
-// Unit tests — idempotency across frames
-// -------------------------------------------------------------------------
+    #[test]
+    fn unnamed_struct_default_uses_debug_repr() {
+        let e = UnnamedStructDefault(7, "hello".into());
+        assert_eq!(e.debug(), format!("{:?}", e));
+    }
 
-#[test]
-fn events_do_not_carry_over_between_frames() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<TickEvent>();
-    let consumer = manager.subscribe::<TickEvent>();
+    #[test]
+    fn unnamed_struct_all_fields_interpolated() {
+        let e = UnnamedStructAllFields(404, "not found".into());
+        assert_eq!(e.debug(), "code=404 label=not found");
+    }
 
-    // Frame 1: dispatch one event and consume it.
-    dispatcher.dispatch(TickEvent);
-    manager.dispatch_all();
-    let _ = consumer.try_consume();
+    #[test]
+    fn unnamed_struct_first_field_only() {
+        let e = UnnamedStructFirstOnly(1, "ignored".into(), 3.14);
+        assert_eq!(e.debug(), "first=1");
+    }
 
-    // Frame 2: no new dispatch.
-    manager.dispatch_all();
-    assert_eq!(
-        consumer.try_consume(),
-        None,
-        "Stale event leaked into next frame"
-    );
-}
+    #[test]
+    fn unnamed_struct_last_field_only() {
+        // Only {2} is referenced; _0 and _1 are not bound.
+        let e = UnnamedStructLastOnly(0, "skip".into(), 2.72);
+        assert!(e.debug().contains("2.72"));
+    }
 
-#[test]
-fn dispatch_all_is_idempotent_when_queue_is_empty() {
-    let mut manager = EventManager::new();
-    let _dispatcher = manager.register::<TickEvent>();
-    let consumer = manager.subscribe::<TickEvent>();
+    #[test]
+    fn unnamed_struct_static_ignores_all_fields() {
+        let e = UnnamedStructStatic(1, 2);
+        assert_eq!(e.debug(), "unnamed static");
+    }
 
-    // Calling dispatch_all with nothing queued must be a no-op.
-    manager.dispatch_all();
-    manager.dispatch_all();
-    assert_eq!(consumer.try_consume(), None);
-}
+    // ── Unit enum ─────────────────────────────────────────────────────────
 
-// -------------------------------------------------------------------------
-// Integration tests
-// -------------------------------------------------------------------------
+    #[test]
+    fn unit_enum_each_variant_returns_its_message() {
+        assert_eq!(UnitEnum::Alpha.debug(), "alpha occurred");
+        assert_eq!(UnitEnum::Beta.debug(), "beta occurred");
+    }
 
-/// Simulates a three-frame engine loop where events from multiple systems
-/// are dispatched and consumed each frame.
-#[test]
-fn integration_multi_frame_engine_loop() {
-    let mut manager = EventManager::new();
-    let key_dispatcher = manager.register::<KeyEvent>();
-    let mouse_dispatcher = manager.register::<MouseEvent>();
-    let key_consumer = manager.subscribe::<KeyEvent>();
-    let mouse_consumer = manager.subscribe::<MouseEvent>();
+    #[test]
+    fn unit_enum_default_uses_debug_repr() {
+        assert_eq!(
+            UnitEnumDefault::Foo.debug(),
+            format!("{:?}", UnitEnumDefault::Foo)
+        );
+        assert_eq!(
+            UnitEnumDefault::Bar.debug(),
+            format!("{:?}", UnitEnumDefault::Bar)
+        );
+    }
 
-    // --- Frame 1 ---
-    key_dispatcher.dispatch(KeyEvent {
-        key: "W".into(),
-        pressed: true,
-    });
-    mouse_dispatcher.dispatch(MouseEvent { x: 10.0, y: 20.0 });
-    manager.dispatch_all();
+    // ── Named-field enum ──────────────────────────────────────────────────
 
-    assert_eq!(key_consumer.consume_all().count(), 1);
-    assert_eq!(mouse_consumer.consume_all().count(), 1);
-
-    // --- Frame 2 ---
-    // No events dispatched; both queues should be empty.
-    manager.dispatch_all();
-    assert_eq!(key_consumer.try_consume(), None);
-    assert_eq!(mouse_consumer.try_consume(), None);
-
-    // --- Frame 3 ---
-    key_dispatcher.dispatch(KeyEvent {
-        key: "W".into(),
-        pressed: false,
-    });
-    mouse_dispatcher.dispatch(MouseEvent { x: 15.0, y: 25.0 });
-    mouse_dispatcher.dispatch(MouseEvent { x: 16.0, y: 26.0 });
-    manager.dispatch_all();
-
-    assert_eq!(key_consumer.consume_all().count(), 1);
-    assert_eq!(mouse_consumer.consume_all().count(), 2);
-}
-
-/// Two independent subsystems subscribe to the same event type.
-/// Both must receive every event, independently.
-#[test]
-fn integration_two_systems_react_to_same_event() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<WindowResizeEvent>();
-
-    // "Renderer" and "UI system" both care about resize events.
-    let renderer = manager.subscribe::<WindowResizeEvent>();
-    let ui_system = manager.subscribe::<WindowResizeEvent>();
-
-    dispatcher.dispatch(WindowResizeEvent {
-        width: 1920,
-        height: 1080,
-    });
-    manager.dispatch_all();
-
-    let renderer_events: Vec<_> = renderer.consume_all().collect();
-    let ui_events: Vec<_> = ui_system.consume_all().collect();
-
-    assert_eq!(renderer_events.len(), 1);
-    assert_eq!(ui_events.len(), 1);
-    assert_eq!(
-        renderer_events[0],
-        WindowResizeEvent {
+    #[test]
+    fn named_enum_resized_interpolates_both_fields() {
+        let e = NamedEnum::Resized {
             width: 1920,
-            height: 1080
+            height: 1080,
+        };
+        assert_eq!(e.debug(), "resized to 1920×1080");
+    }
+
+    #[test]
+    fn named_enum_moved_interpolates_two_of_three_fields() {
+        let e = NamedEnum::Moved {
+            x: 1.0,
+            y: 2.5,
+            _z: 0.0,
+        };
+        assert_eq!(e.debug(), "moved to (1, 2.5)");
+    }
+
+    #[test]
+    fn named_enum_reset_static_message() {
+        let e = NamedEnum::Reset { _dummy: true };
+        assert_eq!(e.debug(), "reset");
+    }
+
+    // ── Unnamed-field enum ────────────────────────────────────────────────
+
+    #[test]
+    fn unnamed_enum_single_field() {
+        assert_eq!(UnnamedEnum::Single(99).debug(), "single=99");
+    }
+
+    #[test]
+    fn unnamed_enum_pair_both_fields() {
+        let e = UnnamedEnum::Pair("hello".into(), "world".into());
+        assert_eq!(e.debug(), "pair: hello / world");
+    }
+
+    #[test]
+    fn unnamed_enum_head_first_field_only() {
+        let e = UnnamedEnum::Head(7, 255);
+        assert_eq!(e.debug(), "head=7");
+    }
+
+    // ── Mixed enum ────────────────────────────────────────────────────────
+
+    #[test]
+    fn mixed_enum_unit_variant() {
+        assert_eq!(MixedEnum::Unit.debug(), "just a unit");
+    }
+
+    #[test]
+    fn mixed_enum_named_variant() {
+        let e = MixedEnum::Named { id: 1234567890 };
+        assert_eq!(e.debug(), "named: id=1234567890");
+    }
+
+    #[test]
+    fn mixed_enum_unnamed_variant() {
+        let e = MixedEnum::Unnamed("payload".into());
+        assert_eq!(e.debug(), "unnamed: payload");
+    }
+
+    // ── Enum without any attributes ───────────────────────────────────────
+
+    #[test]
+    fn no_attr_enum_falls_back_to_debug() {
+        assert_eq!(
+            NoAttrEnum::Alpha.debug(),
+            format!("{:?}", NoAttrEnum::Alpha)
+        );
+        assert_eq!(
+            NoAttrEnum::Beta(42).debug(),
+            format!("{:?}", NoAttrEnum::Beta(42))
+        );
+    }
+}
+
+// =========================================================================
+// Section 3 – EventManager: core behaviour
+// =========================================================================
+
+mod event_manager {
+    use super::*;
+
+    // A minimal event used by most tests below.
+    #[derive(Debug, Clone, Event)]
+    #[event("counter={0}")]
+    struct CounterEvent(u32);
+
+    // A second, distinct event type to test type isolation.
+    #[derive(Debug, Clone, Event)]
+    #[event("label={0}")]
+    struct LabelEvent(String);
+
+    // ── 3.1  Basic round-trip ─────────────────────────────────────────────
+
+    #[test]
+    fn single_event_reaches_single_subscriber() {
+        let mut mgr = EventManager::new();
+        let dispatcher: Dispatcher<CounterEvent> = mgr.register();
+        let consumer: Consumer<CounterEvent> = mgr.subscribe();
+
+        dispatcher.dispatch(CounterEvent(1));
+        mgr.dispatch_all();
+
+        let events = collect(&consumer);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, 1);
+    }
+
+    #[test]
+    fn multiple_events_all_reach_subscriber() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        for i in 0..5 {
+            dispatcher.dispatch(CounterEvent(i));
         }
-    );
-    assert_eq!(ui_events[0], renderer_events[0]);
-}
+        mgr.dispatch_all();
 
-/// Verifies that the Dispatcher can safely be sent to another thread and
-/// that events produced off-thread are forwarded correctly on the next
-/// call to dispatch_all (which runs on the main thread).
-#[test]
-fn integration_dispatcher_usable_from_another_thread() {
-    let mut manager = EventManager::new();
-    let dispatcher = manager.register::<KeyEvent>();
-    let consumer = manager.subscribe::<KeyEvent>();
-
-    let handle = thread::spawn(move || {
-        dispatcher.dispatch(KeyEvent {
-            key: "Enter".into(),
-            pressed: true,
-        });
-    });
-
-    handle.join().expect("thread panicked");
-
-    // Give the channel time to settle (it's synchronous, so this is
-    // just belt-and-braces).
-    thread::sleep(Duration::from_millis(10));
-
-    manager.dispatch_all();
-    assert_eq!(
-        consumer.try_consume(),
-        Some(KeyEvent {
-            key: "Enter".into(),
-            pressed: true
-        })
-    );
-}
-
-/// Stress test: large volume of events across multiple types in one frame.
-#[test]
-fn integration_high_volume_single_frame() {
-    const N: usize = 10_000;
-
-    let mut manager = EventManager::new();
-    let tick_dispatcher = manager.register::<TickEvent>();
-    let key_dispatcher = manager.register::<KeyEvent>();
-
-    let tick_consumer_a = manager.subscribe::<TickEvent>();
-    let tick_consumer_b = manager.subscribe::<TickEvent>();
-    let key_consumer = manager.subscribe::<KeyEvent>();
-
-    for _ in 0..N {
-        tick_dispatcher.dispatch(TickEvent);
-    }
-    for i in 0..N {
-        key_dispatcher.dispatch(KeyEvent {
-            key: format!("key_{i}"),
-            pressed: i % 2 == 0,
-        });
+        let values: Vec<u32> = collect(&consumer).into_iter().map(|e| e.0).collect();
+        assert_eq!(values, vec![0, 1, 2, 3, 4]);
     }
 
-    manager.dispatch_all();
+    // ── 3.2  Buffering ────────────────────────────────────────────────────
 
-    assert_eq!(tick_consumer_a.consume_all().count(), N);
-    assert_eq!(tick_consumer_b.consume_all().count(), N);
-    assert_eq!(key_consumer.consume_all().count(), N);
+    #[test]
+    fn events_are_buffered_until_dispatch_all() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        dispatcher.dispatch(CounterEvent(42));
+
+        // Nothing delivered yet.
+        assert!(collect(&consumer).is_empty());
+
+        mgr.dispatch_all();
+        assert_eq!(collect(&consumer).len(), 1);
+    }
+
+    #[test]
+    fn dispatch_all_can_be_called_multiple_times() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        dispatcher.dispatch(CounterEvent(1));
+        mgr.dispatch_all();
+
+        dispatcher.dispatch(CounterEvent(2));
+        mgr.dispatch_all();
+
+        // Each tick delivers one event.
+        let first = collect(&consumer);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].0, 1);
+
+        let second = collect(&consumer);
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].0, 2);
+    }
+
+    #[test]
+    fn no_events_means_empty_consumer() {
+        let mut mgr = EventManager::new();
+        let _dispatcher = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        mgr.dispatch_all();
+        assert!(collect(&consumer).is_empty());
+    }
+
+    // ── 3.3  Fan-out: multiple subscribers ────────────────────────────────
+
+    #[test]
+    fn single_event_reaches_all_subscribers() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+        let c1 = mgr.subscribe::<CounterEvent>();
+        let c2 = mgr.subscribe::<CounterEvent>();
+        let c3 = mgr.subscribe::<CounterEvent>();
+
+        dispatcher.dispatch(CounterEvent(99));
+        mgr.dispatch_all();
+
+        for consumer in [&c1, &c2, &c3] {
+            let events = collect(consumer);
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].0, 99);
+        }
+    }
+
+    #[test]
+    fn multiple_events_fan_out_to_all_subscribers() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+        let c1 = mgr.subscribe::<CounterEvent>();
+        let c2 = mgr.subscribe::<CounterEvent>();
+
+        for i in 0..3 {
+            dispatcher.dispatch(CounterEvent(i));
+        }
+        mgr.dispatch_all();
+
+        for consumer in [&c1, &c2] {
+            let values: Vec<u32> = collect(consumer).into_iter().map(|e| e.0).collect();
+            assert_eq!(values, vec![0, 1, 2]);
+        }
+    }
+
+    // ── 3.4  Type isolation ───────────────────────────────────────────────
+
+    #[test]
+    fn subscribers_only_receive_their_event_type() {
+        let mut mgr = EventManager::new();
+        let counter_dispatcher = mgr.register::<CounterEvent>();
+        let label_dispatcher = mgr.register::<LabelEvent>();
+
+        let counter_consumer = mgr.subscribe::<CounterEvent>();
+        let label_consumer = mgr.subscribe::<LabelEvent>();
+
+        counter_dispatcher.dispatch(CounterEvent(7));
+        label_dispatcher.dispatch(LabelEvent("hello".into()));
+        mgr.dispatch_all();
+
+        let counters = collect(&counter_consumer);
+        assert_eq!(counters.len(), 1);
+        assert_eq!(counters[0].0, 7);
+
+        let labels = collect(&label_consumer);
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels[0].0, "hello");
+    }
+
+    #[test]
+    fn no_cross_contamination_between_event_types() {
+        let mut mgr = EventManager::new();
+        let counter_dispatcher = mgr.register::<CounterEvent>();
+        let _label_dispatcher = mgr.register::<LabelEvent>();
+
+        let counter_consumer = mgr.subscribe::<CounterEvent>();
+        let label_consumer = mgr.subscribe::<LabelEvent>();
+
+        // Only fire a CounterEvent.
+        counter_dispatcher.dispatch(CounterEvent(1));
+        mgr.dispatch_all();
+
+        assert_eq!(collect(&counter_consumer).len(), 1);
+        assert!(collect(&label_consumer).is_empty()); // Must not receive anything.
+    }
+
+    // ── 3.5  No subscribers registered ───────────────────────────────────
+
+    #[test]
+    fn dispatching_with_no_subscribers_does_not_panic() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+
+        dispatcher.dispatch(CounterEvent(0));
+        // Must not panic even though nobody is listening.
+        mgr.dispatch_all();
+    }
+
+    #[test]
+    fn dispatch_all_on_empty_manager_does_not_panic() {
+        let mut mgr = EventManager::new();
+        mgr.dispatch_all(); // Nothing registered at all.
+    }
+
+    // ── 3.6  Dropped-consumer pruning ────────────────────────────────────
+
+    #[test]
+    fn dropped_consumer_is_pruned_silently() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+
+        let alive = mgr.subscribe::<CounterEvent>();
+        {
+            let _dead = mgr.subscribe::<CounterEvent>();
+            // `_dead` is dropped here; its receiver is gone.
+        }
+
+        // Subsequent dispatches must not panic.
+        dispatcher.dispatch(CounterEvent(5));
+        mgr.dispatch_all();
+
+        let events = collect(&alive);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, 5);
+    }
+
+    #[test]
+    fn all_consumers_dropped_does_not_panic() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+
+        {
+            let _c1 = mgr.subscribe::<CounterEvent>();
+            let _c2 = mgr.subscribe::<CounterEvent>();
+        } // Both dropped here.
+
+        dispatcher.dispatch(CounterEvent(1));
+        mgr.dispatch_all(); // Must not panic.
+    }
+
+    // ── 3.7  Dropped Dispatcher ────────────────────────────────────────────
+
+    #[test]
+    fn subscribing_without_dispatcher_gives_empty_consumer() {
+        let mut mgr = EventManager::new();
+        // Subscribe before any dispatcher is registered for this type.
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        let _dispatcher = mgr.register::<CounterEvent>();
+        // No events dispatched.
+        mgr.dispatch_all();
+
+        assert!(collect(&consumer).is_empty());
+    }
+
+    // ── 3.8  High-volume stress ───────────────────────────────────────────
+
+    #[test]
+    fn high_volume_events_all_delivered() {
+        const N: u32 = 10_000;
+
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        for i in 0..N {
+            dispatcher.dispatch(CounterEvent(i));
+        }
+        mgr.dispatch_all();
+
+        let events = collect(&consumer);
+        assert_eq!(events.len() as u32, N);
+        for (i, event) in events.iter().enumerate() {
+            assert_eq!(event.0, i as u32);
+        }
+    }
+
+    // ── 3.9  Multiple ticks accumulate correctly ──────────────────────────
+
+    #[test]
+    fn events_accumulate_correctly_across_many_ticks() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        let ticks = 10u32;
+        let per_tick = 3u32;
+
+        for tick in 0..ticks {
+            for j in 0..per_tick {
+                dispatcher.dispatch(CounterEvent(tick * per_tick + j));
+            }
+            mgr.dispatch_all();
+        }
+
+        // Drain everything accumulated.
+        let all: Vec<u32> = collect(&consumer).into_iter().map(|e| e.0).collect();
+        let expected: Vec<u32> = (0..ticks * per_tick).collect();
+        assert_eq!(all, expected);
+    }
+
+    // ── 3.10  try_consume ─────────────────────────────────────────────────
+
+    #[test]
+    fn try_consume_returns_none_when_empty() {
+        let mut mgr = EventManager::new();
+        let _dispatcher = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        mgr.dispatch_all();
+        assert!(consumer.try_consume().is_none());
+    }
+
+    #[test]
+    fn try_consume_drains_one_at_a_time() {
+        let mut mgr = EventManager::new();
+        let dispatcher = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        dispatcher.dispatch(CounterEvent(1));
+        dispatcher.dispatch(CounterEvent(2));
+        mgr.dispatch_all();
+
+        assert_eq!(consumer.try_consume().unwrap().0, 1);
+        assert_eq!(consumer.try_consume().unwrap().0, 2);
+        assert!(consumer.try_consume().is_none());
+    }
+
+    // ── 3.11  Multiple dispatchers for the same type ──────────────────────
+
+    #[test]
+    fn two_dispatchers_for_same_type_both_reach_subscriber() {
+        let mut mgr = EventManager::new();
+        let d1 = mgr.register::<CounterEvent>();
+        let d2 = mgr.register::<CounterEvent>();
+        let consumer = mgr.subscribe::<CounterEvent>();
+
+        d1.dispatch(CounterEvent(1));
+        d2.dispatch(CounterEvent(2));
+        mgr.dispatch_all();
+
+        let mut values: Vec<u32> = collect(&consumer).into_iter().map(|e| e.0).collect();
+        values.sort(); // Order across producers is not guaranteed.
+        assert_eq!(values, vec![1, 2]);
+    }
+
+    // ── 3.12  EventManager::new() vs Default ─────────────────────────────
+
+    #[test]
+    fn new_and_default_are_equivalent() {
+        let mut mgr_new = EventManager::new();
+        let mut mgr_default = EventManager::default();
+
+        let d1 = mgr_new.register::<CounterEvent>();
+        let c1 = mgr_new.subscribe::<CounterEvent>();
+        d1.dispatch(CounterEvent(1));
+        mgr_new.dispatch_all();
+        assert_eq!(collect(&c1).len(), 1);
+
+        let d2 = mgr_default.register::<CounterEvent>();
+        let c2 = mgr_default.subscribe::<CounterEvent>();
+        d2.dispatch(CounterEvent(1));
+        mgr_default.dispatch_all();
+        assert_eq!(collect(&c2).len(), 1);
+    }
 }

--- a/Engine/Source/events/src/tests.rs
+++ b/Engine/Source/events/src/tests.rs
@@ -425,16 +425,16 @@ mod event_manager {
         let dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
+        // Each tick delivers one event.
         dispatcher.dispatch(CounterEvent(1));
         mgr.dispatch_all();
 
-        dispatcher.dispatch(CounterEvent(2));
-        mgr.dispatch_all();
-
-        // Each tick delivers one event.
         let first = collect(&consumer);
         assert_eq!(first.len(), 1);
         assert_eq!(first[0].0, 1);
+
+        dispatcher.dispatch(CounterEvent(2));
+        mgr.dispatch_all();
 
         let second = collect(&consumer);
         assert_eq!(second.len(), 1);

--- a/Engine/Source/events/tests/integrations.rs
+++ b/Engine/Source/events/tests/integrations.rs
@@ -72,8 +72,12 @@ struct RawEvent {
 #[derive(Debug, Clone, Event)]
 enum RawEnumEvent {
     A,
+    // this field is used
+    #[allow(unused)]
     B(i32),
-    C { label: String },
+    C {
+        label: String,
+    },
 }
 
 // =============================================================================

--- a/Engine/Source/events/tests/integrations.rs
+++ b/Engine/Source/events/tests/integrations.rs
@@ -1,0 +1,349 @@
+//! Integration tests for the `events` crate.
+//!
+//! These tests live in `events/tests/` and therefore exercise only the public API.
+//! They cover cross-crate usage of the Event derive macro, realistic engine-loop
+//! simulations, and concurrency safety.
+
+use events::{Consumer, Dispatcher, Event, EventManager};
+use macros::Event;
+use std::thread;
+
+// =============================================================================
+// Helper
+// =============================================================================
+
+fn collect_all<T: Event>(consumer: &Consumer<T>) -> Vec<T> {
+    consumer.consume_all().collect()
+}
+
+// =============================================================================
+// Section A – Derive macro: Event types defined outside the crate
+//
+// Ensures the macro works when the user crate defines its own event types
+// (the most common real-world scenario).
+// =============================================================================
+
+// ── A.1  A realistic application event hierarchy ──────────────────────────────
+
+#[derive(Debug, Clone, Event)]
+#[event("window resized to {width}×{height} px")]
+struct WindowResized {
+    width: u32,
+    height: u32,
+}
+
+#[derive(Debug, Clone, Event)]
+#[event("key pressed: code={0}")]
+struct KeyPressed(u32);
+
+#[derive(Debug, Clone, Event)]
+#[event("mouse moved to ({x:.1}, {y:.1})")]
+struct MouseMoved {
+    x: f64,
+    y: f64,
+}
+
+/// Unit event – fired once, carries no payload.
+#[derive(Debug, Clone, Event)]
+#[event("application shutdown requested")]
+struct ShutdownRequested;
+
+/// Enum event mixing all three variant kinds.
+#[derive(Debug, Clone, Event)]
+enum NetworkEvent {
+    #[event("connected to {host}:{port}")]
+    Connected { host: String, port: u16 },
+
+    #[event("disconnected")]
+    Disconnected,
+
+    #[event("packet received: {0} bytes")]
+    PacketReceived(usize),
+}
+
+// ── A.2  Types whose `debug()` relies on `{self:?}` (no attribute) ────────────
+
+#[derive(Debug, Clone, Event)]
+struct RawEvent {
+    id: u32,
+    tag: &'static str,
+}
+
+#[derive(Debug, Clone, Event)]
+enum RawEnumEvent {
+    A,
+    B(i32),
+    C { label: String },
+}
+
+// =============================================================================
+// Section B – `debug()` correctness for integration-level types
+// =============================================================================
+
+#[test]
+fn window_resized_debug_contains_dimensions() {
+    let e = WindowResized {
+        width: 1920,
+        height: 1080,
+    };
+    assert_eq!(e.debug(), "window resized to 1920×1080 px");
+}
+
+#[test]
+fn key_pressed_debug_contains_code() {
+    assert_eq!(KeyPressed(65).debug(), "key pressed: code=65");
+}
+
+#[test]
+fn mouse_moved_debug_contains_coordinates() {
+    let e = MouseMoved { x: 12.3, y: 45.6 };
+    let dbg = e.debug();
+    assert!(dbg.contains("12.3"), "debug output: {}", dbg);
+    assert!(dbg.contains("45.6"), "debug output: {}", dbg);
+}
+
+#[test]
+fn shutdown_requested_is_static_string() {
+    assert_eq!(ShutdownRequested.debug(), "application shutdown requested");
+}
+
+#[test]
+fn network_event_connected_interpolates_host_and_port() {
+    let e = NetworkEvent::Connected {
+        host: "127.0.0.1".into(),
+        port: 8080,
+    };
+    assert_eq!(e.debug(), "connected to 127.0.0.1:8080");
+}
+
+#[test]
+fn network_event_disconnected_is_static() {
+    assert_eq!(NetworkEvent::Disconnected.debug(), "disconnected");
+}
+
+#[test]
+fn network_event_packet_received_shows_byte_count() {
+    assert_eq!(
+        NetworkEvent::PacketReceived(512).debug(),
+        "packet received: 512 bytes"
+    );
+}
+
+#[test]
+fn raw_event_falls_back_to_debug_repr() {
+    let e = RawEvent { id: 1, tag: "test" };
+    let dbg = e.debug();
+    // The default uses `{self:?}` so the Debug impl must round-trip.
+    assert!(dbg.contains("RawEvent"));
+    assert!(dbg.contains('1'));
+    assert!(dbg.contains("test"));
+}
+
+#[test]
+fn raw_enum_event_each_variant_falls_back_to_debug() {
+    assert_eq!(RawEnumEvent::A.debug(), format!("{:?}", RawEnumEvent::A));
+    assert_eq!(
+        RawEnumEvent::B(7).debug(),
+        format!("{:?}", RawEnumEvent::B(7))
+    );
+    let v = RawEnumEvent::C { label: "hi".into() };
+    assert_eq!(v.debug(), format!("{:?}", v));
+}
+
+// =============================================================================
+// Section C – EventManager: realistic "engine loop" simulations
+// =============================================================================
+
+/// Simulates a two-system engine: an input system produces KeyPressed events,
+/// a UI system produces WindowResized events, and two unrelated consumers
+/// listen to each.
+#[test]
+fn realistic_multi_system_engine_loop() {
+    let mut mgr = EventManager::new();
+
+    let key_dispatcher: Dispatcher<KeyPressed> = mgr.register();
+    let win_dispatcher: Dispatcher<WindowResized> = mgr.register();
+
+    let key_consumer: Consumer<KeyPressed> = mgr.subscribe();
+    let win_consumer: Consumer<WindowResized> = mgr.subscribe();
+
+    // Simulate three frames.
+    for frame in 0u32..3 {
+        key_dispatcher.dispatch(KeyPressed(65 + frame));
+
+        if frame == 1 {
+            win_dispatcher.dispatch(WindowResized {
+                width: 800,
+                height: 600,
+            });
+        }
+
+        mgr.dispatch_all();
+    }
+
+    // Drain and verify.
+    let keys: Vec<u32> = collect_all(&key_consumer)
+        .into_iter()
+        .map(|e| e.0)
+        .collect();
+    assert_eq!(keys, vec![65, 66, 67]);
+
+    let wins = collect_all(&win_consumer);
+    assert_eq!(wins.len(), 1);
+    assert_eq!(wins[0].width, 800);
+}
+
+/// Producer fires many events; multiple consumers should each receive all of them.
+#[test]
+fn fan_out_to_many_consumers() {
+    const N: usize = 500;
+
+    let mut mgr = EventManager::new();
+    let dispatcher = mgr.register::<KeyPressed>();
+
+    let consumers: Vec<Consumer<KeyPressed>> = (0..8).map(|_| mgr.subscribe()).collect();
+
+    for i in 0..N as u32 {
+        dispatcher.dispatch(KeyPressed(i));
+    }
+    mgr.dispatch_all();
+
+    for consumer in &consumers {
+        let events = collect_all(consumer);
+        assert_eq!(events.len(), N, "consumer did not receive all events");
+        for (i, event) in events.iter().enumerate() {
+            assert_eq!(event.0, i as u32);
+        }
+    }
+}
+
+/// Dispatcher is moved to a background thread; the event manager dispatches on the
+/// main thread. Tests `Send` bounds on Dispatcher and Event.
+#[test]
+fn dispatcher_is_send_and_can_be_moved_to_thread() {
+    let mut mgr = EventManager::new();
+    let dispatcher = mgr.register::<KeyPressed>();
+    let consumer = mgr.subscribe::<KeyPressed>();
+
+    let handle = thread::spawn(move || {
+        for i in 0..10u32 {
+            dispatcher.dispatch(KeyPressed(i));
+        }
+    });
+
+    handle.join().expect("thread panicked");
+    mgr.dispatch_all();
+
+    let events = collect_all(&consumer);
+    assert_eq!(events.len(), 10);
+}
+
+/// Verifies that `ShutdownRequested` (a unit event) correctly clones and reaches
+/// all subscribers.
+#[test]
+fn unit_event_reaches_all_consumers() {
+    let mut mgr = EventManager::new();
+    let dispatcher = mgr.register::<ShutdownRequested>();
+    let c1 = mgr.subscribe::<ShutdownRequested>();
+    let c2 = mgr.subscribe::<ShutdownRequested>();
+
+    dispatcher.dispatch(ShutdownRequested);
+    mgr.dispatch_all();
+
+    assert_eq!(collect_all(&c1).len(), 1);
+    assert_eq!(collect_all(&c2).len(), 1);
+}
+
+// =============================================================================
+// Section D – Edge cases on the public API
+// =============================================================================
+
+/// Registering but never subscribing: must not panic on dispatch_all.
+#[test]
+fn register_without_subscribe_is_safe() {
+    let mut mgr = EventManager::new();
+    let dispatcher = mgr.register::<KeyPressed>();
+    dispatcher.dispatch(KeyPressed(1));
+    mgr.dispatch_all();
+    // No assertion needed – we just must not panic.
+}
+
+/// Subscribing but never registering any dispatcher: consumer stays empty.
+#[test]
+fn subscribe_without_register_yields_empty_consumer() {
+    let mut mgr = EventManager::new();
+    let consumer = mgr.subscribe::<KeyPressed>();
+    mgr.dispatch_all();
+    assert!(collect_all(&consumer).is_empty());
+}
+
+/// Calling dispatch_all repeatedly without any events in between is a no-op.
+#[test]
+fn repeated_dispatch_all_with_no_events() {
+    let mut mgr = EventManager::new();
+    let _d = mgr.register::<KeyPressed>();
+    let consumer = mgr.subscribe::<KeyPressed>();
+
+    for _ in 0..100 {
+        mgr.dispatch_all();
+    }
+    assert!(collect_all(&consumer).is_empty());
+}
+
+/// Consumers that are dropped mid-simulation are silently pruned; remaining
+/// consumers and subsequent dispatches must be unaffected.
+#[test]
+fn mid_simulation_consumer_drop_is_handled() {
+    let mut mgr = EventManager::new();
+    let dispatcher = mgr.register::<KeyPressed>();
+    let alive = mgr.subscribe::<KeyPressed>();
+
+    {
+        let _dying = mgr.subscribe::<KeyPressed>();
+        dispatcher.dispatch(KeyPressed(1));
+        mgr.dispatch_all();
+        // `_dying` dropped here.
+    }
+
+    // After the dropped consumer is pruned, further dispatches must work fine.
+    dispatcher.dispatch(KeyPressed(2));
+    mgr.dispatch_all();
+
+    let events: Vec<u32> = collect_all(&alive).into_iter().map(|e| e.0).collect();
+    // Both events delivered to `alive` (which was never dropped).
+    assert_eq!(events, vec![1, 2]);
+}
+
+/// consume_all returns an empty iterator when called before dispatch_all.
+#[test]
+fn consume_all_before_dispatch_all_is_empty() {
+    let mut mgr = EventManager::new();
+    let dispatcher = mgr.register::<KeyPressed>();
+    let consumer = mgr.subscribe::<KeyPressed>();
+
+    dispatcher.dispatch(KeyPressed(42));
+    // Not yet dispatched.
+    assert!(collect_all(&consumer).is_empty());
+}
+
+/// Verifies that an enum event (NetworkEvent) goes through the full pipeline.
+#[test]
+fn enum_event_round_trips_through_manager() {
+    let mut mgr = EventManager::new();
+    let dispatcher = mgr.register::<NetworkEvent>();
+    let consumer = mgr.subscribe::<NetworkEvent>();
+
+    dispatcher.dispatch(NetworkEvent::Connected {
+        host: "example.com".into(),
+        port: 443,
+    });
+    dispatcher.dispatch(NetworkEvent::PacketReceived(1024));
+    dispatcher.dispatch(NetworkEvent::Disconnected);
+    mgr.dispatch_all();
+
+    let events = collect_all(&consumer);
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].debug(), "connected to example.com:443");
+    assert_eq!(events[1].debug(), "packet received: 1024 bytes");
+    assert_eq!(events[2].debug(), "disconnected");
+}

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -58,7 +58,7 @@ fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenS
         }
     };
 
-    if data.variants.len() == 0 {
+    if data.variants.is_empty() {
         content = quote! {
             format!("{self:?}")
         }

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -1,6 +1,9 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Fields, LitStr, parse_macro_input};
+use syn::{
+    Attribute, Data, DataEnum, DataStruct, DeriveInput, Fields, FieldsUnnamed, Ident, LitStr,
+    parse_macro_input,
+};
 
 #[proc_macro_derive(Event, attributes(event))]
 pub fn derive_event(input: TokenStream) -> TokenStream {
@@ -29,25 +32,20 @@ fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenS
                 // Get all field names: { system, source, .. }
                 let idents = fields.named.iter().map(|f| &f.ident);
                 quote! {
+                    #[allow(unused_variables)]
                     Self::#var_name { #(#idents,)* .. } => format!(#message_format),
                 }
             }
             Fields::Unnamed(fields) => {
-                // For tuple variants like Error(String), we map them to 0, 1, etc.
-                let idents: Vec<_> = fields
-                    .unnamed
-                    .iter()
-                    .enumerate()
-                    .map(|(i, _)| quote::format_ident!("{}", i))
-                    .collect();
-
-                // This requires the user to use {0} in their message string
+                let idents = get_idents_from_unnamed(&message_format, fields);
                 quote! {
+                    #[allow(unused_variables)]
                     Self::#var_name ( #(#idents,)* .. ) => format!(#message_format),
                 }
             }
             Fields::Unit => {
                 quote! {
+                    #[allow(unused_variables)]
                     Self::#var_name => format!(#message_format),
                 }
             }
@@ -78,23 +76,17 @@ fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::To
             // Get all field names: { system, source, .. }
             let idents = fields.named.iter().map(|f| &f.ident);
             quote! {
+                #[allow(unused_variables)]
                 let Self { #(#idents,)* .. } = self;
                 format!(#message_format)
             }
         }
         Fields::Unnamed(fields) => {
-            // For tuple variants like Error(String), we map them to 0, 1, etc.
-            let idents: Vec<_> = fields
-                .unnamed
-                .iter()
-                .enumerate()
-                .map(|(i, _)| quote::format_ident!("{}", i))
-                .collect();
-
-            // This requires the user to use {0} in their message string
+            let idents = get_idents_from_unnamed(&message_format, fields);
             quote! {
+                #[allow(unused_variables)]
                 let ( #(#idents,)* .. ) = self;
-                format!(#message_format)
+                format!(#message_format, #(#idents),*)
             }
         }
         Fields::Unit => {
@@ -128,4 +120,25 @@ fn get_message_format_from_attrs(attrs: &Vec<Attribute>) -> String {
         }
     }
     String::from("{self:?}")
+}
+
+fn get_idents_from_unnamed(format: &str, fields: &FieldsUnnamed) -> Vec<Ident> {
+    // Create the list of potential variables (_0, _1, etc.)
+    let all_idents: Vec<_> = fields
+        .unnamed
+        .iter()
+        .enumerate()
+        .map(|(i, _)| quote::format_ident!("_{}", i))
+        .collect();
+
+    // ONLY include the identifier if "{index}" appears in the message string
+    let mut idents = Vec::new();
+    for (i, ident) in all_idents.iter().enumerate() {
+        let search_pattern = format!("{{{}}}", i); // e.g., "{0}"
+        if format.contains(&search_pattern) {
+            idents.push(ident.clone());
+        }
+    }
+
+    idents
 }

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -85,7 +85,7 @@ fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::To
             let idents = get_idents_for_unnamed(&message_format, fields);
             quote! {
                 #[allow(unused_variables)]
-                let ( #(#idents,)* .. ) = self;
+                let Self ( #(#idents,)* .. ) = self;
                 format!(#message_format, #(#idents),*)
             }
         }

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -37,7 +37,7 @@ fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenS
                 }
             }
             Fields::Unnamed(fields) => {
-                let idents = get_idents_from_unnamed(&message_format, fields);
+                let idents = get_idents_for_unnamed(&message_format, fields);
                 quote! {
                     #[allow(unused_variables)]
                     Self::#var_name ( #(#idents,)* .. ) => format!(#message_format),
@@ -82,7 +82,7 @@ fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::To
             }
         }
         Fields::Unnamed(fields) => {
-            let idents = get_idents_from_unnamed(&message_format, fields);
+            let idents = get_idents_for_unnamed(&message_format, fields);
             quote! {
                 #[allow(unused_variables)]
                 let ( #(#idents,)* .. ) = self;
@@ -122,7 +122,7 @@ fn get_message_format_from_attrs(attrs: &Vec<Attribute>) -> String {
     String::from("{self:?}")
 }
 
-fn get_idents_from_unnamed(format: &str, fields: &FieldsUnnamed) -> Vec<Ident> {
+fn get_idents_for_unnamed(format: &str, fields: &FieldsUnnamed) -> Vec<Ident> {
     // Create the list of potential variables (_0, _1, etc.)
     let all_idents: Vec<_> = fields
         .unnamed

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -52,12 +52,22 @@ fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenS
         }
     });
 
+    let mut content = quote! {
+        match self {
+            #(#arms)*
+        }
+    };
+
+    if data.variants.len() == 0 {
+        content = quote! {
+            format!("{self:?}")
+        }
+    }
+
     let expanded = quote! {
         impl Event for #name {
             fn debug(&self) -> String {
-                match self {
-                    #(#arms)*
-                }
+                #content
             }
         }
     };

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -37,10 +37,10 @@ fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenS
                 }
             }
             Fields::Unnamed(fields) => {
-                let idents = get_idents_for_unnamed(&message_format, fields);
+                let (message_format, idents) = get_idents_for_unnamed(&message_format, fields);
                 quote! {
                     #[allow(unused_variables)]
-                    Self::#var_name ( #(#idents,)* .. ) => format!(#message_format, #(#idents),*),
+                    Self::#var_name ( #(#idents,)* .. ) => format!(#message_format),
                 }
             }
             Fields::Unit => {
@@ -92,11 +92,11 @@ fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::To
             }
         }
         Fields::Unnamed(fields) => {
-            let idents = get_idents_for_unnamed(&message_format, fields);
+            let (message_format, idents) = get_idents_for_unnamed(&message_format, fields);
             quote! {
                 #[allow(unused_variables)]
                 let Self ( #(#idents,)* .. ) = self;
-                format!(#message_format, #(#idents),*)
+                format!(#message_format)
             }
         }
         Fields::Unit => {
@@ -132,23 +132,23 @@ fn get_message_format_from_attrs(attrs: &Vec<Attribute>) -> String {
     String::from("{self:?}")
 }
 
-fn get_idents_for_unnamed(format: &str, fields: &FieldsUnnamed) -> Vec<Ident> {
+fn get_idents_for_unnamed(format: &str, fields: &FieldsUnnamed) -> (String, Vec<Ident>) {
     // Create the list of potential variables (_0, _1, etc.)
-    let all_idents: Vec<_> = fields
+    let idents: Vec<_> = fields
         .unnamed
         .iter()
         .enumerate()
         .map(|(i, _)| quote::format_ident!("_{}", i))
         .collect();
 
-    // ONLY include the identifier if "{index}" appears in the message string
-    let mut idents = Vec::new();
-    for (i, ident) in all_idents.iter().enumerate() {
-        let search_pattern = format!("{{{}}}", i); // e.g., "{0}"
+    let mut new_format = format.to_string();
+    for i in 0..idents.len() {
+        let search_pattern = format!("{{{i}}}"); // e.g., "{0}"
+        let new_pattern = format!("{{_{i}}}"); // e.g., "{_0}"
         if format.contains(&search_pattern) {
-            idents.push(ident.clone());
+            new_format = new_format.replace(&search_pattern, &new_pattern);
         }
     }
 
-    idents
+    (new_format, idents)
 }

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -40,7 +40,7 @@ fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenS
                 let idents = get_idents_for_unnamed(&message_format, fields);
                 quote! {
                     #[allow(unused_variables)]
-                    Self::#var_name ( #(#idents,)* .. ) => format!(#message_format),
+                    Self::#var_name ( #(#idents,)* .. ) => format!(#message_format, #(#idents),*),
                 }
             }
             Fields::Unit => {


### PR DESCRIPTION
Fix an issue where the `Event` derive macro would destructure structs with unnamed fields by creating variables named after ints (like "0"). Now, destructures to names with _ for the names to be acceptable by the compiler. To keep using the indexes in the format message, we replace format specifiers like `{0}` with `{_0}` in the format string.

Setup removing subscribers from the event manager if their channel closes.

Completely refactor & update unit & integration tests.

## TODO

- [x] if receive channel is closed, remove from list
- [x] Setup tests for Events
    - make an event of every possible type (enum & struct with each field type)
    - annotate them fitting possible edge cases
- [x] Fix: if using format specifier for not first element, format panics at compile
- [x] Fix: empty enums panic macro