### PR TITLE
refactor: move `delta_time` to `f64` & feat: atomic frame counting

### DIFF
--- a/crates/dirk_events/src/lib.rs
+++ b/crates/dirk_events/src/lib.rs
@@ -529,3 +529,11 @@ impl<T: Event> std::fmt::Debug for Consumer<T> {
 #[derive(Debug, Clone, Event)]
 #[event("App exit requested: {0}")]
 pub struct AppExit(pub String);
+
+/// An event run at the beginning of every tick.
+///
+/// This event contains the frame number.
+/// Used for thread synchronization.
+#[derive(Debug, Clone, Event)]
+#[event("App exit requested: {0}")]
+pub struct BeginFrame(pub u64);

--- a/crates/dirk_platform/src/lib.rs
+++ b/crates/dirk_platform/src/lib.rs
@@ -63,7 +63,7 @@ impl Platform {
     }
     /// Process pending OS events without blocking.
     /// Returns the events that occurred this tick for the engine to handle.
-    pub fn tick(&mut self, _delta_time: f32) {
+    pub fn tick(&mut self, _delta_time: f64) {
         match self
             .event_loop
             .pump_app_events(Some(Duration::ZERO), &mut self.handler)

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -494,7 +494,7 @@ impl Renderer {
     /// world (unless in [`WorldEvent::Created`] or [`WorldEvent::Destroyed`].
     pub fn tick(
         &mut self,
-        _delta_time: f32,
+        _delta_time: f64,
         windows: &HashMap<WindowId, dirk_platform::Window>,
     ) -> Result<()> {
         // Temporarily move receivers out for the borrow checker

--- a/crates/dirk_renderer/src/proxy/systems.rs
+++ b/crates/dirk_renderer/src/proxy/systems.rs
@@ -21,7 +21,7 @@ impl RendererUniverseSystem {
 
 impl UniverseSystem for RendererUniverseSystem {
     // these functions aren't needed
-    fn tick(&self, _: &mut CommandBuffer, _: &dirk_universe::Universe, _: f32) {}
+    fn tick(&self, _: &mut CommandBuffer, _: &dirk_universe::Universe, _: f64) {}
 
     fn entity_spawned(
         &self,

--- a/crates/dirk_universe/src/lib.rs
+++ b/crates/dirk_universe/src/lib.rs
@@ -86,7 +86,7 @@ impl Universe {
     /// Will panic in certain internal conditions like if a [`World`] that
     /// was just created is not found in the [`Universe`].
     /// No panic should be caused by user error.
-    pub fn tick(&mut self, delta_time: f32) {
+    pub fn tick(&mut self, delta_time: f64) {
         let mut cmd = CommandBuffer::new();
 
         let buffers = std::mem::take(&mut self.buffers);

--- a/crates/dirk_universe/src/systems.rs
+++ b/crates/dirk_universe/src/systems.rs
@@ -46,7 +46,7 @@ pub trait UniverseSystem: System {
     fn entity_despawned(&self, cmd: &mut CommandBuffer, universe: &Universe, entity: Entity);
 
     /// This function will be called by the [`Universe`] on every tick.
-    fn tick(&self, cmd: &mut CommandBuffer, universe: &Universe, delta_time: f32);
+    fn tick(&self, cmd: &mut CommandBuffer, universe: &Universe, delta_time: f64);
 }
 
 /// A [`System`] that is run on every entity that matches the query.
@@ -86,7 +86,7 @@ pub trait TickingSystem: System {
         &self,
         cmd: &mut CommandBuffer,
         universe: &Universe,
-        delta_time: f32,
+        delta_time: f64,
         entities: &mut dyn Iterator<Item = Entity>,
     );
     /// Returns the query used to construct the `entities` of the tick function.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -197,9 +197,9 @@ impl Engine {
         &self.exit_error
     }
     /// Returns the time in seconds since last tick. This consumes the delta time.
-    fn capture_delta_time(&mut self) -> f32 {
+    fn capture_delta_time(&mut self) -> f64 {
         let current_time = Instant::now();
-        let delta = current_time.duration_since(self.last_tick).as_secs_f32();
+        let delta = current_time.duration_since(self.last_tick).as_secs_f64();
         self.last_tick = current_time;
         delta
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,13 @@
 //! The engine module. The engine holds all the state & manages
 //! all the systems for the engine to run properly.
 
-use std::{collections::HashMap, ffi::CString, str::FromStr, time::Instant};
+use std::{
+    collections::HashMap,
+    ffi::CString,
+    str::FromStr,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
 
 use anyhow::Context;
 use dirk_universe::{Entity, Universe, World, WorldId};
@@ -13,7 +19,10 @@ use dirk_logging::Logger;
 /// This is the main struct that holds global engine state.
 pub struct Engine {
     exit_consumer: dirk_events::Consumer<dirk_events::AppExit>,
+    frame_dispatcher: dirk_events::Dispatcher<dirk_events::BeginFrame>,
     event_manager: dirk_events::EventManager,
+
+    frame: AtomicU64,
 
     #[allow(unused)]
     asset_registry: dirk_assets::AssetRegistry,
@@ -79,9 +88,12 @@ impl Engine {
         info!("engine initialised");
         Ok(Self {
             exit_consumer: event_manager.subscribe(),
+            frame_dispatcher: event_manager.register(),
             event_manager,
             logger,
             asset_registry,
+
+            frame: AtomicU64::new(0),
 
             platform,
             renderer,
@@ -145,6 +157,10 @@ impl Engine {
     }
 
     fn tick_inner(&mut self) -> anyhow::Result<bool> {
+        let frame = self.frame.fetch_add(1, Ordering::Relaxed);
+        self.frame_dispatcher
+            .dispatch(dirk_events::BeginFrame(frame));
+
         let delta_time = self.capture_delta_time();
         self.event_manager.dispatch_all();
 


### PR DESCRIPTION
## Changes

- add: `frame` in engine. An atomic u64 for frame count
- add: `BeginFrame` event to broadcast the frame count at the beginning of every frame.
- refactor: move all delta times to use by `f64`