### PR TITLE
improve app exiting by allowing a message to be displayed

### DIFF
--- a/Engine/Source/engine/src/lib.rs
+++ b/Engine/Source/engine/src/lib.rs
@@ -14,7 +14,7 @@ use logging::Logger;
 
 /// This is the main struct that holds global engine state.
 pub struct Engine {
-    exit_consumer: events::Consumer<platform::AppExit>,
+    exit_consumer: events::Consumer<events::AppExit>,
     event_manager: events::EventManager,
 
     #[allow(unused)]
@@ -158,7 +158,8 @@ impl Engine {
     }
 
     fn process_events(&mut self) {
-        if let Some(platform::AppExit(_)) = self.exit_consumer.try_consume() {
+        if let Some(events::AppExit(msg)) = self.exit_consumer.try_consume() {
+            info!("App exit requested: {msg}");
             self.exit(None);
         }
     }

--- a/Engine/Source/events/src/lib.rs
+++ b/Engine/Source/events/src/lib.rs
@@ -520,3 +520,12 @@ impl<T: Event> std::fmt::Debug for Consumer<T> {
         f.debug_struct("Consumer").finish_non_exhaustive()
     }
 }
+
+/// An event to request to the engine to exit.
+///
+/// This event is used by various engine systems.
+/// It can be used by the platform to signal to the engine that the windows
+/// have all been closed. It is also used when users manually exit the engine.
+#[derive(Debug, Clone, Event)]
+#[event("App exit requested: {0}")]
+pub struct AppExit(pub String);

--- a/Engine/Source/platform/src/event.rs
+++ b/Engine/Source/platform/src/event.rs
@@ -3,8 +3,8 @@ use winit::window::WindowId;
 
 /// An event to signal that the application has exited
 #[derive(Debug, Clone, Event)]
-#[event("App Exit with code {0}")]
-pub struct AppExit(pub i32);
+#[event("App exit requested: {0}")]
+pub struct AppExit(pub String);
 
 /// All platform events.
 /// These are specific to global platform stuff. No input or window

--- a/Engine/Source/platform/src/event.rs
+++ b/Engine/Source/platform/src/event.rs
@@ -1,11 +1,6 @@
 use events::Event;
 use winit::window::WindowId;
 
-/// An event to signal that the application has exited
-#[derive(Debug, Clone, Event)]
-#[event("App exit requested: {0}")]
-pub struct AppExit(pub String);
-
 /// All platform events.
 /// These are specific to global platform stuff. No input or window
 /// specific events are listed here.

--- a/Engine/Source/platform/src/lib.rs
+++ b/Engine/Source/platform/src/lib.rs
@@ -30,7 +30,7 @@ pub struct Platform {
     handler: PlatformHandler,
     event_loop: EventLoop,
 
-    exit_dispatcher: events::Dispatcher<event::AppExit>,
+    exit_dispatcher: events::Dispatcher<events::AppExit>,
     window_consumer: events::Consumer<WindowEvent>,
 }
 
@@ -74,16 +74,19 @@ impl Platform {
             .pump_app_events(Some(Duration::ZERO), &mut self.handler)
         {
             PumpStatus::Exit(code) => {
-                info!("Event loop exited with code {code}");
                 // Treat a forced OS exit like a window close.
-                self.exit_dispatcher.dispatch(event::AppExit(code));
+                self.exit_dispatcher.dispatch(events::AppExit(format!(
+                    "Event loop exited with code {code}"
+                )));
                 return;
             }
             PumpStatus::Continue => {}
         }
 
         if self.handler.windows.is_empty() {
-            self.exit_dispatcher.dispatch(event::AppExit(0));
+            self.exit_dispatcher.dispatch(events::AppExit(
+                "all platform windows have been closed".into(),
+            ));
         }
 
         self.window_consumer.consume_all().for_each(|event| {


### PR DESCRIPTION
Move `AppExit` event into `events` crate & add a String field for a message.