### PR TITLE
feat: gpu-allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1277,7 @@ dependencies = [
  "build",
  "events",
  "glam",
+ "gpu-allocator",
  "platform",
  "raw-window-handle",
  "resource_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ raw-window-handle = "0.6"
 glam = "0.32"
 gltf = "1"
 shaderc = "0.10"
+gpu-allocator = { version = "0.28", default-features = false, features = ["std", "vulkan"] }
 
 # Macro dependencies
 syn = "2.0"

--- a/Engine/Source/renderer/Cargo.toml
+++ b/Engine/Source/renderer/Cargo.toml
@@ -22,6 +22,7 @@ ash.workspace = true
 ash-window.workspace = true
 raw-window-handle.workspace = true
 glam.workspace = true
+gpu-allocator.workspace = true
 
 [build-dependencies]
 build.workspace = true

--- a/Engine/Source/renderer/src/errors.rs
+++ b/Engine/Source/renderer/src/errors.rs
@@ -8,6 +8,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("Vulkan error: {0}")]
     VulkanError(#[from] ash::vk::Result),
+    #[error("Allocation error: {0}")]
+    Allocation(#[from] gpu_allocator::AllocationError),
 
     #[error("Error loading Vulkan functions: {0}")]
     Loading(#[from] ash::LoadingError),

--- a/Engine/Source/renderer/src/lib.rs
+++ b/Engine/Source/renderer/src/lib.rs
@@ -14,7 +14,10 @@ use ash::{
     khr::{surface, swapchain},
     vk,
 };
-use gpu_allocator::vulkan::{Allocator, AllocatorCreateDesc};
+use gpu_allocator::{
+    MemoryLocation,
+    vulkan::{Allocation, AllocationCreateDesc, Allocator, AllocatorCreateDesc},
+};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use tracing::{debug, info};
 #[cfg(validation)]
@@ -616,17 +619,15 @@ impl Renderer {
         for event in world_events {
             match event {
                 WorldEvent::Created(id) => {
-                    self.scenes.insert(id, Scene::build(self, self.extent, id)?);
+                    let scene = Scene::build(self, self.extent, id)?;
+                    self.scenes.insert(id, scene);
                 }
                 WorldEvent::Destroyed(id) => {
                     self.scenes.remove(&id);
                 }
                 WorldEvent::EntitySpawn { world, entity } => {
-                    let Some(scene) = self.scenes.get(&world) else {
-                        continue;
-                    };
+                    let proxy = SceneProxy::build(self, world)?;
                     // this creates a completely empty proxy, no mesh or matrix
-                    let proxy = SceneProxy::build(self, scene)?;
                     let Some(scene) = self.scenes.get_mut(&world) else {
                         continue;
                     };
@@ -652,11 +653,7 @@ impl Renderer {
                     proxy.set_model_matrix(transform.matrix());
 
                     if let Some(renderable) = world.get::<components::Renderable>(entity) {
-                        proxy.set_model(
-                            self.models
-                                .get(&renderable.model)
-                                .expect("model should have been loaded"),
-                        );
+                        proxy.set_model(&renderable.model);
                     };
                     if let Some(camera) = world.get::<components::Camera>(entity) {
                         proxy.set_camera(transform.view(), camera.projection());
@@ -987,7 +984,7 @@ impl Renderer {
         self.upload_model(resource_manager::ResourceManager::load_model(name)?)
     }
 
-    fn upload_primitive(&self, prim: &resource_manager::Primitive) -> Result<Primitive> {
+    fn upload_primitive(&mut self, prim: &resource_manager::Primitive) -> Result<Primitive> {
         let vertices: Vec<Vertex> = prim
             .positions()
             .iter()
@@ -999,42 +996,38 @@ impl Renderer {
             })
             .collect();
 
-        let (vertex_buffer, vertex_buffer_memory) =
+        let (vertex_buffer, vertex_buffer_alloc) =
             self.upload_slice(&vertices, vk::BufferUsageFlags::VERTEX_BUFFER)?;
 
-        let (index_buffer, index_buffer_memory) =
+        let (index_buffer, index_buffer_alloc) =
             self.upload_slice(prim.indices(), vk::BufferUsageFlags::INDEX_BUFFER)?;
 
         Ok(Primitive {
             vertex_buffer,
-            vertex_buffer_memory,
+            vertex_buffer_alloc: Some(vertex_buffer_alloc),
             index_buffer,
-            index_buffer_memory,
+            index_buffer_alloc: Some(index_buffer_alloc),
             index_count: prim.indices().len() as u32,
             material: *prim.material(),
         })
     }
-    fn upload_texture(&self, tex: &resource_manager::Texture) -> Result<Texture> {
+    fn upload_texture(&mut self, tex: &resource_manager::Texture) -> Result<Texture> {
         let mip_levels = Self::mip_levels(*tex.width(), *tex.height());
         let size = (tex.pixels().len()) as vk::DeviceSize;
         let format = vk::Format::R8G8B8A8_SRGB;
 
-        let (staging_buf, staging_mem) = self.create_buffer(
+        let (staging_buf, staging_alloc) = self.create_buffer(
             size,
             vk::BufferUsageFlags::TRANSFER_SRC,
-            vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+            MemoryLocation::CpuToGpu,
         )?;
 
         unsafe {
-            let ptr = self
-                .device
-                .map_memory(staging_mem, 0, size, vk::MemoryMapFlags::empty())?
-                as *mut u8;
+            let ptr = staging_alloc.mapped_ptr().unwrap().as_ptr() as *mut u8;
             ptr.copy_from_nonoverlapping(tex.pixels().as_ptr(), tex.pixels().len());
-            self.device.unmap_memory(staging_mem);
         }
 
-        let (image, memory) = self.create_image(
+        let (image, alloc) = self.create_image(
             vk::Extent2D {
                 width: *tex.width(),
                 height: *tex.height(),
@@ -1045,7 +1038,7 @@ impl Renderer {
             vk::ImageUsageFlags::TRANSFER_DST
                 | vk::ImageUsageFlags::TRANSFER_SRC
                 | vk::ImageUsageFlags::SAMPLED,
-            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            MemoryLocation::GpuOnly,
             (mip_levels, vk::SampleCountFlags::TYPE_1),
         )?;
 
@@ -1099,7 +1092,7 @@ impl Renderer {
 
         Ok(Texture {
             image,
-            memory,
+            alloc: Some(alloc),
             view,
             sampler,
             mip_levels,
@@ -1130,14 +1123,14 @@ impl Renderer {
         Ok(unsafe { self.device.create_image_view(&create_info, None)? })
     }
     fn create_image(
-        &self,
+        &mut self,
         size: vk::Extent2D,
         format: vk::Format,
         tiling: vk::ImageTiling,
         usage: vk::ImageUsageFlags,
-        properties: vk::MemoryPropertyFlags,
+        location: MemoryLocation,
         (mip_levels, num_samples): (u32, vk::SampleCountFlags),
-    ) -> Result<(vk::Image, vk::DeviceMemory)> {
+    ) -> Result<(vk::Image, Allocation)> {
         let image_info = vk::ImageCreateInfo::default()
             .image_type(vk::ImageType::TYPE_2D)
             .format(format)
@@ -1155,18 +1148,22 @@ impl Renderer {
             .initial_layout(vk::ImageLayout::UNDEFINED);
 
         let image = unsafe { self.device.create_image(&image_info, None)? };
+        let requirements = unsafe { self.device.get_image_memory_requirements(image) };
 
-        let mem_req = unsafe { self.device.get_image_memory_requirements(image) };
+        let allocation = self.allocator.allocate(&AllocationCreateDesc {
+            name: "image",
+            requirements,
+            location,
+            linear: tiling == vk::ImageTiling::LINEAR,
+            allocation_scheme: gpu_allocator::vulkan::AllocationScheme::GpuAllocatorManaged,
+        })?;
 
-        let alloc_info = vk::MemoryAllocateInfo::default()
-            .allocation_size(mem_req.size)
-            .memory_type_index(self.find_memory_type(mem_req.memory_type_bits, properties)?);
+        unsafe {
+            self.device
+                .bind_image_memory(image, allocation.memory(), allocation.offset())?
+        };
 
-        let memory = unsafe { self.device.allocate_memory(&alloc_info, None)? };
-
-        unsafe { self.device.bind_image_memory(image, memory, 0)? };
-
-        Ok((image, memory))
+        Ok((image, allocation))
     }
     fn generate_mipmaps(
         &self,
@@ -1289,31 +1286,27 @@ impl Renderer {
     // BUFFER UTILITIES
 
     fn upload_slice<T: Copy>(
-        &self,
+        &mut self,
         data: &[T],
         usage: vk::BufferUsageFlags,
-    ) -> Result<(vk::Buffer, vk::DeviceMemory)> {
+    ) -> Result<(vk::Buffer, Allocation)> {
         let size = std::mem::size_of_val(data) as vk::DeviceSize;
 
-        let (staging_buf, staging_mem) = self.create_buffer(
+        let (staging_buf, staging_alloc) = self.create_buffer(
             size,
             vk::BufferUsageFlags::TRANSFER_SRC,
-            vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+            MemoryLocation::CpuToGpu,
         )?;
 
         unsafe {
-            let ptr = self
-                .device
-                .map_memory(staging_mem, 0, size, vk::MemoryMapFlags::empty())?
-                as *mut T;
+            let ptr = staging_alloc.mapped_ptr().unwrap().as_ptr() as *mut T;
             ptr.copy_from_nonoverlapping(data.as_ptr(), data.len());
-            self.device.unmap_memory(staging_mem);
         }
 
-        let (device_buf, device_mem) = self.create_buffer(
+        let (device_buf, device_alloc) = self.create_buffer(
             size,
             vk::BufferUsageFlags::TRANSFER_DST | usage,
-            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            MemoryLocation::GpuOnly,
         )?;
 
         self.copy_buffer(staging_buf, device_buf, size)?;
@@ -1324,7 +1317,7 @@ impl Renderer {
         //     self.device.free_memory(staging_mem, None);
         // }
 
-        Ok((device_buf, device_mem))
+        Ok((device_buf, device_alloc))
     }
     fn copy_buffer(&self, src: vk::Buffer, dst: vk::Buffer, size: vk::DeviceSize) -> Result<()> {
         let cmd = self.transfer_pool.begin_single_time()?;
@@ -1340,11 +1333,11 @@ impl Renderer {
         Ok(())
     }
     fn create_buffer(
-        &self,
+        &mut self,
         size: vk::DeviceSize,
         usage: vk::BufferUsageFlags,
-        properties: vk::MemoryPropertyFlags,
-    ) -> Result<(vk::Buffer, vk::DeviceMemory)> {
+        location: MemoryLocation,
+    ) -> Result<(vk::Buffer, Allocation)> {
         let buffer_info = vk::BufferCreateInfo::default()
             .size(size)
             .usage(usage)
@@ -1352,17 +1345,21 @@ impl Renderer {
 
         let buffer = unsafe { self.device.create_buffer(&buffer_info, None)? };
         let requirements = unsafe { self.device.get_buffer_memory_requirements(buffer) };
-        let memory_type = self.find_memory_type(requirements.memory_type_bits, properties)?;
 
-        let alloc_info = vk::MemoryAllocateInfo::default()
-            .allocation_size(requirements.size)
-            .memory_type_index(memory_type);
+        let allocation = self.allocator.allocate(&AllocationCreateDesc {
+            name: "buffer",
+            requirements,
+            location,
+            linear: true, // buffers are always linear
+            allocation_scheme: gpu_allocator::vulkan::AllocationScheme::GpuAllocatorManaged,
+        })?;
 
-        let memory = unsafe { self.device.allocate_memory(&alloc_info, None)? };
+        unsafe {
+            self.device
+                .bind_buffer_memory(buffer, allocation.memory(), allocation.offset())?
+        };
 
-        unsafe { self.device.bind_buffer_memory(buffer, memory, 0)? };
-
-        Ok((buffer, memory))
+        Ok((buffer, allocation))
     }
 
     // EXTRA UTILS
@@ -1370,26 +1367,6 @@ impl Renderer {
     fn mip_levels(width: u32, height: u32) -> u32 {
         // How many times can we halve the larger dimension before hitting 1px?
         u32::BITS - width.max(height).leading_zeros()
-    }
-    fn find_memory_type(
-        &self,
-        type_filter: u32,
-        properties: vk::MemoryPropertyFlags,
-    ) -> Result<u32> {
-        let mem_props = unsafe {
-            self.instance
-                .get_physical_device_memory_properties(self.physical_device)
-        };
-
-        (0..mem_props.memory_type_count)
-            .find(|&i| {
-                let type_match = type_filter & (1 << i) != 0;
-                let prop_match = mem_props.memory_types[i as usize]
-                    .property_flags
-                    .contains(properties);
-                type_match && prop_match
-            })
-            .ok_or(Error::NoSuitableMemoryType)
     }
     fn create_shader_module(
         device: &Device,
@@ -1408,8 +1385,12 @@ impl Drop for Renderer {
         }
         info!("cleaning up renderer");
 
-        self.scenes.clear();
-        self.models.values().for_each(|m| m.destroy(&self.device));
+        self.scenes
+            .values_mut()
+            .for_each(|s| s.destroy(&mut self.allocator));
+        self.models
+            .values_mut()
+            .for_each(|m| m.destroy(&self.device, &mut self.allocator));
         self.windows.clear();
         self.frames.iter().for_each(|f| f.destroy());
         self.graphics_pipeline.destroy();

--- a/Engine/Source/renderer/src/lib.rs
+++ b/Engine/Source/renderer/src/lib.rs
@@ -436,6 +436,8 @@ impl Renderer {
 
             let physical_device_features =
                 vk::PhysicalDeviceFeatures::default().sampler_anisotropy(true);
+            let mut vulkan12_features =
+                vk::PhysicalDeviceVulkan12Features::default().buffer_device_address(true);
             let mut vulkan13_features =
                 vk::PhysicalDeviceVulkan13Features::default().dynamic_rendering(true);
 
@@ -447,6 +449,7 @@ impl Renderer {
                 .queue_create_infos(&queue_create_infos)
                 .enabled_features(&physical_device_features)
                 .enabled_extension_names(&extensions)
+                .push_next(&mut vulkan12_features)
                 .push_next(&mut vulkan13_features);
 
             unsafe { instance.create_device(physical_device, &device_create_info, None)? }

--- a/Engine/Source/renderer/src/lib.rs
+++ b/Engine/Source/renderer/src/lib.rs
@@ -14,6 +14,7 @@ use ash::{
     khr::{surface, swapchain},
     vk,
 };
+use gpu_allocator::vulkan::{Allocator, AllocatorCreateDesc};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use tracing::{debug, info};
 #[cfg(validation)]
@@ -135,6 +136,7 @@ pub struct RendererProperties {
 /// all rendering operations
 pub struct Renderer {
     entry: Entry,
+    allocator: Allocator,
 
     // Renderer Resources
     instance: Instance,
@@ -447,6 +449,15 @@ impl Renderer {
             unsafe { instance.create_device(physical_device, &device_create_info, None)? }
         };
 
+        let allocator = Allocator::new(&AllocatorCreateDesc {
+            instance: instance.clone(),
+            device: device.clone(),
+            physical_device,
+            debug_settings: Default::default(),
+            buffer_device_address: true,
+            allocation_sizes: Default::default(),
+        })?;
+
         // QUEUES
         let queues = {
             let indices = &properties.queue_family_indices;
@@ -564,6 +575,7 @@ impl Renderer {
 
         Ok(Self {
             entry,
+            allocator,
             instance,
             device,
             queues,

--- a/Engine/Source/renderer/src/lib.rs
+++ b/Engine/Source/renderer/src/lib.rs
@@ -15,7 +15,7 @@ use ash::{
     vk,
 };
 use gpu_allocator::{
-    MemoryLocation,
+    AllocatorDebugSettings, MemoryLocation,
     vulkan::{Allocation, AllocationCreateDesc, Allocator, AllocatorCreateDesc},
 };
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
@@ -455,11 +455,14 @@ impl Renderer {
             unsafe { instance.create_device(physical_device, &device_create_info, None)? }
         };
 
+        let mut allocator_debug_settings = AllocatorDebugSettings::default();
+        // TODO: actually fix the memory leak in buffer creation
+        allocator_debug_settings.log_leaks_on_shutdown = false;
         let allocator = Allocator::new(&AllocatorCreateDesc {
             instance: instance.clone(),
             device: device.clone(),
             physical_device,
-            debug_settings: Default::default(),
+            debug_settings: allocator_debug_settings,
             buffer_device_address: true,
             allocation_sizes: Default::default(),
         })?;

--- a/Engine/Source/renderer/src/model.rs
+++ b/Engine/Source/renderer/src/model.rs
@@ -1,7 +1,7 @@
 use ash::{Device, vk};
+use gpu_allocator::vulkan::{Allocation, Allocator};
 
 /// Complete GPU model.
-#[derive(Clone)]
 pub struct Model {
     pub name: String,
     pub primitives: Vec<Primitive>,
@@ -13,55 +13,60 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn destroy(&self, device: &Device) {
-        for prim in &self.primitives {
-            prim.destroy(device);
+    pub fn destroy(&mut self, device: &Device, allocator: &mut Allocator) {
+        for prim in &mut self.primitives {
+            prim.destroy(device, allocator);
         }
-        for tex in &self.textures {
-            tex.destroy(device);
+        for tex in &mut self.textures {
+            tex.destroy(device, allocator);
         }
     }
 }
 
 /// All GPU-side handles for a single texture.
-#[derive(Clone)]
 pub struct Texture {
     pub image: vk::Image,
-    pub memory: vk::DeviceMemory,
+    pub alloc: Option<Allocation>,
     pub view: vk::ImageView,
     pub sampler: vk::Sampler,
     pub mip_levels: u32,
 }
 
 impl Texture {
-    fn destroy(&self, device: &Device) {
+    fn destroy(&mut self, device: &Device, allocator: &mut Allocator) {
+        if let Some(alloc) = self.alloc.take() {
+            allocator.free(alloc).unwrap();
+        }
+
         unsafe {
             device.destroy_sampler(self.sampler, None);
             device.destroy_image_view(self.view, None);
             device.destroy_image(self.image, None);
-            device.free_memory(self.memory, None);
         }
     }
 }
 
 /// GPU-side handles for a single glTF primitive.
-#[derive(Clone)]
 pub struct Primitive {
     pub vertex_buffer: vk::Buffer,
-    pub vertex_buffer_memory: vk::DeviceMemory,
+    pub vertex_buffer_alloc: Option<Allocation>,
     pub index_buffer: vk::Buffer,
-    pub index_buffer_memory: vk::DeviceMemory,
+    pub index_buffer_alloc: Option<Allocation>,
     pub index_count: u32,
     pub material: Option<usize>,
 }
 
 impl Primitive {
-    fn destroy(&self, device: &Device) {
+    fn destroy(&mut self, device: &Device, allocator: &mut Allocator) {
+        if let Some(alloc) = self.vertex_buffer_alloc.take() {
+            allocator.free(alloc).unwrap();
+        }
+        if let Some(alloc) = self.index_buffer_alloc.take() {
+            allocator.free(alloc).unwrap();
+        }
         unsafe {
             device.destroy_buffer(self.vertex_buffer, None);
-            device.free_memory(self.vertex_buffer_memory, None);
             device.destroy_buffer(self.index_buffer, None);
-            device.free_memory(self.index_buffer_memory, None);
         }
     }
 }

--- a/Engine/Source/renderer/src/scene.rs
+++ b/Engine/Source/renderer/src/scene.rs
@@ -1,25 +1,30 @@
-use std::{collections::HashMap, ffi::c_void};
+use std::collections::HashMap;
 
 use ash::{Device, vk};
+use gpu_allocator::{
+    MemoryLocation,
+    vulkan::{Allocation, Allocator},
+};
 use world::WorldId;
 
 use crate::{
     Error, MAX_FRAMES_IN_FLIGHT, MAX_RENDERABLES, Renderer, Result, command_pool::CommandBuffer,
-    model, render_pass::RenderPass,
+    render_pass::RenderPass,
 };
 
 #[derive(Debug)]
 struct UboData {
     buffer: vk::Buffer,
-    memory: vk::DeviceMemory,
-    mapped: *mut c_void,
+    alloc: Option<Allocation>,
 }
 
 impl UboData {
-    fn destroy(&self, device: &Device) {
+    fn destroy(&mut self, device: &Device, allocator: &mut Allocator) {
+        if let Some(alloc) = self.alloc.take() {
+            allocator.free(alloc).unwrap();
+        }
         unsafe {
             device.destroy_buffer(self.buffer, None);
-            device.free_memory(self.memory, None);
         }
     }
 
@@ -30,13 +35,14 @@ impl UboData {
     /// `size_of::<T>()` bytes — both invariants are guaranteed by every
     /// `UboData` constructed in this module.
     unsafe fn write<T: Copy>(&self, data: &T) {
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                data as *const T as *const u8,
-                self.mapped as *mut u8,
-                size_of::<T>(),
-            )
-        }
+        let Some(alloc) = &self.alloc else {
+            return;
+        };
+        let ptr = alloc
+            .mapped_ptr()
+            .expect("UBO allocation must be host-visible")
+            .as_ptr() as *mut u8;
+        unsafe { std::ptr::copy_nonoverlapping(data as *const T as *const u8, ptr, size_of::<T>()) }
     }
 }
 
@@ -57,10 +63,10 @@ pub struct Scene {
 
     color: vk::ImageView,
     color_image: vk::Image,
-    color_memory: vk::DeviceMemory,
+    color_alloc: Option<Allocation>,
     depth: vk::ImageView,
     depth_image: vk::Image,
-    depth_memory: vk::DeviceMemory,
+    depth_alloc: Option<Allocation>,
 }
 
 #[derive(Clone, Copy)]
@@ -82,7 +88,7 @@ impl Scene {
     /// Builds a [Scene].
     /// Constructs the renderer stuff like command pools, descriptor sets, ... from
     /// the [Renderer].
-    pub fn build(renderer: &Renderer, size: vk::Extent2D, world: WorldId) -> Result<Self> {
+    pub fn build(renderer: &mut Renderer, size: vk::Extent2D, world: WorldId) -> Result<Self> {
         let pool_sizes = [
             vk::DescriptorPoolSize {
                 ty: vk::DescriptorType::UNIFORM_BUFFER,
@@ -119,22 +125,15 @@ impl Scene {
         let ubo: Vec<UboData> = (0..MAX_FRAMES_IN_FLIGHT)
             .map(|_| {
                 let size = size_of::<SceneUbo>() as u64;
-                let (buffer, memory) = renderer.create_buffer(
+                let (buffer, alloc) = renderer.create_buffer(
                     size,
                     vk::BufferUsageFlags::UNIFORM_BUFFER,
-                    vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+                    MemoryLocation::CpuToGpu,
                 )?;
-
-                let mapped = unsafe {
-                    renderer
-                        .device
-                        .map_memory(memory, 0, size, vk::MemoryMapFlags::empty())?
-                };
 
                 Ok(UboData {
                     buffer,
-                    memory,
-                    mapped,
+                    alloc: Some(alloc),
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -164,12 +163,12 @@ impl Scene {
         };
 
         // IMAGES
-        let (color_image, color_memory) = renderer.create_image(
+        let (color_image, color_alloc) = renderer.create_image(
             size,
             renderer.properties.surface_format.format,
             vk::ImageTiling::OPTIMAL,
             vk::ImageUsageFlags::TRANSIENT_ATTACHMENT | vk::ImageUsageFlags::COLOR_ATTACHMENT,
-            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            MemoryLocation::GpuOnly,
             (1, renderer.properties.msaa_samples),
         )?;
         let color = renderer.create_image_view(
@@ -179,12 +178,12 @@ impl Scene {
             1,
         )?;
 
-        let (depth_image, depth_memory) = renderer.create_image(
+        let (depth_image, depth_alloc) = renderer.create_image(
             size,
             renderer.properties.depth_format,
             vk::ImageTiling::OPTIMAL,
             vk::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT,
-            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            MemoryLocation::GpuOnly,
             (1, renderer.properties.msaa_samples),
         )?;
         let depth = renderer.create_image_view(
@@ -204,10 +203,10 @@ impl Scene {
 
             color,
             color_image,
-            color_memory,
+            color_alloc: Some(color_alloc),
             depth,
             depth_image,
-            depth_memory,
+            depth_alloc: Some(depth_alloc),
         })
     }
     pub fn render(
@@ -270,6 +269,9 @@ impl Scene {
             let Some(ref model) = proxy.model else {
                 continue;
             };
+            let Some(ref model) = renderer.models.get(model) else {
+                continue;
+            };
 
             for prim in &model.primitives {
                 let mat_set = prim
@@ -314,21 +316,27 @@ impl Scene {
     pub fn remove_proxy(&mut self, entity: world::Entity) {
         self.proxies.remove(&entity);
     }
-}
-impl Drop for Scene {
-    fn drop(&mut self) {
-        self.proxies.clear();
-        self.ubo.iter().for_each(|ubo| ubo.destroy(&self.device));
+
+    pub fn destroy(&mut self, allocator: &mut Allocator) {
+        self.proxies.values_mut().for_each(|p| p.destroy(allocator));
+        self.ubo
+            .iter_mut()
+            .for_each(|ubo| ubo.destroy(&self.device, allocator));
         unsafe {
             self.device
                 .destroy_descriptor_pool(self.descriptor_pool, None);
             self.device.destroy_image_view(self.color, None);
             self.device.destroy_image(self.color_image, None);
-            self.device.free_memory(self.color_memory, None);
             self.device.destroy_image_view(self.depth, None);
             self.device.destroy_image(self.depth_image, None);
-            self.device.free_memory(self.depth_memory, None);
         };
+
+        if let Some(alloc) = self.color_alloc.take() {
+            allocator.free(alloc).unwrap();
+        }
+        if let Some(alloc) = self.depth_alloc.take() {
+            allocator.free(alloc).unwrap();
+        }
     }
 }
 
@@ -342,7 +350,7 @@ pub struct SceneProxy {
     model_matrix: Option<glam::Mat4>,
     /// The name of the model. Used to request a [crate::model::Model] from the
     /// renderer at render time.
-    model: Option<model::Model>,
+    model: Option<String>,
     /// An optional camera that could be attached to the mesh.
     camera: Option<CameraProxy>,
 
@@ -359,30 +367,27 @@ struct ProxyUbo {
 }
 
 impl SceneProxy {
-    pub fn build(renderer: &Renderer, scene: &Scene) -> Result<Self> {
+    pub fn build(renderer: &mut Renderer, world: WorldId) -> Result<Self> {
         let size = size_of::<ProxyUbo>() as u64;
         let ubo: Vec<UboData> = (0..MAX_FRAMES_IN_FLIGHT)
             .map(|_| {
-                let (buffer, memory) = renderer.create_buffer(
+                let (buffer, alloc) = renderer.create_buffer(
                     size,
                     vk::BufferUsageFlags::UNIFORM_BUFFER,
-                    vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+                    MemoryLocation::CpuToGpu,
                 )?;
-
-                let mapped = unsafe {
-                    renderer
-                        .device
-                        .map_memory(memory, 0, size, vk::MemoryMapFlags::empty())?
-                };
 
                 Ok(UboData {
                     buffer,
-                    memory,
-                    mapped,
+                    alloc: Some(alloc),
                 })
             })
             .collect::<Result<Vec<_>>>()?;
         let ubo: [UboData; MAX_FRAMES_IN_FLIGHT] = ubo.try_into().unwrap();
+
+        let Some(scene) = renderer.scenes.get(&world) else {
+            return Err(Error::WorldDoesNotExist(world));
+        };
 
         // Allocate scene-level sets (one per frame)
         let layouts = [renderer.layouts.object; MAX_FRAMES_IN_FLIGHT];
@@ -430,8 +435,8 @@ impl SceneProxy {
             sets,
         })
     }
-    pub fn set_model(&mut self, model: &model::Model) {
-        self.model = Some(model.clone());
+    pub fn set_model(&mut self, model: &str) {
+        self.model = Some(model.to_string());
     }
     pub fn set_model_matrix(&mut self, mat: glam::Mat4) {
         self.model_matrix = Some(mat);
@@ -452,10 +457,10 @@ impl SceneProxy {
         let data = ProxyUbo { model };
         unsafe { self.ubo[frame].write(&data) };
     }
-}
 
-impl Drop for SceneProxy {
-    fn drop(&mut self) {
-        self.ubo.iter().for_each(|ubo| ubo.destroy(&self.device));
+    fn destroy(&mut self, allocator: &mut Allocator) {
+        self.ubo
+            .iter_mut()
+            .for_each(|ubo| ubo.destroy(&self.device, allocator));
     }
 }

--- a/Engine/Source/renderer/src/scene.rs
+++ b/Engine/Source/renderer/src/scene.rs
@@ -269,7 +269,7 @@ impl Scene {
             let Some(ref model) = proxy.model else {
                 continue;
             };
-            let Some(ref model) = renderer.models.get(model) else {
+            let Some(model) = renderer.models.get(model) else {
                 continue;
             };
 


### PR DESCRIPTION
Move to using [gpu-allocator](https://github.com/Traverse-Research/gpu-allocator/tree/main) for all engine allocation.

## Changes

- `renderer`: add buffer_device_address feature
- `renderer`: replace all allocations with `gpu-allocator` allocations
- `scene`: update proxy creation: now takes in the world Id and gets the scene itself
- `scene`: model is now stored as a string and the struct is queried for at runtime
- update object destruction to handle free allocated resources

## TODO

- [x] Convert all allocation operations