### PR TITLE
refactor: clean up macros dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
 name = "macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ gpu-allocator = { version = "0.28", default-features = false, features = ["std",
 syn = "2.0"
 quote = "1.0"
 pastey = "0.2"
+proc-macro2 = "1"

--- a/Engine/Source/macros/Cargo.toml
+++ b/Engine/Source/macros/Cargo.toml
@@ -12,3 +12,4 @@ proc-macro = true
 [dependencies]
 syn.workspace = true
 quote.workspace = true
+proc-macro2.workspace = true

--- a/Engine/Source/macros/src/event.rs
+++ b/Engine/Source/macros/src/event.rs
@@ -1,8 +1,8 @@
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, DataEnum, DataStruct, DeriveInput, Fields, FieldsUnnamed, Ident, LitStr};
 
-pub fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenStream {
+pub fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> syn::Result<TokenStream> {
     let name = &input.ident;
     // Split generics into the three parts needed for an impl block:
     // <T: Any>  |  <T>  |  where T: Any

--- a/Engine/Source/macros/src/event.rs
+++ b/Engine/Source/macros/src/event.rs
@@ -1,0 +1,142 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Attribute, DataEnum, DataStruct, DeriveInput, Fields, FieldsUnnamed, Ident, LitStr};
+
+pub fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenStream {
+    let name = &input.ident;
+    // Split generics into the three parts needed for an impl block:
+    // <T: Any>  |  <T>  |  where T: Any
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    // Generate the match arms for a "message" method
+    let arms = data.variants.iter().map(|variant| {
+        let var_name = &variant.ident;
+
+        // Look for #[event("foo")]
+        let message_format = get_message_format_from_attrs(&variant.attrs); // Default message
+
+        match &variant.fields {
+            Fields::Named(fields) => {
+                // Get all field names: { system, source, .. }
+                let idents = fields.named.iter().map(|f| &f.ident);
+                quote! {
+                    #[allow(unused_variables)]
+                    Self::#var_name { #(#idents,)* .. } => format!(#message_format),
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let (message_format, idents) = get_idents_for_unnamed(&message_format, fields);
+                quote! {
+                    #[allow(unused_variables)]
+                    Self::#var_name ( #(#idents,)* .. ) => format!(#message_format),
+                }
+            }
+            Fields::Unit => {
+                quote! {
+                    #[allow(unused_variables)]
+                    Self::#var_name => format!(#message_format),
+                }
+            }
+        }
+    });
+
+    let mut content = quote! {
+        match self {
+            #(#arms)*
+        }
+    };
+
+    if data.variants.is_empty() {
+        content = quote! { format!("{self:?}") }
+    }
+
+    let expanded = quote! {
+        // Add #impl_generics after `impl`, and #ty_generics after the type name.
+        impl #impl_generics Event for #name #ty_generics #where_clause {
+            fn debug(&self) -> String {
+                #content
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+pub fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::TokenStream {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    // Look for #[event("foo")]
+    let message_format = get_message_format_from_attrs(&input.attrs); // Default message
+
+    let content = match &data.fields {
+        Fields::Named(fields) => {
+            // Get all field names: { system, source, .. }
+            let idents = fields.named.iter().map(|f| &f.ident);
+            quote! {
+                #[allow(unused_variables)]
+                let Self { #(#idents,)* .. } = self;
+                format!(#message_format)
+            }
+        }
+        Fields::Unnamed(fields) => {
+            let (message_format, idents) = get_idents_for_unnamed(&message_format, fields);
+            quote! {
+                #[allow(unused_variables)]
+                let Self ( #(#idents,)* .. ) = self;
+                format!(#message_format)
+            }
+        }
+        Fields::Unit => {
+            quote! {
+                format!(#message_format)
+            }
+        }
+    };
+
+    // Build the output
+    let expanded = quote! {
+        impl #impl_generics Event for #name #ty_generics #where_clause {
+            fn debug(&self) -> String {
+                #content
+            }
+        }
+    };
+
+    // Hand the generated code back to the compiler
+    TokenStream::from(expanded)
+}
+
+fn get_message_format_from_attrs(attrs: &Vec<Attribute>) -> String {
+    for attr in attrs {
+        if attr.path().is_ident("event") {
+            return attr
+                .parse_args::<LitStr>()
+                .inspect_err(|e| panic!("parsing event attribute: {e}"))
+                .unwrap()
+                .value();
+        }
+    }
+    String::from("{self:?}")
+}
+
+fn get_idents_for_unnamed(format: &str, fields: &FieldsUnnamed) -> (String, Vec<Ident>) {
+    // Create the list of potential variables (_0, _1, etc.)
+    let idents: Vec<_> = fields
+        .unnamed
+        .iter()
+        .enumerate()
+        .map(|(i, _)| quote::format_ident!("_{}", i))
+        .collect();
+
+    let mut new_format = format.to_string();
+    for i in 0..idents.len() {
+        let search_pattern = format!("{{{i}}}"); // e.g., "{0}"
+        let new_pattern = format!("{{_{i}}}"); // e.g., "{_0}"
+        if format.contains(&search_pattern) {
+            new_format = new_format.replace(&search_pattern, &new_pattern);
+        }
+    }
+
+    (new_format, idents)
+}

--- a/Engine/Source/macros/src/event.rs
+++ b/Engine/Source/macros/src/event.rs
@@ -133,3 +133,83 @@ fn rewrite_unnamed_placeholders(format: &str, fields: &FieldsUnnamed) -> (String
 
     (new_format, idents)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::{DeriveInput, parse_str};
+
+    // ── rewrite_unnamed_placeholders ──────────────────────────────────────────
+
+    fn unnamed_fields_from(src: &str) -> FieldsUnnamed {
+        let input: DeriveInput = parse_str(src).unwrap();
+        match input.data {
+            syn::Data::Struct(s) => match s.fields {
+                Fields::Unnamed(u) => u,
+                _ => panic!("expected unnamed fields"),
+            },
+            _ => panic!("expected a struct"),
+        }
+    }
+
+    #[test]
+    fn rewrite_replaces_all_positional_placeholders() {
+        let fields = unnamed_fields_from("struct Foo(u32, String);");
+        let (fmt, idents) = rewrite_unnamed_placeholders("{0} and {1}", &fields);
+        assert_eq!(fmt, "{_0} and {_1}");
+        assert_eq!(idents.len(), 2);
+        assert_eq!(idents[0], quote::format_ident!("_0"));
+        assert_eq!(idents[1], quote::format_ident!("_1"));
+    }
+
+    #[test]
+    fn rewrite_leaves_non_positional_format_intact() {
+        let fields = unnamed_fields_from("struct Foo(u32);");
+        let (fmt, idents) = rewrite_unnamed_placeholders("no placeholders", &fields);
+        assert_eq!(fmt, "no placeholders");
+        assert_eq!(idents.len(), 1);
+    }
+
+    #[test]
+    fn rewrite_handles_partial_placeholder_use() {
+        let fields = unnamed_fields_from("struct Foo(u32, String, bool);");
+        let (fmt, _) = rewrite_unnamed_placeholders("only {1} matters", &fields);
+        assert_eq!(fmt, "only {_1} matters");
+    }
+
+    #[test]
+    fn rewrite_handles_repeated_placeholder() {
+        let fields = unnamed_fields_from("struct Foo(u32, String);");
+        let (fmt, _) = rewrite_unnamed_placeholders("{0} then {0} again", &fields);
+        assert_eq!(fmt, "{_0} then {_0} again");
+    }
+
+    // ── get_message_format_from_attrs ─────────────────────────────────────────
+
+    #[test]
+    fn format_falls_back_to_debug_repr_when_no_attr() {
+        let input: DeriveInput = parse_str("struct Foo;").unwrap();
+        let result = get_message_format_from_attrs(&input.attrs).unwrap();
+        assert_eq!(result, "{self:?}");
+    }
+
+    #[test]
+    fn format_extracts_literal_from_event_attr() {
+        let input: DeriveInput = parse_str(r#"#[event("hello world")] struct Foo;"#).unwrap();
+        let result = get_message_format_from_attrs(&input.attrs).unwrap();
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn format_returns_error_for_non_string_arg() {
+        let input: DeriveInput = parse_str(r#"#[event(42)] struct Foo;"#).unwrap();
+        assert!(get_message_format_from_attrs(&input.attrs).is_err());
+    }
+
+    #[test]
+    fn format_ignores_unrelated_attributes() {
+        let input: DeriveInput = parse_str(r#"#[derive(Debug)] struct Foo;"#).unwrap();
+        let result = get_message_format_from_attrs(&input.attrs).unwrap();
+        assert_eq!(result, "{self:?}");
+    }
+}

--- a/Engine/Source/macros/src/event.rs
+++ b/Engine/Source/macros/src/event.rs
@@ -8,135 +8,128 @@ pub fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> syn::Result<To
     // <T: Any>  |  <T>  |  where T: Any
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    // Generate the match arms for a "message" method
-    let arms = data.variants.iter().map(|variant| {
-        let var_name = &variant.ident;
-
-        // Look for #[event("foo")]
-        let message_format = get_message_format_from_attrs(&variant.attrs); // Default message
-
-        match &variant.fields {
-            Fields::Named(fields) => {
-                // Get all field names: { system, source, .. }
-                let idents = fields.named.iter().map(|f| &f.ident);
-                quote! {
+    let content = if data.variants.is_empty() {
+        // Nothing to match on; fall back to the Debug representation.
+        quote! { format!("{self:?}") }
+    } else {
+        let arms = data
+            .variants
+            .iter()
+            .map(|variant| {
+                let var_name = &variant.ident;
+                let fmt = get_message_format_from_attrs(&variant.attrs)?;
+                let (pattern, format_expr) = create_field_bindings(&variant.fields, &fmt);
+                Ok(quote! {
                     #[allow(unused_variables)]
-                    Self::#var_name { #(#idents,)* .. } => format!(#message_format),
-                }
-            }
-            Fields::Unnamed(fields) => {
-                let (message_format, idents) = get_idents_for_unnamed(&message_format, fields);
-                quote! {
-                    #[allow(unused_variables)]
-                    Self::#var_name ( #(#idents,)* .. ) => format!(#message_format),
-                }
-            }
-            Fields::Unit => {
-                quote! {
-                    #[allow(unused_variables)]
-                    Self::#var_name => format!(#message_format),
-                }
-            }
-        }
-    });
+                    Self::#var_name #pattern => #format_expr,
+                })
+            })
+            .collect::<syn::Result<Vec<_>>>()?;
 
-    let mut content = quote! {
-        match self {
-            #(#arms)*
-        }
+        quote! { match self { #(#arms)* } }
     };
 
-    if data.variants.is_empty() {
-        content = quote! { format!("{self:?}") }
-    }
-
-    let expanded = quote! {
-        // Add #impl_generics after `impl`, and #ty_generics after the type name.
+    Ok(quote! {
         impl #impl_generics Event for #name #ty_generics #where_clause {
             fn debug(&self) -> String {
                 #content
             }
         }
-    };
-
-    TokenStream::from(expanded)
+    })
 }
 
-pub fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::TokenStream {
+pub fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> syn::Result<TokenStream> {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    // Look for #[event("foo")]
-    let message_format = get_message_format_from_attrs(&input.attrs); // Default message
+    let fmt = get_message_format_from_attrs(&input.attrs)?;
+    let (pattern, format_expr) = create_field_bindings(&data.fields, &fmt);
 
-    let content = match &data.fields {
-        Fields::Named(fields) => {
-            // Get all field names: { system, source, .. }
-            let idents = fields.named.iter().map(|f| &f.ident);
-            quote! {
-                #[allow(unused_variables)]
-                let Self { #(#idents,)* .. } = self;
-                format!(#message_format)
-            }
-        }
-        Fields::Unnamed(fields) => {
-            let (message_format, idents) = get_idents_for_unnamed(&message_format, fields);
-            quote! {
-                #[allow(unused_variables)]
-                let Self ( #(#idents,)* .. ) = self;
-                format!(#message_format)
-            }
-        }
-        Fields::Unit => {
-            quote! {
-                format!(#message_format)
-            }
-        }
+    let content = match data.fields {
+        // Unit structs need no destructuring; everything else gets a `let Self …`.
+        Fields::Unit => format_expr,
+        _ => quote! {
+            #[allow(unused_variables)]
+            let Self #pattern = self;
+            #format_expr
+        },
     };
 
-    // Build the output
-    let expanded = quote! {
+    Ok(quote! {
         impl #impl_generics Event for #name #ty_generics #where_clause {
             fn debug(&self) -> String {
                 #content
             }
         }
-    };
-
-    // Hand the generated code back to the compiler
-    TokenStream::from(expanded)
+    })
 }
 
-fn get_message_format_from_attrs(attrs: &Vec<Attribute>) -> String {
+/// This will create the field destructuring pattern & the expression for the
+/// formatting of the field
+/// Returns (pattern, format expression)
+fn create_field_bindings(fields: &Fields, message_format: &str) -> (TokenStream, TokenStream) {
+    match fields {
+        // struct Foo { x: T, y: T }  →  let Self { x, y, .. } = self;
+        Fields::Named(named) => {
+            let idents: Vec<_> = named.named.iter().map(|f| &f.ident).collect();
+            // `..` lets the pattern survive the addition of new fields.
+            let pattern = quote! { { #(#idents,)* .. } };
+            let format_expr = quote! { format!(#message_format) };
+
+            (pattern, format_expr)
+        }
+        // struct Foo(T, T)  →  let Self(_0, _1) = self;
+        Fields::Unnamed(unnamed) => {
+            let (fmt, idents) = rewrite_unnamed_placeholders(message_format, unnamed);
+            // No `..`: we enumerate every field, so the pattern is already
+            // exhaustive. Adding `..` would cause an "unnecessary `..`" lint.
+            let pattern = quote! { ( #(#idents,)* ) };
+            let format_expr = quote! { format!(#fmt) };
+
+            (pattern, format_expr)
+        }
+        // struct Foo;  →  nothing to destructure.
+        Fields::Unit => (quote! {}, quote! { format!(#message_format) }),
+    }
+}
+
+/// Extracts the format string from the first `#[event("…")]` attribute found.
+///
+/// Returns `"{self:?}"` when no `#[event]` attribute is present.
+/// Emits a `syn::Error` with a proper source span if the attribute argument
+/// is not a string literal.
+fn get_message_format_from_attrs(attrs: &[Attribute]) -> syn::Result<String> {
     for attr in attrs {
         if attr.path().is_ident("event") {
-            return attr
+            return Ok(attr
                 .parse_args::<LitStr>()
-                .inspect_err(|e| panic!("parsing event attribute: {e}"))
-                .unwrap()
-                .value();
+                .map_err(|_| {
+                    syn::Error::new_spanned(attr, "expected a string literal: #[event(\"…\")]")
+                })?
+                .value());
         }
     }
-    String::from("{self:?}")
+    Ok(String::from("{self:?}"))
 }
 
-fn get_idents_for_unnamed(format: &str, fields: &FieldsUnnamed) -> (String, Vec<Ident>) {
+/// Rewrites positional `{0}`, `{1}`, … placeholders to the named bindings
+/// `{_0}`, `{_1}`, … used when destructuring unnamed (tuple) fields, and
+/// returns the rewritten format string together with the binding [`Ident`]s.
+fn rewrite_unnamed_placeholders(format: &str, fields: &FieldsUnnamed) -> (String, Vec<Ident>) {
     // Create the list of potential variables (_0, _1, etc.)
-    let idents: Vec<_> = fields
+    let idents: Vec<Ident> = fields
         .unnamed
         .iter()
         .enumerate()
         .map(|(i, _)| quote::format_ident!("_{}", i))
         .collect();
 
-    let mut new_format = format.to_string();
-    for i in 0..idents.len() {
-        let search_pattern = format!("{{{i}}}"); // e.g., "{0}"
-        let new_pattern = format!("{{_{i}}}"); // e.g., "{_0}"
-        if format.contains(&search_pattern) {
-            new_format = new_format.replace(&search_pattern, &new_pattern);
-        }
-    }
+    let new_format = idents
+        .iter()
+        .enumerate()
+        .fold(format.to_string(), |acc, (i, _)| {
+            acc.replace(&format!("{{{i}}}"), &format!("{{_{i}}}"))
+        });
 
     (new_format, idents)
 }

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -4,29 +4,91 @@ use syn::{Data, DeriveInput, parse_macro_input};
 
 mod event;
 
+/// Derive the `Event` trait for a `struct` or `enum`.
+///
+/// Generates a `debug(&self) -> String` implementation that formats the value
+/// using a caller-supplied template, or falls back to `"{self:?}"` when none
+/// is provided.
+///
+/// # The `#[event("…")]` attribute
+///
+/// Attach `#[event("…")]` to the type (for structs) or to individual variants
+/// (for enums) to control the debug message.
+///
+/// ## Named-field structs / variants
+///
+/// All field names are bound in scope so you can interpolate them:
+///
+/// ```rust
+/// # pub trait Event: Send + Clone + 'static { fn debug(&self) -> String; }
+/// # use macros::Event;
+/// #[derive(Event, Clone)]
+/// #[event("player {name} joined with {hp} hp")]
+/// struct PlayerJoined { name: String, hp: u32 }
+/// ```
+///
+/// ## Tuple (unnamed) structs / variants
+///
+/// Use positional placeholders `{0}`, `{1}`, … which are rewritten to the
+/// internal bindings `_0`, `_1`, …:
+///
+/// ```rust
+/// # pub trait Event: Send + Clone + 'static { fn debug(&self) -> String; }
+/// # use macros::Event;
+/// #[derive(Event, Clone)]
+/// enum Msg {
+///     #[event("moved to ({0}, {1})")]
+///     Moved(f32, f32),
+/// }
+/// ```
+///
+/// ## Unit structs / variants
+///
+/// The `{self:?}` fallback (or a static string) works fine:
+///
+/// ```rust
+/// # pub trait Event: Send + Clone + 'static { fn debug(&self) -> String; }
+/// # use macros::Event;
+/// #[derive(Event, Clone)]
+/// #[event("server stopped")]
+/// struct ServerStopped;
+/// ```
 #[proc_macro_derive(Event, attributes(event))]
-pub fn derive_event(input: TokenStream) -> TokenStream {
-    // Parse the representation
+pub fn derive_event(input: proc_macro::TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    match input.data {
+    let result: syn::Result<proc_macro2::TokenStream> = match input.data {
         Data::Enum(ref data) => event::derive_event_enum(&input, data),
         Data::Struct(ref data) => event::derive_event_struct(&input, data),
-        _ => panic!("can only derive event from struct or enum"),
-    }
+        _ => Err(syn::Error::new(
+            input.ident.span(),
+            "`Event` can only be derived for structs and enums",
+        )),
+    };
+
+    result.unwrap_or_else(|e| e.to_compile_error()).into()
 }
 
+/// Derive the `Component` marker trait for any type.
+///
+/// This is a zero-boilerplate derive that simply emits an empty `impl Component
+/// for …` block, respecting any generics on the type:
+///
+/// ```rust
+/// # trait Component {}
+/// # use macros::Component;
+/// #[derive(Component)]
+/// #[derive(Clone)]
+/// struct Transform { position: (i32, i32) }
+/// ```
 #[proc_macro_derive(Component)]
 pub fn derive_component(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
-    // Split generics into the three parts needed for an impl block:
-    // <T: Any>  |  <T>  |  where T: Any
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let expanded = quote! {
+    quote! {
         impl #impl_generics Component for #name #ty_generics #where_clause {}
-    };
-
-    TokenStream::from(expanded)
+    }
+    .into()
 }

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -19,6 +19,9 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
 
 fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenStream {
     let name = &input.ident;
+    // Split generics into the three parts needed for an impl block:
+    // <T: Any>  |  <T>  |  where T: Any
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     // Generate the match arms for a "message" method
     let arms = data.variants.iter().map(|variant| {
@@ -59,13 +62,12 @@ fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenS
     };
 
     if data.variants.is_empty() {
-        content = quote! {
-            format!("{self:?}")
-        }
+        content = quote! { format!("{self:?}") }
     }
 
     let expanded = quote! {
-        impl Event for #name {
+        // Add #impl_generics after `impl`, and #ty_generics after the type name.
+        impl #impl_generics Event for #name #ty_generics #where_clause {
             fn debug(&self) -> String {
                 #content
             }
@@ -77,6 +79,7 @@ fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenS
 
 fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::TokenStream {
     let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     // Look for #[event("foo")]
     let message_format = get_message_format_from_attrs(&input.attrs); // Default message
@@ -108,7 +111,7 @@ fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::To
 
     // Build the output
     let expanded = quote! {
-        impl Event for #name {
+        impl #impl_generics Event for #name #ty_generics #where_clause {
             fn debug(&self) -> String {
                 #content
             }
@@ -157,9 +160,12 @@ fn get_idents_for_unnamed(format: &str, fields: &FieldsUnnamed) -> (String, Vec<
 pub fn derive_component(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
+    // Split generics into the three parts needed for an impl block:
+    // <T: Any>  |  <T>  |  where T: Any
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let expanded = quote! {
-        impl Component for #name {}
+        impl #impl_generics Component for #name #ty_generics #where_clause {}
     };
 
     TokenStream::from(expanded)

--- a/Engine/Source/macros/src/lib.rs
+++ b/Engine/Source/macros/src/lib.rs
@@ -1,9 +1,8 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-    Attribute, Data, DataEnum, DataStruct, DeriveInput, Fields, FieldsUnnamed, Ident, LitStr,
-    parse_macro_input,
-};
+use syn::{Data, DeriveInput, parse_macro_input};
+
+mod event;
 
 #[proc_macro_derive(Event, attributes(event))]
 pub fn derive_event(input: TokenStream) -> TokenStream {
@@ -11,149 +10,10 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     match input.data {
-        Data::Enum(ref data) => derive_event_enum(&input, data),
-        Data::Struct(ref data) => derive_event_struct(&input, data),
+        Data::Enum(ref data) => event::derive_event_enum(&input, data),
+        Data::Struct(ref data) => event::derive_event_struct(&input, data),
         _ => panic!("can only derive event from struct or enum"),
     }
-}
-
-fn derive_event_enum(input: &DeriveInput, data: &DataEnum) -> proc_macro::TokenStream {
-    let name = &input.ident;
-    // Split generics into the three parts needed for an impl block:
-    // <T: Any>  |  <T>  |  where T: Any
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-
-    // Generate the match arms for a "message" method
-    let arms = data.variants.iter().map(|variant| {
-        let var_name = &variant.ident;
-
-        // Look for #[event("foo")]
-        let message_format = get_message_format_from_attrs(&variant.attrs); // Default message
-
-        match &variant.fields {
-            Fields::Named(fields) => {
-                // Get all field names: { system, source, .. }
-                let idents = fields.named.iter().map(|f| &f.ident);
-                quote! {
-                    #[allow(unused_variables)]
-                    Self::#var_name { #(#idents,)* .. } => format!(#message_format),
-                }
-            }
-            Fields::Unnamed(fields) => {
-                let (message_format, idents) = get_idents_for_unnamed(&message_format, fields);
-                quote! {
-                    #[allow(unused_variables)]
-                    Self::#var_name ( #(#idents,)* .. ) => format!(#message_format),
-                }
-            }
-            Fields::Unit => {
-                quote! {
-                    #[allow(unused_variables)]
-                    Self::#var_name => format!(#message_format),
-                }
-            }
-        }
-    });
-
-    let mut content = quote! {
-        match self {
-            #(#arms)*
-        }
-    };
-
-    if data.variants.is_empty() {
-        content = quote! { format!("{self:?}") }
-    }
-
-    let expanded = quote! {
-        // Add #impl_generics after `impl`, and #ty_generics after the type name.
-        impl #impl_generics Event for #name #ty_generics #where_clause {
-            fn debug(&self) -> String {
-                #content
-            }
-        }
-    };
-
-    TokenStream::from(expanded)
-}
-
-fn derive_event_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::TokenStream {
-    let name = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-
-    // Look for #[event("foo")]
-    let message_format = get_message_format_from_attrs(&input.attrs); // Default message
-
-    let content = match &data.fields {
-        Fields::Named(fields) => {
-            // Get all field names: { system, source, .. }
-            let idents = fields.named.iter().map(|f| &f.ident);
-            quote! {
-                #[allow(unused_variables)]
-                let Self { #(#idents,)* .. } = self;
-                format!(#message_format)
-            }
-        }
-        Fields::Unnamed(fields) => {
-            let (message_format, idents) = get_idents_for_unnamed(&message_format, fields);
-            quote! {
-                #[allow(unused_variables)]
-                let Self ( #(#idents,)* .. ) = self;
-                format!(#message_format)
-            }
-        }
-        Fields::Unit => {
-            quote! {
-                format!(#message_format)
-            }
-        }
-    };
-
-    // Build the output
-    let expanded = quote! {
-        impl #impl_generics Event for #name #ty_generics #where_clause {
-            fn debug(&self) -> String {
-                #content
-            }
-        }
-    };
-
-    // Hand the generated code back to the compiler
-    TokenStream::from(expanded)
-}
-
-fn get_message_format_from_attrs(attrs: &Vec<Attribute>) -> String {
-    for attr in attrs {
-        if attr.path().is_ident("event") {
-            return attr
-                .parse_args::<LitStr>()
-                .inspect_err(|e| panic!("parsing event attribute: {e}"))
-                .unwrap()
-                .value();
-        }
-    }
-    String::from("{self:?}")
-}
-
-fn get_idents_for_unnamed(format: &str, fields: &FieldsUnnamed) -> (String, Vec<Ident>) {
-    // Create the list of potential variables (_0, _1, etc.)
-    let idents: Vec<_> = fields
-        .unnamed
-        .iter()
-        .enumerate()
-        .map(|(i, _)| quote::format_ident!("_{}", i))
-        .collect();
-
-    let mut new_format = format.to_string();
-    for i in 0..idents.len() {
-        let search_pattern = format!("{{{i}}}"); // e.g., "{0}"
-        let new_pattern = format!("{{_{i}}}"); // e.g., "{_0}"
-        if format.contains(&search_pattern) {
-            new_format = new_format.replace(&search_pattern, &new_pattern);
-        }
-    }
-
-    (new_format, idents)
 }
 
 #[proc_macro_derive(Component)]


### PR DESCRIPTION
Add `proc-macro2` dependency.
Add extensive documentation & clean up the code to avoid code duplication.
Improve error handling in whole crate.