### PR TITLE
feat: store EventManager behind ArcMutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ name = "events"
 version = "0.1.0"
 dependencies = [
  "macros",
+ "parking_lot",
  "tracing",
 ]
 

--- a/Engine/Source/engine/src/lib.rs
+++ b/Engine/Source/engine/src/lib.rs
@@ -57,7 +57,7 @@ impl Engine {
                 app_version: version,
             },
             platform.main_window(),
-            &mut event_manager,
+            event_manager.clone(),
         )
         .context("renderer init")?;
 

--- a/Engine/Source/events/Cargo.toml
+++ b/Engine/Source/events/Cargo.toml
@@ -8,5 +8,6 @@ version.workspace = true
 
 [dependencies]
 macros.workspace = true
+parking_lot.workspace = true
 
 tracing.workspace = true

--- a/Engine/Source/events/src/lib.rs
+++ b/Engine/Source/events/src/lib.rs
@@ -1,13 +1,14 @@
 //! This crate the engine's event system.
-
+use parking_lot::Mutex;
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    sync::mpsc::{self, Receiver, Sender},
+    sync::{
+        Arc,
+        mpsc::{self, Receiver, Sender},
+    },
 };
-
 use tracing::trace;
-
 mod tests;
 
 /// The trait that should be implemented by every event type.
@@ -15,49 +16,70 @@ pub trait Event: Send + Clone + 'static {
     fn debug(&self) -> String;
 }
 
-/// The event manager struct.
+/// Private inner state, held behind the `Arc<Mutex<>>`.
 #[derive(Default)]
-pub struct EventManager {
+struct EventManagerInner {
     producers: Vec<Box<dyn AnyProducer>>,
     subscribers: HashMap<TypeId, Vec<Subscriber>>,
+}
+
+/// The event manager.
+///
+/// Cheaply cloneable — all clones share the same underlying state.
+/// Use [`EventManager::new`] to create one and pass it around freely.
+#[derive(Clone, Default)]
+pub struct EventManager {
+    inner: Arc<Mutex<EventManagerInner>>,
 }
 
 impl EventManager {
     pub fn new() -> Self {
         Self::default()
     }
-
-    pub fn register<T: Event>(&mut self) -> Dispatcher<T> {
+    /// Registers a new event type and returns a [`Dispatcher`] for it.
+    pub fn register<T: Event>(&self) -> Dispatcher<T> {
         let (sender, receiver) = mpsc::channel::<T>();
-
-        self.producers.push(Box::new(TypedProducer {
+        self.inner.lock().producers.push(Box::new(TypedProducer {
             type_id: TypeId::of::<T>(),
             receiver,
         }));
-        Dispatcher { sender }
+        Dispatcher {
+            sender,
+            manager: self.clone(),
+        }
     }
-    pub fn subscribe<T: Event>(&mut self) -> Consumer<T> {
+    /// Subscribes to an event type and returns a [`Consumer`] for it.
+    pub fn subscribe<T: Event>(&self) -> Consumer<T> {
         let (sender, receiver) = mpsc::channel::<T>();
-
         let type_id = TypeId::of::<T>();
-
-        let subscribers = self.subscribers.entry(type_id).or_default();
-
-        subscribers.push(Subscriber {
-            sender: Box::new(sender),
-        });
-        Consumer { receiver }
+        self.inner
+            .lock()
+            .subscribers
+            .entry(type_id)
+            .or_default()
+            .push(Subscriber {
+                sender: Box::new(sender),
+            });
+        Consumer {
+            receiver,
+            manager: self.clone(),
+        }
     }
     /// Drains all producers and forwards their pending events to matching subscribers.
     /// Call this once per frame / tick in your engine loop.
-    pub fn dispatch_all(&mut self) {
-        for producer in &self.producers {
-            producer.forward_pending(&mut self.subscribers);
+    pub fn dispatch_all(&self) {
+        let mut inner = self.inner.lock();
+        let EventManagerInner {
+            producers,
+            subscribers,
+        } = &mut *inner;
+        for producer in producers.iter() {
+            producer.forward_pending(subscribers);
         }
     }
 }
 
-/// The Type Erasure Trait
+/// The Type Erasure Trait.
 /// Allows the EventManager to forward pending events without knowing `T`.
 trait AnyProducer: Send {
     fn forward_pending(&self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>);
@@ -80,7 +102,6 @@ impl<T: Event> AnyProducer for TypedProducer<T> {
         let Some(subscribers) = subscribers.get_mut(&self.type_id) else {
             return;
         };
-
         while let Ok(event) = self.receiver.try_recv() {
             subscribers.retain(|sub| {
                 let Some(sender) = sub.sender.downcast_ref::<Sender<T>>() else {
@@ -101,25 +122,36 @@ struct Subscriber {
 
 /// This struct is created by the envent manager.
 /// It allows dispatching of events to subscribers.
-#[derive(Debug)]
 pub struct Dispatcher<T: Event> {
     sender: Sender<T>,
+    manager: EventManager,
 }
 
 impl<T: Event> Dispatcher<T> {
-    /// Queues an event to be forwarded to subscribers.
+    /// Queues an event to be forwarded to subscribers on the next [`EventManager::dispatch_all`].
     pub fn dispatch(&self, event: T) {
         trace!("dispatching event {}", event.debug());
-        // Ignore send errors: it just means the EventManager was dropped.
         let _ = self.sender.send(event);
     }
 }
 
-/// This struct is created by the event manager.
-/// It can consume events that are sent by the event manager.
-#[derive(Debug)]
+impl<T: Event> Clone for Dispatcher<T> {
+    fn clone(&self) -> Self {
+        self.manager.register()
+    }
+}
+
+impl<T: Event> std::fmt::Debug for Dispatcher<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dispatcher").finish_non_exhaustive()
+    }
+}
+
+/// Cloning produces a fresh [`Consumer`] with its own independent subscription,
+/// sharing the same underlying [`EventManager`].
 pub struct Consumer<T: Event> {
     receiver: Receiver<T>,
+    manager: EventManager,
 }
 
 impl<T: Event> Consumer<T> {
@@ -135,5 +167,17 @@ impl<T: Event> Consumer<T> {
     /// Returns an iterator that drains all currently pending events.
     pub fn consume_all(&self) -> impl Iterator<Item = T> {
         std::iter::from_fn(|| self.try_consume())
+    }
+}
+
+impl<T: Event> Clone for Consumer<T> {
+    fn clone(&self) -> Self {
+        self.manager.subscribe()
+    }
+}
+
+impl<T: Event> std::fmt::Debug for Consumer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Consumer").finish_non_exhaustive()
     }
 }

--- a/Engine/Source/events/src/tests.rs
+++ b/Engine/Source/events/src/tests.rs
@@ -378,7 +378,7 @@ mod event_manager {
 
     #[test]
     fn single_event_reaches_single_subscriber() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher: Dispatcher<CounterEvent> = mgr.register();
         let consumer: Consumer<CounterEvent> = mgr.subscribe();
 
@@ -392,7 +392,7 @@ mod event_manager {
 
     #[test]
     fn multiple_events_all_reach_subscriber() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -409,7 +409,7 @@ mod event_manager {
 
     #[test]
     fn events_are_buffered_until_dispatch_all() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -424,7 +424,7 @@ mod event_manager {
 
     #[test]
     fn dispatch_all_can_be_called_multiple_times() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -446,7 +446,7 @@ mod event_manager {
 
     #[test]
     fn no_events_means_empty_consumer() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let _dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -458,7 +458,7 @@ mod event_manager {
 
     #[test]
     fn single_event_reaches_all_subscribers() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let c1 = mgr.subscribe::<CounterEvent>();
         let c2 = mgr.subscribe::<CounterEvent>();
@@ -476,7 +476,7 @@ mod event_manager {
 
     #[test]
     fn multiple_events_fan_out_to_all_subscribers() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let c1 = mgr.subscribe::<CounterEvent>();
         let c2 = mgr.subscribe::<CounterEvent>();
@@ -496,7 +496,7 @@ mod event_manager {
 
     #[test]
     fn subscribers_only_receive_their_event_type() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let counter_dispatcher = mgr.register::<CounterEvent>();
         let label_dispatcher = mgr.register::<LabelEvent>();
 
@@ -518,7 +518,7 @@ mod event_manager {
 
     #[test]
     fn no_cross_contamination_between_event_types() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let counter_dispatcher = mgr.register::<CounterEvent>();
         let _label_dispatcher = mgr.register::<LabelEvent>();
 
@@ -537,7 +537,7 @@ mod event_manager {
 
     #[test]
     fn dispatching_with_no_subscribers_does_not_panic() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
 
         dispatcher.dispatch(CounterEvent(0));
@@ -547,7 +547,7 @@ mod event_manager {
 
     #[test]
     fn dispatch_all_on_empty_manager_does_not_panic() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         mgr.dispatch_all(); // Nothing registered at all.
     }
 
@@ -555,7 +555,7 @@ mod event_manager {
 
     #[test]
     fn dropped_consumer_is_pruned_silently() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
 
         let alive = mgr.subscribe::<CounterEvent>();
@@ -575,7 +575,7 @@ mod event_manager {
 
     #[test]
     fn all_consumers_dropped_does_not_panic() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
 
         {
@@ -591,7 +591,7 @@ mod event_manager {
 
     #[test]
     fn subscribing_without_dispatcher_gives_empty_consumer() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         // Subscribe before any dispatcher is registered for this type.
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -608,7 +608,7 @@ mod event_manager {
     fn high_volume_events_all_delivered() {
         const N: u32 = 10_000;
 
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -628,7 +628,7 @@ mod event_manager {
 
     #[test]
     fn events_accumulate_correctly_across_many_ticks() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -652,7 +652,7 @@ mod event_manager {
 
     #[test]
     fn try_consume_returns_none_when_empty() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let _dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -662,7 +662,7 @@ mod event_manager {
 
     #[test]
     fn try_consume_drains_one_at_a_time() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
 
@@ -679,7 +679,7 @@ mod event_manager {
 
     #[test]
     fn two_dispatchers_for_same_type_both_reach_subscriber() {
-        let mut mgr = EventManager::new();
+        let mgr = EventManager::new();
         let d1 = mgr.register::<CounterEvent>();
         let d2 = mgr.register::<CounterEvent>();
         let consumer = mgr.subscribe::<CounterEvent>();
@@ -697,8 +697,8 @@ mod event_manager {
 
     #[test]
     fn new_and_default_are_equivalent() {
-        let mut mgr_new = EventManager::new();
-        let mut mgr_default = EventManager::default();
+        let mgr_new = EventManager::new();
+        let mgr_default = EventManager::default();
 
         let d1 = mgr_new.register::<CounterEvent>();
         let c1 = mgr_new.subscribe::<CounterEvent>();

--- a/Engine/Source/events/tests/integrations.rs
+++ b/Engine/Source/events/tests/integrations.rs
@@ -163,7 +163,7 @@ fn raw_enum_event_each_variant_falls_back_to_debug() {
 /// listen to each.
 #[test]
 fn realistic_multi_system_engine_loop() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
 
     let key_dispatcher: Dispatcher<KeyPressed> = mgr.register();
     let win_dispatcher: Dispatcher<WindowResized> = mgr.register();
@@ -202,7 +202,7 @@ fn realistic_multi_system_engine_loop() {
 fn fan_out_to_many_consumers() {
     const N: usize = 500;
 
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
 
     let consumers: Vec<Consumer<KeyPressed>> = (0..8).map(|_| mgr.subscribe()).collect();
@@ -225,7 +225,7 @@ fn fan_out_to_many_consumers() {
 /// main thread. Tests `Send` bounds on Dispatcher and Event.
 #[test]
 fn dispatcher_is_send_and_can_be_moved_to_thread() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
     let consumer = mgr.subscribe::<KeyPressed>();
 
@@ -246,7 +246,7 @@ fn dispatcher_is_send_and_can_be_moved_to_thread() {
 /// all subscribers.
 #[test]
 fn unit_event_reaches_all_consumers() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let dispatcher = mgr.register::<ShutdownRequested>();
     let c1 = mgr.subscribe::<ShutdownRequested>();
     let c2 = mgr.subscribe::<ShutdownRequested>();
@@ -265,7 +265,7 @@ fn unit_event_reaches_all_consumers() {
 /// Registering but never subscribing: must not panic on dispatch_all.
 #[test]
 fn register_without_subscribe_is_safe() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
     dispatcher.dispatch(KeyPressed(1));
     mgr.dispatch_all();
@@ -275,7 +275,7 @@ fn register_without_subscribe_is_safe() {
 /// Subscribing but never registering any dispatcher: consumer stays empty.
 #[test]
 fn subscribe_without_register_yields_empty_consumer() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let consumer = mgr.subscribe::<KeyPressed>();
     mgr.dispatch_all();
     assert!(collect_all(&consumer).is_empty());
@@ -284,7 +284,7 @@ fn subscribe_without_register_yields_empty_consumer() {
 /// Calling dispatch_all repeatedly without any events in between is a no-op.
 #[test]
 fn repeated_dispatch_all_with_no_events() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let _d = mgr.register::<KeyPressed>();
     let consumer = mgr.subscribe::<KeyPressed>();
 
@@ -298,7 +298,7 @@ fn repeated_dispatch_all_with_no_events() {
 /// consumers and subsequent dispatches must be unaffected.
 #[test]
 fn mid_simulation_consumer_drop_is_handled() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
     let alive = mgr.subscribe::<KeyPressed>();
 
@@ -321,7 +321,7 @@ fn mid_simulation_consumer_drop_is_handled() {
 /// consume_all returns an empty iterator when called before dispatch_all.
 #[test]
 fn consume_all_before_dispatch_all_is_empty() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
     let consumer = mgr.subscribe::<KeyPressed>();
 
@@ -333,7 +333,7 @@ fn consume_all_before_dispatch_all_is_empty() {
 /// Verifies that an enum event (NetworkEvent) goes through the full pipeline.
 #[test]
 fn enum_event_round_trips_through_manager() {
-    let mut mgr = EventManager::new();
+    let mgr = EventManager::new();
     let dispatcher = mgr.register::<NetworkEvent>();
     let consumer = mgr.subscribe::<NetworkEvent>();
 

--- a/Engine/Source/renderer/src/lib.rs
+++ b/Engine/Source/renderer/src/lib.rs
@@ -14,6 +14,7 @@ use ash::{
     khr::{surface, swapchain},
     vk,
 };
+use events::EventManager;
 use gpu_allocator::{
     AllocatorDebugSettings,
     vulkan::{Allocator, AllocatorCreateDesc},
@@ -175,6 +176,9 @@ pub struct Renderer {
     debug_messenger: vk::DebugUtilsMessengerEXT,
 
     // Events
+    /// TODO: will be used to create listeners for scenes
+    #[allow(unused)]
+    event_manager: EventManager,
     window_consumer: events::Consumer<platform::WindowEvent>,
     platform_consumer: events::Consumer<platform::PlatformEvent>,
     world_consumer: events::Consumer<world::events::WorldEvent>,
@@ -189,7 +193,7 @@ impl Renderer {
     pub fn init(
         create_info: RendererCreateInfo,
         window: &platform::Window,
-        event_manager: &mut events::EventManager,
+        event_manager: events::EventManager,
     ) -> Result<Self> {
         info!("Intializing Vulkan...");
 
@@ -607,6 +611,7 @@ impl Renderer {
             window_consumer: event_manager.subscribe(),
             platform_consumer: event_manager.subscribe(),
             world_consumer: event_manager.subscribe(),
+            event_manager,
         })
     }
 


### PR DESCRIPTION
`EventManager` now internally uses an ArcMutex to handle storing data. This means it can be cloned with no overhead.
Implemented `Clone` on dispatcher & consumer to allow cloning. Cloning simply creates a new one from the internal resource manager.
Update the renderer to store a hard copy of the EventManager.

There is no breaking API change (all tests pass). However, I removed the mut in front of manager creations as it is no longer needed.