### PR TITLE
feat: allow adding components that are not declared in World crate

### DIFF
--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -152,3 +152,15 @@ fn get_idents_for_unnamed(format: &str, fields: &FieldsUnnamed) -> (String, Vec<
 
     (new_format, idents)
 }
+
+#[proc_macro_derive(Component)]
+pub fn derive_component(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let expanded = quote! {
+        impl Component for #name {}
+    };
+
+    TokenStream::from(expanded)
+}

--- a/Engine/Source/world/src/components.rs
+++ b/Engine/Source/world/src/components.rs
@@ -1,4 +1,6 @@
+use crate::Component;
 use glam::{Mat4, Vec3};
+use macros::Component;
 use tracing::warn;
 
 /// Marks an entity as having a renderable mesh.
@@ -12,7 +14,7 @@ use tracing::warn;
 /// let r = Renderable { model: "meshes/cube.glb".into() };
 /// assert_eq!(r.model, "meshes/cube.glb");
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Component)]
 pub struct Renderable {
     /// Asset-registry key for the mesh to render (e.g. `"meshes/cube.glb"`).
     pub model: String,
@@ -37,7 +39,7 @@ pub struct Renderable {
 /// let fwd = t.forward();
 /// assert!((fwd.length() - 1.0).abs() < 1e-5);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Component)]
 pub struct Transform {
     /// World-space position.
     pub location: Vec3,
@@ -127,7 +129,7 @@ impl From<Transform> for Mat4 {
 /// // The matrix must be finite.
 /// assert!(proj.to_cols_array().iter().all(|v| v.is_finite()));
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Component)]
 pub struct Camera {
     /// Vertical field of view **in radians**.
     pub fov: f32,

--- a/Engine/Source/world/src/lib.rs
+++ b/Engine/Source/world/src/lib.rs
@@ -65,7 +65,7 @@ pub type WorldId = u32;
 /// use world::Component;
 /// use macros::Component;
 ///
-/// #[derivce(Component)]
+/// #[derive(Component)]
 /// struct Health(f32);
 /// ```
 pub trait Component: 'static + Sized {}

--- a/Engine/Source/world/src/lib.rs
+++ b/Engine/Source/world/src/lib.rs
@@ -37,6 +37,7 @@
 //! The macro generates all the boilerplate storage and [`Component`] trait
 //! implementations automatically.
 
+use std::any::{Any, TypeId};
 use std::collections::HashMap;
 
 mod tests;
@@ -45,7 +46,6 @@ pub mod components;
 pub mod events;
 pub mod player;
 use crate::events::*;
-use components::*;
 
 /// A unique, opaque identifier for a spawned entity.
 ///
@@ -57,58 +57,116 @@ pub type Entity = u32;
 /// An identifier that distinguishes multiple [`World`] instances from each other.
 pub type WorldId = u32;
 
-/// Marker trait implemented automatically by the [`define_components!`] macro.
+/// Marker trait for component types.
 ///
-/// Do **not** implement this trait manually; use the macro instead.
-pub trait Component: 'static + Sized {
-    /// Returns a shared reference to the per-type storage map.
-    #[doc(hidden)]
-    fn storage(components: &Components) -> &HashMap<Entity, Self>;
-    /// Returns a mutable reference to the per-type storage map.
-    #[doc(hidden)]
-    fn storage_mut(components: &mut Components) -> &mut HashMap<Entity, Self>;
+/// Implement this in **any** crate — no central registration or macro needed.
+///
+/// ```rust
+/// use world::Component;
+/// use macros::Component;
+///
+/// #[derivce(Component)]
+/// struct Health(f32);
+/// ```
+pub trait Component: 'static + Sized {}
+
+/// Type-erased storage for a single component type.
+///
+/// The `as_any` / `as_any_mut` pattern lets us downcast back to the concrete
+/// `TypedStorage<C>` without exposing `C` through the trait object.
+trait AnyStorage {
+    /// Remove the component for `entity` if present.
+    fn remove(&mut self, entity: Entity);
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
-/// Declares the set of component types used by the engine.
-///
-/// Generates the [`Components`] aggregate struct, the `remove_all` helper, and
-/// the [`Component`] trait impl for every listed type.
-macro_rules! define_components {
-    ( $( $C:ident ),* $(,)? ) => {
-
-        /// Aggregate storage for all registered component types.
-        ///
-        /// Each field is a [`HashMap`] keyed by [`Entity`]. Fields are named
-        /// after their component type. Access is mediated through [`World`];
-        /// prefer the [`World::get`] / [`World::insert`] API over touching
-        /// this struct directly.
-        #[allow(non_snake_case)]
-        #[derive(Debug, Default)]
-        pub struct Components {
-            $( $C: HashMap<Entity, $C>, )*
-        }
-
-        impl Components {
-            /// Removes every component attached to `entity`.
-            fn remove_all(&mut self, entity: Entity) {
-                $( self.$C.remove(&entity); )*
-            }
-        }
-
-        $(
-            impl Component for $C {
-                fn storage(components: &Components) -> &HashMap<Entity, Self> {
-                    &components.$C
-                }
-                fn storage_mut(components: &mut Components) -> &mut HashMap<Entity, Self> {
-                    &mut components.$C
-                }
-            }
-        )*
-    };
+struct TypedStorage<C: Component> {
+    map: HashMap<Entity, C>,
 }
 
-define_components!(Transform, Renderable, Camera);
+impl<C: Component> AnyStorage for TypedStorage<C> {
+    fn remove(&mut self, entity: Entity) {
+        self.map.remove(&entity);
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Dynamic, open-ended component storage.
+///
+/// Each component type gets its own `HashMap<Entity, C>`, looked up by
+/// [`TypeId`].  No central registration is required — storage for a type is
+/// created on the first `insert` and lives until the `World` is dropped.
+#[derive(Default)]
+struct Components {
+    storages: HashMap<TypeId, Box<dyn AnyStorage>>,
+}
+
+impl std::fmt::Debug for Components {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Components {{ {} type(s) }}", self.storages.len())
+    }
+}
+
+impl Components {
+    /// Returns a shared reference to the typed storage bucket for `C`,
+    /// or `None` if no component of that type has ever been inserted.
+    fn typed<C: Component>(&self) -> Option<&TypedStorage<C>> {
+        self.storages
+            .get(&TypeId::of::<C>())
+            .and_then(|b| b.as_any().downcast_ref::<TypedStorage<C>>())
+    }
+
+    /// Returns a mutable reference to the typed storage bucket for `C`,
+    /// creating an empty one if it does not yet exist.
+    fn typed_mut<C: Component>(&mut self) -> &mut TypedStorage<C> {
+        self.storages
+            .entry(TypeId::of::<C>())
+            .or_insert_with(|| {
+                Box::new(TypedStorage::<C> {
+                    map: HashMap::new(),
+                })
+            })
+            .as_any_mut()
+            .downcast_mut::<TypedStorage<C>>()
+            .unwrap() // safe: we just inserted exactly this type
+    }
+
+    fn insert<C: Component>(&mut self, entity: Entity, component: C) {
+        self.typed_mut::<C>().map.insert(entity, component);
+    }
+
+    fn get<C: Component>(&self, entity: Entity) -> Option<&C> {
+        self.typed::<C>()?.map.get(&entity)
+    }
+
+    fn get_mut<C: Component>(&mut self, entity: Entity) -> Option<&mut C> {
+        self.typed_mut::<C>().map.get_mut(&entity)
+    }
+
+    fn remove<C: Component>(&mut self, entity: Entity) {
+        if let Some(storage) = self.storages.get_mut(&TypeId::of::<C>()) {
+            storage.remove(entity);
+        }
+    }
+
+    /// Removes **every** component attached to `entity` across all types.
+    fn remove_all(&mut self, entity: Entity) {
+        for storage in self.storages.values_mut() {
+            storage.remove(entity);
+        }
+    }
+
+    fn contains<C: Component>(&self, entity: Entity) -> bool {
+        self.typed::<C>()
+            .is_some_and(|s| s.map.contains_key(&entity))
+    }
+}
 
 /// Stores all entities and their components for a single game world.
 ///
@@ -161,10 +219,6 @@ impl World {
         self.id
     }
 
-    // -----------------------------------------------------------------------
-    // Entity management
-    // -----------------------------------------------------------------------
-
     /// Spawns a new entity and returns its unique [`Entity`] ID.
     ///
     /// The returned ID is stable for the lifetime of the world and is never
@@ -173,12 +227,10 @@ impl World {
         let id = self.next_id;
         self.next_id += 1;
         self.alive.push(id);
-
         self.dispatcher.dispatch(WorldEvent::EntitySpawn {
             world: self.id,
             entity: id,
         });
-
         id
     }
 
@@ -210,10 +262,6 @@ impl World {
         self.alive.contains(&entity)
     }
 
-    // -----------------------------------------------------------------------
-    // Component access
-    // -----------------------------------------------------------------------
-
     /// Attaches `component` to `entity`, replacing any existing component of
     /// the same type.
     ///
@@ -223,7 +271,7 @@ impl World {
     /// regardless, but it will never be returned by queries. Callers should
     /// ensure the entity was obtained from [`World::spawn`] on this world.
     pub fn insert<C: Component>(&mut self, entity: Entity, component: C) {
-        C::storage_mut(&mut self.components).insert(entity, component);
+        self.components.insert(entity, component);
         self.dispatcher.dispatch(WorldEvent::EntityUpdate {
             world: self.id,
             entity,
@@ -233,7 +281,7 @@ impl World {
     /// Returns a shared reference to a component, or `None` if the entity
     /// does not have one.
     pub fn get<C: Component>(&self, entity: Entity) -> Option<&C> {
-        C::storage(&self.components).get(&entity)
+        self.components.get(entity)
     }
 
     /// Returns a mutable reference to a component, or `None` if the entity
@@ -243,7 +291,7 @@ impl World {
             world: self.id,
             entity,
         });
-        C::storage_mut(&mut self.components).get_mut(&entity)
+        self.components.get_mut(entity)
     }
 
     /// Removes a single component from an entity.
@@ -251,16 +299,12 @@ impl World {
     /// The entity itself is **not** despawned. If the component is not
     /// present this is a no-op.
     pub fn remove<C: Component>(&mut self, entity: Entity) {
-        C::storage_mut(&mut self.components).remove(&entity);
+        self.components.remove::<C>(entity);
         self.dispatcher.dispatch(WorldEvent::EntityUpdate {
             world: self.id,
             entity,
         });
     }
-
-    // -----------------------------------------------------------------------
-    // Queries
-    // -----------------------------------------------------------------------
 
     /// Returns all alive entities that have component `A`.
     ///
@@ -278,7 +322,7 @@ impl World {
     pub fn query_single<A: Component>(&self) -> Vec<Entity> {
         self.alive
             .iter()
-            .filter(|&e| A::storage(&self.components).contains_key(e))
+            .filter(|&&e| self.components.contains::<A>(e))
             .cloned()
             .collect()
     }
@@ -287,10 +331,7 @@ impl World {
     pub fn query_double<A: Component, B: Component>(&self) -> Vec<Entity> {
         self.alive
             .iter()
-            .filter(|&e| {
-                A::storage(&self.components).contains_key(e)
-                    && B::storage(&self.components).contains_key(e)
-            })
+            .filter(|&&e| self.components.contains::<A>(e) && self.components.contains::<B>(e))
             .cloned()
             .collect()
     }
@@ -300,10 +341,10 @@ impl World {
     pub fn query_triple<A: Component, B: Component, C: Component>(&self) -> Vec<Entity> {
         self.alive
             .iter()
-            .filter(|&e| {
-                A::storage(&self.components).contains_key(e)
-                    && B::storage(&self.components).contains_key(e)
-                    && C::storage(&self.components).contains_key(e)
+            .filter(|&&e| {
+                self.components.contains::<A>(e)
+                    && self.components.contains::<B>(e)
+                    && self.components.contains::<C>(e)
             })
             .cloned()
             .collect()
@@ -316,11 +357,11 @@ impl World {
     ) -> Vec<Entity> {
         self.alive
             .iter()
-            .filter(|&e| {
-                A::storage(&self.components).contains_key(e)
-                    && B::storage(&self.components).contains_key(e)
-                    && C::storage(&self.components).contains_key(e)
-                    && D::storage(&self.components).contains_key(e)
+            .filter(|&&e| {
+                self.components.contains::<A>(e)
+                    && self.components.contains::<B>(e)
+                    && self.components.contains::<C>(e)
+                    && self.components.contains::<D>(e)
             })
             .cloned()
             .collect()


### PR DESCRIPTION
World components can now be declared in any crate. All they need is to implement the Component marker trait. This can easily be done with the new derive macro.