### PR TITLE
refactor: exiting the engine

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -203,6 +203,10 @@ impl Engine {
     }
     /// Specify `err` to exit with an error.
     pub fn exit(&mut self, err: Option<anyhow::Error>) {
+        if matches!(self.exit_state, ExitState::Error(_)) {
+            return;
+        }
+
         self.exit_state = match err {
             Some(err) => ExitState::Error(err),
             None => ExitState::Requested,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -139,22 +139,22 @@ impl Engine {
     /// Ticks the engine. This is the master function that calls
     /// every other system's tick function.
     ///
-    /// # Errors
-    ///
-    /// Errors can occure if the various ticking systems have errors.
-    /// For now, only rendering can return an error.
-    pub fn tick(&mut self) -> bool {
-        self.frame += 1;
-        match self.tick_inner() {
-            Ok(exit) => exit,
-            Err(err) => {
-                self.exit_state = ExitState::Error(err.context("engine tick"));
-                false
-            }
+    /// Returns the current exit state after advancing one frame, unless an
+    /// exit has already been requested.
+    pub fn tick(&mut self) -> &ExitState {
+        if self.is_requesting_exit() {
+            return &self.exit_state;
         }
+
+        self.frame += 1;
+        if let Err(err) = self.tick_inner() {
+            self.exit(Some(err.context("engine tick")));
+        }
+
+        &self.exit_state
     }
 
-    fn tick_inner(&mut self) -> anyhow::Result<bool> {
+    fn tick_inner(&mut self) -> anyhow::Result<()> {
         self.frame_dispatcher
             .dispatch(dirk_events::BeginFrame(self.frame));
 
@@ -167,7 +167,7 @@ impl Engine {
 
         self.process_events();
         if self.is_requesting_exit() {
-            return Ok(false);
+            return Ok(());
         }
 
         self.platform.tick(delta_time);
@@ -183,7 +183,7 @@ impl Engine {
             .for_each(|player| player.tick(&mut self.universe));
 
         self.render().context("rendering")?;
-        Ok(!self.is_requesting_exit())
+        Ok(())
     }
 
     fn render(&mut self) -> anyhow::Result<()> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -10,6 +10,28 @@ use tracing::info;
 
 use dirk_logging::Logger;
 
+/// This state is returned by [`Engine::tick`].
+/// It holds why the engine is exiting.
+pub enum ExitState {
+    /// The engine is not exiting. The engine should never exit with this state.
+    Running,
+    /// The engine exit has been requested by a system.
+    Requested,
+    /// An error occured in the [`Engine`], it is exiting.
+    Error(anyhow::Error),
+}
+
+impl ExitState {
+    /// Returns if this exit state is exiting
+    #[must_use]
+    pub fn exiting(&self) -> bool {
+        match self {
+            Self::Running => false,
+            Self::Requested | Self::Error(_) => true,
+        }
+    }
+}
+
 /// This is the main struct that holds global engine state.
 pub struct Engine {
     exit_consumer: dirk_events::Consumer<dirk_events::AppExit>,
@@ -17,6 +39,7 @@ pub struct Engine {
     event_manager: dirk_events::EventManager,
 
     frame: u64,
+    last_tick: Instant,
 
     #[allow(unused)]
     asset_registry: dirk_assets::AssetRegistry,
@@ -28,9 +51,7 @@ pub struct Engine {
     next_player_id: PlayerId,
     players: HashMap<PlayerId, Player>,
 
-    is_requesting_exit: bool,
-    exit_error: Option<anyhow::Error>,
-    last_tick: Instant,
+    exit_state: ExitState,
 
     #[allow(unused)]
     logger: Logger,
@@ -88,6 +109,7 @@ impl Engine {
             asset_registry,
 
             frame: 0,
+            last_tick: Instant::now(),
 
             platform,
             renderer,
@@ -96,9 +118,7 @@ impl Engine {
             next_player_id: 0,
             players: HashMap::new(),
 
-            is_requesting_exit: false,
-            exit_error: None,
-            last_tick: Instant::now(),
+            exit_state: ExitState::Running,
         })
     }
     /// Will start the main game/editor. This should be called
@@ -135,7 +155,7 @@ impl Engine {
         if !match self.tick_inner() {
             Ok(exit) => exit,
             Err(err) => {
-                self.exit_error = Some(err.context("engine tick"));
+                self.exit_state = ExitState::Error(err.context("engine tick"));
                 false
             }
         } {
@@ -144,7 +164,7 @@ impl Engine {
         let ret = match self.render() {
             Ok(()) => true,
             Err(err) => {
-                self.exit_error = Some(err.context("rendering"));
+                self.exit_state = ExitState::Error(err.context("rendering"));
                 false
             }
         };
@@ -196,16 +216,18 @@ impl Engine {
     /// Returns if the engine is planning to exit. i.e., if the engine
     /// will shutdown at the next tick.
     pub fn is_requesting_exit(&self) -> bool {
-        self.is_requesting_exit || self.exit_error.is_some()
+        self.exit_state.exiting()
     }
     /// Specify `err` to exit with an error.
     pub fn exit(&mut self, err: Option<anyhow::Error>) {
-        self.is_requesting_exit = true;
-        self.exit_error = err;
+        self.exit_state = match err {
+            Some(err) => ExitState::Error(err),
+            None => ExitState::Requested,
+        };
     }
     /// Returns the exit error
-    pub fn get_exit_error(&self) -> &Option<anyhow::Error> {
-        &self.exit_error
+    pub fn exit_state(&self) -> &ExitState {
+        &self.exit_state
     }
     /// Returns the time in seconds since last tick. This consumes the delta time.
     fn capture_delta_time(&mut self) -> f64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn run() -> anyhow::Result<()> {
 
     let mut engine = dirkengine::engine::Engine::init().context("engine init")?;
     engine.start().context("start engine")?;
-    while engine.tick() {}
+    while matches!(engine.tick(), ExitState::Running) {}
 
     match engine.exit_state() {
         ExitState::Running => unreachable!("engine loop only stops once exit is requested"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn run() -> anyhow::Result<()> {
     while engine.tick() {}
 
     match engine.exit_state() {
-        ExitState::Running => panic!(""),
+        ExitState::Running => unreachable!("engine loop only stops once exit is requested"),
         ExitState::Requested => Ok(()),
         ExitState::Error(err) => {
             error!("{err:#}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 //! just engine init & tick looping
 
 use anyhow::Context;
+use dirkengine::engine::ExitState;
 use tracing::error;
 
 fn run() -> anyhow::Result<()> {
@@ -11,10 +12,14 @@ fn run() -> anyhow::Result<()> {
     engine.start().context("start engine")?;
     while engine.tick() {}
 
-    if let Some(err) = engine.get_exit_error() {
-        error!("{err:#}");
+    match engine.exit_state() {
+        ExitState::Running => panic!(""),
+        ExitState::Requested => Ok(()),
+        ExitState::Error(err) => {
+            error!("{err:#}");
+            Ok(())
+        }
     }
-    Ok(())
 }
 
 fn main() {


### PR DESCRIPTION
## Summary

Refactor engine exit handling to use an explicit `ExitState` instead of separate exit flags and error storage.

## Changes

- add `ExitState` with `Running`, `Requested`, and `Error(anyhow::Error)` variants
- make `Engine::tick` return the current `ExitState`
- consolidate exit tracking into a single `exit_state` field
- preserve the first engine error instead of replacing it with later exit requests
- stop ticking immediately once exit has already been requested
- update the main loop to run while the engine is `Running`
- replace the previous impossible exit path with `unreachable!` in `main`

## Why

This makes shutdown behavior explicit and easier to reason about:
- normal exit requests and error-driven exits now share one state model
- callers can inspect why the engine stopped without coordinating separate fields
- the engine no longer overwrites an existing error during shutdown