### PR TITLE
add: `utils` crate with version & direction utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 name = "utils"
 version = "0.1.0"
 dependencies = [
+ "glam",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ derive-getters = "0.5"
 
 # Engine modules
 build = { path = "Engine/Source/build" }
+utils = { path = "Engine/Source/utils" }
 logging = { path = "Engine/Source/logging" }
 engine = { path = "Engine/Source/engine" }
 events = { path = "Engine/Source/events" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "Engine/Source/build",
+    "Engine/Source/utils",
     "Engine/Source/engine",
     "Engine/Source/events",
     "Engine/Source/macros",

--- a/Engine/Source/utils/Cargo.toml
+++ b/Engine/Source/utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "utils"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+thiserror.workspace = true

--- a/Engine/Source/utils/Cargo.toml
+++ b/Engine/Source/utils/Cargo.toml
@@ -8,3 +8,4 @@ version.workspace = true
 
 [dependencies]
 thiserror.workspace = true
+glam.workspace = true

--- a/Engine/Source/utils/src/lib.rs
+++ b/Engine/Source/utils/src/lib.rs
@@ -5,3 +5,13 @@
 
 mod version;
 pub use version::*;
+
+/// The up direction used for all world and
+/// renderer coordinate calcualtions.
+///
+/// Y-up
+pub const UP_DIRECTION: glam::Vec3 = glam::Vec3::Y;
+/// The forward direction used for all world and
+/// renderer coordinate calcualtions.
+/// We use Z-forward because that is how Vulkan does it.
+pub const FORWARD_DIRECTION: glam::Vec3 = glam::Vec3::Z;

--- a/Engine/Source/utils/src/lib.rs
+++ b/Engine/Source/utils/src/lib.rs
@@ -1,0 +1,7 @@
+//! This is a utility crate.
+//! It has basic utilities for use throughout the engine.
+//! No actual engine systems live in this crate. It just has
+//! many small features, functions and structures.
+
+mod version;
+pub use version::*;

--- a/Engine/Source/utils/src/version.rs
+++ b/Engine/Source/utils/src/version.rs
@@ -1,0 +1,277 @@
+use std::{fmt, str::FromStr};
+
+use thiserror::Error;
+
+/// A simple representation of a version. This is
+/// used to track engine version, etc...
+/// For now it is mainly used by Vulkan when populating
+/// the application info struct.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Version(u32);
+
+impl Default for Version {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl Version {
+    pub const ZERO: Self = Self(0);
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        assert!(
+            major < (1 << 10),
+            "major version must fit in 10 bits (0–1023)"
+        );
+        assert!(
+            minor < (1 << 10),
+            "minor version must fit in 10 bits (0–1023)"
+        );
+        assert!(
+            patch < (1 << 12),
+            "patch version must fit in 12 bits (0–4095)"
+        );
+        Self(((major) << 22) | ((minor) << 12) | (patch))
+    }
+    pub fn major(&self) -> u32 {
+        self.0 >> 22
+    }
+    pub fn minor(&self) -> u32 {
+        (self.0 >> 12) & 0x3ff
+    }
+    pub fn patch(&self) -> u32 {
+        self.0 & 0xfff
+    }
+    /// Increments major, resets minor and patch to 0.
+    pub fn bump_major(self) -> Self {
+        Self::new(self.major() + 1, 0, 0)
+    }
+    /// Increments minor, resets patch to 0.
+    pub fn bump_minor(self) -> Self {
+        Self::new(self.major(), self.minor() + 1, 0)
+    }
+    /// Increments patch.
+    pub fn bump_patch(self) -> Self {
+        Self::new(self.major(), self.minor(), self.patch() + 1)
+    }
+    /// Returns true if `self` is semver-compatible with `required`
+    /// (same major, self.minor >= required.minor).
+    pub fn is_compatible_with(self, required: Self) -> bool {
+        self.major() == required.major() && self >= required
+    }
+    /// If the major is 0, then this is a prerelease version.
+    pub fn is_prerelease(self) -> bool {
+        self.major() == 0
+    }
+}
+
+impl From<u32> for Version {
+    fn from(v: u32) -> Self {
+        Self(v)
+    }
+}
+
+impl From<Version> for u32 {
+    fn from(v: Version) -> Self {
+        v.0
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Comparing the raw packed `u32` is equivalent to comparing
+/// (major, minor, patch) lexicographically because the fields are
+/// stored in significance order.
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major(), self.minor(), self.patch())
+    }
+}
+
+impl fmt::Debug for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Version({self})")
+    }
+}
+
+#[derive(Debug, PartialEq, Error)]
+pub struct ParseVersionError(String);
+
+impl fmt::Display for ParseVersionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid version string: '{}'", self.0)
+    }
+}
+
+impl FromStr for Version {
+    type Err = ParseVersionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let err = || ParseVersionError(s.to_string());
+        let mut parts = s.trim_start_matches('v').splitn(3, '.');
+        let major = parts
+            .next()
+            .ok_or_else(err)?
+            .parse::<u32>()
+            .map_err(|_| err())?;
+        let minor = parts
+            .next()
+            .ok_or_else(err)?
+            .parse::<u32>()
+            .map_err(|_| err())?;
+        let patch = parts
+            .next()
+            .ok_or_else(err)?
+            .parse::<u32>()
+            .map_err(|_| err())?;
+        Ok(Self::new(major, minor, patch))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Construction & accessors --
+
+    #[test]
+    fn test_fields_roundtrip() {
+        let v = Version::new(1, 2, 3);
+        assert_eq!(v.major(), 1);
+        assert_eq!(v.minor(), 2);
+        assert_eq!(v.patch(), 3);
+    }
+
+    #[test]
+    fn test_zero_constant() {
+        assert_eq!(Version::ZERO.major(), 0);
+        assert_eq!(Version::ZERO.minor(), 0);
+        assert_eq!(Version::ZERO.patch(), 0);
+    }
+
+    /// major/minor: 10 bits → max 1023 ; patch: 12 bits → max 4095
+    #[test]
+    fn test_max_field_values() {
+        let v = Version::new(1023, 1023, 4095);
+        assert_eq!(v.major(), 1023);
+        assert_eq!(v.minor(), 1023);
+        assert_eq!(v.patch(), 4095);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_major_overflow_panics() {
+        Version::new(1024, 0, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_patch_overflow_panics() {
+        Version::new(0, 0, 4096);
+    }
+
+    // -- Bumping --
+
+    #[test]
+    fn test_bump_major_resets_minor_and_patch() {
+        let v = Version::new(1, 5, 3).bump_major();
+        assert_eq!((v.major(), v.minor(), v.patch()), (2, 0, 0));
+    }
+
+    #[test]
+    fn test_bump_minor_resets_patch() {
+        let v = Version::new(1, 5, 3).bump_minor();
+        assert_eq!((v.major(), v.minor(), v.patch()), (1, 6, 0));
+    }
+
+    #[test]
+    fn test_bump_patch() {
+        let v = Version::new(1, 5, 3).bump_patch();
+        assert_eq!((v.major(), v.minor(), v.patch()), (1, 5, 4));
+    }
+
+    // -- Ordering --
+
+    #[test]
+    fn test_ordering() {
+        assert!(Version::new(2, 0, 0) > Version::new(1, 9, 9));
+        assert!(Version::new(1, 1, 0) > Version::new(1, 0, 99));
+        assert!(Version::new(1, 0, 1) > Version::new(1, 0, 0));
+        assert_eq!(Version::new(1, 2, 3), Version::new(1, 2, 3));
+    }
+
+    // -- Compatibility --
+
+    #[test]
+    fn test_compatible_same_major_higher_minor() {
+        assert!(Version::new(1, 3, 0).is_compatible_with(Version::new(1, 2, 0)));
+    }
+
+    #[test]
+    fn test_incompatible_different_major() {
+        assert!(!Version::new(2, 0, 0).is_compatible_with(Version::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn test_incompatible_older_version() {
+        assert!(!Version::new(1, 1, 0).is_compatible_with(Version::new(1, 2, 0)));
+    }
+
+    #[test]
+    fn test_prerelease() {
+        assert!(Version::new(0, 9, 0).is_prerelease());
+        assert!(!Version::new(1, 0, 0).is_prerelease());
+    }
+
+    // -- Formatting & parsing --
+
+    #[test]
+    fn test_display() {
+        assert_eq!(Version::new(1, 2, 3).to_string(), "1.2.3");
+    }
+
+    #[test]
+    fn test_parse_plain() {
+        let v: Version = "1.2.3".parse().unwrap();
+        assert_eq!((v.major(), v.minor(), v.patch()), (1, 2, 3));
+    }
+
+    #[test]
+    fn test_parse_with_v_prefix() {
+        let v: Version = "v2.0.0".parse().unwrap();
+        assert_eq!(v.major(), 2);
+    }
+
+    #[test]
+    fn test_parse_invalid() {
+        assert!("1.2".parse::<Version>().is_err());
+        assert!("abc".parse::<Version>().is_err());
+        assert!("1.x.3".parse::<Version>().is_err());
+    }
+
+    #[test]
+    fn test_parse_display_roundtrip() {
+        let original = Version::new(3, 14, 42);
+        let roundtripped: Version = original.to_string().parse().unwrap();
+        assert_eq!(original, roundtripped);
+    }
+
+    // -- Raw conversion --
+
+    #[test]
+    fn test_from_into_u32() {
+        let v = Version::new(1, 2, 3);
+        let raw: u32 = v.into();
+        let back = Version::from(raw);
+        assert_eq!(v, back);
+    }
+}


### PR DESCRIPTION
Add a `utils` crate.

Contains `Version` type which is a wrapper for u32 to store semantic versions. It is heavily inspired by the Vulkan macros for building versions. Comes with a full test suite.

Added direction vectors (up & right). This will help various engine systems have access to the same coordinate system conventions.