### PR TITLE
feat: multithreaded events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ version = "0.0.1"
 dependencies = [
  "dirk_proc",
  "parking_lot",
+ "tokio",
  "tracing",
 ]
 
@@ -1759,6 +1760,15 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ name = "dirk_events"
 version = "0.0.1"
 dependencies = [
  "dirk_proc",
+ "dirk_threads",
  "parking_lot",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirk_threads"
+version = "0.0.1"
+
+[[package]]
 name = "dirk_universe"
 version = "0.0.1"
 dependencies = [
@@ -542,6 +546,7 @@ dependencies = [
  "dirk_logging",
  "dirk_platform",
  "dirk_renderer",
+ "dirk_threads",
  "dirk_universe",
  "dirk_utils",
  "dirk_world",
@@ -994,6 +999,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1548,6 +1564,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1651,16 @@ checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1768,7 +1804,26 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1901,6 +1956,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ name = "dirk_threads"
 version = "0.0.1"
 dependencies = [
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,9 @@ dependencies = [
 [[package]]
 name = "dirk_threads"
 version = "0.0.1"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "dirk_universe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "anyhow",
  "dirk_build",
  "dirk_events",
+ "dirk_threads",
  "gltf",
  "parking_lot",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tracing-log.workspace = true
 glam.workspace = true
 
 dirk_logging.workspace = true
+dirk_threads.workspace = true
 dirk_utils.workspace = true
 dirk_events.workspace = true
 dirk_platform.workspace = true
@@ -83,6 +84,7 @@ cargo_metadata = "0.23"
 
 # Engine modules
 dirk_build    = { version = "0.0.1", path = "crates/dirk_build" }
+dirk_threads  = { version = "0.0.1", path = "crates/dirk_threads" }
 dirk_utils    = { version = "0.0.1", path = "crates/dirk_utils" }
 dirk_logging  = { version = "0.0.1", path = "crates/dirk_logging" }
 dirk_events   = { version = "0.0.1", path = "crates/dirk_events" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ shaderc = "0.10"
 gpu-allocator = { version = "0.28", default-features = false, features = ["std", "vulkan"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = "1"
+tokio = { version = "1", features = ["sync"] }
 
 # Macro dependencies
 syn = { version = "2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ shaderc = "0.10"
 gpu-allocator = { version = "0.28", default-features = false, features = ["std", "vulkan"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["full"] }
 
 # Macro dependencies
 syn = { version = "2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ shaderc = "0.10"
 gpu-allocator = { version = "0.28", default-features = false, features = ["std", "vulkan"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = "1"
 
 # Macro dependencies
 syn = { version = "2", features = ["full"] }

--- a/crates/dirk_assets/Cargo.toml
+++ b/crates/dirk_assets/Cargo.toml
@@ -28,3 +28,4 @@ dirk_build.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+dirk_threads.workspace = true

--- a/crates/dirk_assets/README.md
+++ b/crates/dirk_assets/README.md
@@ -33,10 +33,12 @@ asset type has its own optional config object (currently only `"model"`).
 ```rust
 use dirk_assets::{AssetRegistry, AssetHandle, AssetType, AssetLoaded, AssetUnloaded, Model};
 use dirk_events::EventManager;
+use dirk_threads::WorkerPool;
 
 # fn test() -> anyhow::Result<()> {
 // 1. Initialise — scans ASSETS_PATH and validates all .dirkasset files.
-let events = EventManager::new();
+let workers = WorkerPool::new("test");
+let events = EventManager::new(workers);
 let mut registry = AssetRegistry::init(&events)?;
 
 // 2. Load an asset by its handle string (path relative to ASSETS_PATH).
@@ -49,7 +51,6 @@ let mut unloaded_consumer = events.subscribe::<AssetUnloaded>();
 
 // 4. Game loop — call once per frame.
 loop {
-    events.dispatch_all();
     registry.tick();
 
     for event in loaded_consumer.consume_all() {

--- a/crates/dirk_assets/README.md
+++ b/crates/dirk_assets/README.md
@@ -44,8 +44,8 @@ let handle = registry.load_asset::<Model>(
     &AssetHandle::from_raw("models/hero.dirkasset", AssetType::Model))?;
 
 // 3. Subscribe to receive load events for future loads.
-let loaded_consumer = events.subscribe::<AssetLoaded<Model>>();
-let unloaded_consumer = events.subscribe::<AssetUnloaded>();
+let mut loaded_consumer = events.subscribe::<AssetLoaded<Model>>();
+let mut unloaded_consumer = events.subscribe::<AssetUnloaded>();
 
 // 4. Game loop — call once per frame.
 loop {

--- a/crates/dirk_assets/src/errors.rs
+++ b/crates/dirk_assets/src/errors.rs
@@ -43,7 +43,8 @@ pub enum Error {
     /// ```rust
     /// # use dirk_assets::{Model, AssetType, AssetHandle};
     /// # fn test() -> anyhow::Result<()> {
-    /// # let events = dirk_events::EventManager::new();
+    /// # let workers = dirk_threads::WorkerPool::new("test");
+    /// # let events = dirk_events::EventManager::new(workers);
     /// # let mut registry = dirk_assets::AssetRegistry::init(&events)?;
     /// # let asset_handle = AssetHandle::from_raw("", AssetType::Model);
     /// // release build only

--- a/crates/dirk_assets/src/events.rs
+++ b/crates/dirk_assets/src/events.rs
@@ -38,7 +38,7 @@ pub(crate) struct InternalAssetUnloaded(pub AssetHandle);
 /// use dirk_events::{Consumer, EventManager};
 ///
 /// # let events = EventManager::new();
-/// let consumer: Consumer<AssetLoaded<Model>> = events.subscribe();
+/// let mut consumer: Consumer<AssetLoaded<Model>> = events.subscribe();
 ///
 /// // Once per frame:
 /// for event in consumer.consume_all() {
@@ -88,7 +88,7 @@ pub struct AssetLoaded<T: Asset> {
 /// use dirk_events::Consumer;
 ///
 /// # let events = dirk_events::EventManager::new();
-/// let consumer: Consumer<AssetUnloaded> = events.subscribe();
+/// let mut consumer: Consumer<AssetUnloaded> = events.subscribe();
 ///
 /// // Once per frame:
 /// for AssetUnloaded { handle } in consumer.consume_all() {

--- a/crates/dirk_assets/src/events.rs
+++ b/crates/dirk_assets/src/events.rs
@@ -35,9 +35,10 @@ pub(crate) struct InternalAssetUnloaded(pub AssetHandle);
 ///
 /// ```rust
 /// use dirk_assets::{AssetLoaded, Handle, Model};
-/// use dirk_events::{Consumer, EventManager};
+/// use dirk_events::Consumer;
 ///
-/// # let events = EventManager::new();
+/// # let workers = dirk_threads::WorkerPool::new("test");
+/// # let events = dirk_events::EventManager::new(workers);
 /// let mut consumer: Consumer<AssetLoaded<Model>> = events.subscribe();
 ///
 /// // Once per frame:
@@ -87,7 +88,8 @@ pub struct AssetLoaded<T: Asset> {
 /// use dirk_assets::AssetUnloaded;
 /// use dirk_events::Consumer;
 ///
-/// # let events = dirk_events::EventManager::new();
+/// # let workers = dirk_threads::WorkerPool::new("test");
+/// # let events = dirk_events::EventManager::new(workers);
 /// let mut consumer: Consumer<AssetUnloaded> = events.subscribe();
 ///
 /// // Once per frame:

--- a/crates/dirk_assets/src/lib.rs
+++ b/crates/dirk_assets/src/lib.rs
@@ -256,10 +256,10 @@ impl DirkAsset {
 ///
 /// ```rust
 /// use dirk_assets::AssetRegistry;
-/// use dirk_events::EventManager;
 ///
 /// # fn test() -> anyhow::Result<()> {
-/// let events = EventManager::new();
+/// # let workers = dirk_threads::WorkerPool::new("test");
+/// # let events = dirk_events::EventManager::new(workers);
 /// let mut registry = AssetRegistry::init(&events)?;
 /// # Ok(()) }
 /// ```
@@ -268,7 +268,8 @@ impl DirkAsset {
 ///
 /// ```rust
 /// # fn test() -> anyhow::Result<()> {
-/// # let events = dirk_events::EventManager::new();
+/// # let workers = dirk_threads::WorkerPool::new("test");
+/// # let events = dirk_events::EventManager::new(workers);
 /// # let mut registry = dirk_assets::AssetRegistry::init(&events).unwrap();
 /// // Must be called once per frame, *after* EventManager::dispatch_all.
 /// registry.tick();
@@ -478,7 +479,8 @@ impl AssetRegistry {
     ///
     /// ```rust
     /// # fn test() -> anyhow::Result<()> {
-    /// # let events = dirk_events::EventManager::new();
+    /// # let workers = dirk_threads::WorkerPool::new("test");
+    /// # let events = dirk_events::EventManager::new(workers);
     /// # let mut registry = dirk_assets::AssetRegistry::init(&events).unwrap();
     /// use dirk_assets::{AssetHandle, AssetRegistry, AssetType};
     /// use dirk_assets::Model;

--- a/crates/dirk_assets/src/tests.rs
+++ b/crates/dirk_assets/src/tests.rs
@@ -605,7 +605,7 @@ mod handle {
     #[test]
     fn drop_of_sole_handle_fires_internal_unloaded_event() {
         let events = EventManager::new();
-        let consumer = events.subscribe::<InternalAssetUnloaded>();
+        let mut consumer = events.subscribe::<InternalAssetUnloaded>();
         let dispatcher = events.register::<InternalAssetUnloaded>();
 
         let asset_handle = AssetHandle::from_raw("sole.dirkasset", AssetType::Unknown);
@@ -626,7 +626,7 @@ mod handle {
     #[test]
     fn drop_does_not_fire_while_clones_still_live() {
         let events = EventManager::new();
-        let consumer = events.subscribe::<InternalAssetUnloaded>();
+        let mut consumer = events.subscribe::<InternalAssetUnloaded>();
         let dispatcher = events.register::<InternalAssetUnloaded>();
 
         let asset_ref = AssetRef::new(
@@ -654,7 +654,7 @@ mod handle {
     #[test]
     fn drop_event_carries_correct_asset_handle() {
         let events = EventManager::new();
-        let consumer = events.subscribe::<InternalAssetUnloaded>();
+        let mut consumer = events.subscribe::<InternalAssetUnloaded>();
         let dispatcher = events.register::<InternalAssetUnloaded>();
 
         let expected = AssetHandle::from_raw("foo/bar.dirkasset", AssetType::Unknown);
@@ -942,7 +942,7 @@ mod registry {
             write_model_fixture(&dir, "ship");
 
             let events2 = EventManager::new();
-            let loaded_consumer = events2.subscribe::<AssetLoaded<Model>>();
+            let mut loaded_consumer = events2.subscribe::<AssetLoaded<Model>>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
             let raw = format!("{sub}/ship.dirkasset");
@@ -962,7 +962,7 @@ mod registry {
             write_model_fixture(&dir, "tank");
 
             let events2 = EventManager::new();
-            let loaded_consumer = events2.subscribe::<AssetLoaded<Model>>();
+            let mut loaded_consumer = events2.subscribe::<AssetLoaded<Model>>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
             let raw = format!("{sub}/tank.dirkasset");
@@ -985,7 +985,7 @@ mod registry {
             write_model_fixture(&dir, "barrel");
 
             let events2 = EventManager::new();
-            let unloaded_consumer = events2.subscribe::<AssetUnloaded>();
+            let mut unloaded_consumer = events2.subscribe::<AssetUnloaded>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
             let raw = format!("{sub}/barrel.dirkasset");
@@ -1015,7 +1015,7 @@ mod registry {
             write_model_fixture(&dir, "plane");
 
             let events2 = EventManager::new();
-            let unloaded_consumer = events2.subscribe::<AssetUnloaded>();
+            let mut unloaded_consumer = events2.subscribe::<AssetUnloaded>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
             let raw = format!("{sub}/plane.dirkasset");
@@ -1044,7 +1044,7 @@ mod registry {
             write_model_fixture(&dir, "crate_mesh");
 
             let events2 = EventManager::new();
-            let unloaded_consumer = events2.subscribe::<AssetUnloaded>();
+            let mut unloaded_consumer = events2.subscribe::<AssetUnloaded>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
             let raw = format!("{sub}/crate_mesh.dirkasset");

--- a/crates/dirk_assets/src/tests.rs
+++ b/crates/dirk_assets/src/tests.rs
@@ -68,6 +68,7 @@ use super::{
 };
 
 use dirk_events::EventManager;
+use dirk_threads::WorkerPool;
 use serde_json;
 use std::{
     fs,
@@ -136,7 +137,8 @@ impl Asset for FakeAsset {
 
 /// Builds a `Handle<FakeAsset>` containing `value`, bypassing the registry.
 fn fake_handle(value: u32, raw_path: &str) -> Handle<FakeAsset> {
-    let events = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let events = EventManager::new(workers);
     let dispatcher = events.register::<InternalAssetUnloaded>();
     let asset_ref = AssetRef::new(
         AssetHandle::from_raw(raw_path, AssetType::Unknown),
@@ -604,7 +606,8 @@ mod handle {
 
     #[test]
     fn drop_of_sole_handle_fires_internal_unloaded_event() {
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         let mut consumer = events.subscribe::<InternalAssetUnloaded>();
         let dispatcher = events.register::<InternalAssetUnloaded>();
 
@@ -612,11 +615,13 @@ mod handle {
         let asset_ref = AssetRef::new(asset_handle.clone(), FakeAsset { value: 0 }, dispatcher);
         let handle = Handle::new(asset_ref);
 
-        events.dispatch_all();
+        // wait for the event to be dispatched
+        std::thread::sleep(std::time::Duration::from_millis(5));
         assert_eq!(consumer.consume_all().count(), 0, "no event yet");
 
         drop(handle);
-        events.dispatch_all();
+        // wait for the event to be dispatched
+        std::thread::sleep(std::time::Duration::from_millis(5));
 
         let fired: Vec<_> = consumer.consume_all().collect();
         assert_eq!(fired.len(), 1, "exactly one InternalAssetUnloaded event");
@@ -625,7 +630,8 @@ mod handle {
 
     #[test]
     fn drop_does_not_fire_while_clones_still_live() {
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         let mut consumer = events.subscribe::<InternalAssetUnloaded>();
         let dispatcher = events.register::<InternalAssetUnloaded>();
 
@@ -639,21 +645,25 @@ mod handle {
         let h3 = h1.clone();
 
         drop(h1);
-        events.dispatch_all();
+        // wait for the event to be dispatched
+        std::thread::sleep(std::time::Duration::from_millis(5));
         assert_eq!(consumer.consume_all().count(), 0, "clones still alive");
 
         drop(h2);
-        events.dispatch_all();
+        // wait for the event to be dispatched
+        std::thread::sleep(std::time::Duration::from_millis(5));
         assert_eq!(consumer.consume_all().count(), 0, "one clone still alive");
 
         drop(h3); // last reference
-        events.dispatch_all();
+        // wait for the event to be dispatched
+        std::thread::sleep(std::time::Duration::from_millis(5));
         assert_eq!(consumer.consume_all().count(), 1, "last clone dropped");
     }
 
     #[test]
     fn drop_event_carries_correct_asset_handle() {
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         let mut consumer = events.subscribe::<InternalAssetUnloaded>();
         let dispatcher = events.register::<InternalAssetUnloaded>();
 
@@ -661,9 +671,8 @@ mod handle {
         let asset_ref = AssetRef::new(expected.clone(), FakeAsset { value: 0 }, dispatcher);
         let handle = Handle::new(asset_ref);
         drop(handle);
-        events.dispatch_all();
 
-        let ev = consumer.consume_all().next().unwrap();
+        let ev = consumer.consume_blocking().unwrap();
         assert_eq!(ev.0, expected);
     }
 
@@ -799,7 +808,8 @@ mod registry {
         if assets_path_exists() {
             return; // skip — this machine has a real asset tree
         }
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         assert!(
             matches!(AssetRegistry::init(&events), Err(Error::IoError(_))),
             "Missing ASSETS_PATH should produce IoError"
@@ -811,7 +821,8 @@ mod registry {
         if !assets_path_exists() {
             return;
         }
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         assert!(
             AssetRegistry::init(&events).is_ok(),
             "init should succeed with a valid ASSETS_PATH"
@@ -825,7 +836,8 @@ mod registry {
         if !assets_path_exists() {
             return;
         }
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         let mut registry = AssetRegistry::init(&events).unwrap();
 
         // Pass a handle whose AssetType is Unknown but request Model — must be TypeMismatch.
@@ -842,7 +854,8 @@ mod registry {
         if !assets_path_exists() {
             return;
         }
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         let mut registry = AssetRegistry::init(&events).unwrap();
 
         let ghost = AssetHandle::from_raw(
@@ -863,7 +876,8 @@ mod registry {
         if !assets_path_exists() {
             return;
         }
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         let mut registry = AssetRegistry::init(&events).unwrap();
 
         let path = "specific/path.dirkasset";
@@ -879,7 +893,8 @@ mod registry {
         if !assets_path_exists() {
             return;
         }
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         let mut registry = AssetRegistry::init(&events).unwrap();
 
         let path = "no/such/asset.dirkasset";
@@ -907,7 +922,8 @@ mod registry {
         let dir = PathBuf::from(ASSETS_PATH).join(&sub);
         fs::create_dir_all(&dir).expect("failed to create test fixture dir");
 
-        let events = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let events = EventManager::new(workers);
         let mut registry = AssetRegistry::init(&events).expect("init failed");
 
         f(&mut registry, &events, &sub);
@@ -923,7 +939,8 @@ mod registry {
             write_model_fixture(&dir, "hero");
 
             // Re-init so the registry picks up the freshly written fixture.
-            let events2 = EventManager::new();
+            let workers = WorkerPool::new("test");
+            let events2 = EventManager::new(workers);
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
             let raw = format!("{sub}/hero.dirkasset");
@@ -941,7 +958,8 @@ mod registry {
             let dir = PathBuf::from(ASSETS_PATH).join(sub);
             write_model_fixture(&dir, "ship");
 
-            let events2 = EventManager::new();
+            let workers = WorkerPool::new("test");
+            let events2 = EventManager::new(workers);
             let mut loaded_consumer = events2.subscribe::<AssetLoaded<Model>>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
@@ -949,7 +967,8 @@ mod registry {
             let handle_id = AssetHandle::from_raw(raw, AssetType::Model);
             let _handle = r2.load_asset::<Model>(&handle_id).unwrap();
 
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             let events_fired: Vec<_> = loaded_consumer.consume_all().collect();
             assert_eq!(events_fired.len(), 1, "Exactly one AssetLoaded event");
         });
@@ -961,7 +980,8 @@ mod registry {
             let dir = PathBuf::from(ASSETS_PATH).join(sub);
             write_model_fixture(&dir, "tank");
 
-            let events2 = EventManager::new();
+            let workers = WorkerPool::new("test");
+            let events2 = EventManager::new(workers);
             let mut loaded_consumer = events2.subscribe::<AssetLoaded<Model>>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
@@ -970,7 +990,8 @@ mod registry {
                 .load_asset::<Model>(&AssetHandle::from_raw(raw, AssetType::Model))
                 .unwrap();
 
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             let ev = loaded_consumer.consume_all().next().unwrap();
             let model = ev.handle.get().expect("handle.get() must succeed");
             // A minimal glTF has exactly one scene.
@@ -984,7 +1005,8 @@ mod registry {
             let dir = PathBuf::from(ASSETS_PATH).join(sub);
             write_model_fixture(&dir, "barrel");
 
-            let events2 = EventManager::new();
+            let workers = WorkerPool::new("test");
+            let events2 = EventManager::new(workers);
             let mut unloaded_consumer = events2.subscribe::<AssetUnloaded>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
@@ -995,9 +1017,11 @@ mod registry {
 
             // Drop all references → InternalAssetUnloaded is queued.
             drop(handle);
-            events2.dispatch_all(); // forward InternalAssetUnloaded to registry
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             r2.tick(); // registry converts it to AssetUnloaded
-            events2.dispatch_all(); // forward AssetUnloaded to consumers
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
 
             let fired: Vec<_> = unloaded_consumer.consume_all().collect();
             assert_eq!(fired.len(), 1, "Exactly one AssetUnloaded event after drop");
@@ -1014,7 +1038,8 @@ mod registry {
             let dir = PathBuf::from(ASSETS_PATH).join(sub);
             write_model_fixture(&dir, "plane");
 
-            let events2 = EventManager::new();
+            let workers = WorkerPool::new("test");
+            let events2 = EventManager::new(workers);
             let mut unloaded_consumer = events2.subscribe::<AssetUnloaded>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
@@ -1023,9 +1048,11 @@ mod registry {
                 .load_asset::<Model>(&AssetHandle::from_raw(raw, AssetType::Model))
                 .unwrap();
 
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             r2.tick();
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
 
             assert_eq!(
                 unloaded_consumer.consume_all().count(),
@@ -1043,7 +1070,8 @@ mod registry {
             let dir = PathBuf::from(ASSETS_PATH).join(sub);
             write_model_fixture(&dir, "crate_mesh");
 
-            let events2 = EventManager::new();
+            let workers = WorkerPool::new("test");
+            let events2 = EventManager::new(workers);
             let mut unloaded_consumer = events2.subscribe::<AssetUnloaded>();
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
@@ -1055,21 +1083,27 @@ mod registry {
             let h3 = h1.clone();
 
             drop(h1);
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             r2.tick();
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             assert_eq!(unloaded_consumer.consume_all().count(), 0);
 
             drop(h2);
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             r2.tick();
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             assert_eq!(unloaded_consumer.consume_all().count(), 0);
 
             drop(h3); // last clone
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             r2.tick();
-            events2.dispatch_all();
+            // wait for the event to be dispatched
+            std::thread::sleep(std::time::Duration::from_millis(5));
             assert_eq!(
                 unloaded_consumer.consume_all().count(),
                 1,
@@ -1084,7 +1118,8 @@ mod registry {
             let dir = PathBuf::from(ASSETS_PATH).join(sub);
             write_model_fixture(&dir, "sphere");
 
-            let events2 = EventManager::new();
+            let workers = WorkerPool::new("test");
+            let events2 = EventManager::new(workers);
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
             let raw = format!("{sub}/sphere.dirkasset");
@@ -1109,7 +1144,8 @@ mod registry {
             let dir = PathBuf::from(ASSETS_PATH).join(sub);
             write_model_fixture(&dir, "rock");
 
-            let events2 = EventManager::new();
+            let workers = WorkerPool::new("test");
+            let events2 = EventManager::new(workers);
             let mut r2 = AssetRegistry::init(&events2).unwrap();
 
             let raw = format!("{sub}/rock.dirkasset");

--- a/crates/dirk_events/Cargo.toml
+++ b/crates/dirk_events/Cargo.toml
@@ -16,6 +16,7 @@ parking_lot.workspace = true
 tracing.workspace = true
 
 dirk_proc.workspace = true
+dirk_threads.workspace = true
 
 tokio.workspace = true
 

--- a/crates/dirk_events/Cargo.toml
+++ b/crates/dirk_events/Cargo.toml
@@ -13,10 +13,11 @@ documentation.workspace = true
 
 [dependencies]
 parking_lot.workspace = true
+tracing.workspace = true
 
 dirk_proc.workspace = true
 
-tracing.workspace = true
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/dirk_events/README.md
+++ b/crates/dirk_events/README.md
@@ -215,5 +215,6 @@ thread::spawn(move || {
     dispatcher.dispatch(WorkDone(2));
 }).join().unwrap();
 
+# std::thread::sleep(std::time::Duration::from_millis(10));
 assert_eq!(consumer.consume_all().count(), 2);
 ```

--- a/crates/dirk_events/README.md
+++ b/crates/dirk_events/README.md
@@ -10,7 +10,7 @@ use inside a game-engine loop.
 | **Event** | any `T: [events::Event]` | A value that travels through the bus |
 | **Dispatcher** | [`Dispatcher<T>`] | Queues events for immediate background routing |
 | **Consumer** | [`Consumer<T>`] | Reads events that have already been routed |
-| **Event Manager** | [`EventManager`] | Wires everything together; [`dispatch_all`] waits for all pending to be distributed |
+| **Event Manager** | [`EventManager`] | Wires everything together |
 
 ## Quick Start
 
@@ -23,7 +23,8 @@ use dirk_events::{Event, EventManager};
 struct PlayerScored { points: u32 }
 
 // 2. Create the shared manager.
-let mgr = EventManager::new();
+let workers = dirk_threads::WorkerPool::new("pool");
+let mgr = EventManager::new(workers);
 
 // 3. Obtain a dispatcher (producer side) and a consumer (subscriber side).
 let dispatcher = mgr.register::<PlayerScored>();
@@ -32,10 +33,7 @@ let mut consumer   = mgr.subscribe::<PlayerScored>();
 // 4. Queue an event from anywhere that holds the dispatcher.
 dispatcher.dispatch(PlayerScored { points: 42 });
 
-// 5. Optionally wait until everything dispatched so far has been routed.
-mgr.dispatch_all();
-
-// 6. Read events on the consumer side.
+// 5. Read events on the consumer side.
 for event in consumer.consume_all() {
     println!("score update: {}", event.debug()); // "player scored 42 points"
 }
@@ -58,8 +56,6 @@ for event in consumer.consume_all() {
 
 * **Immediate background routing** — events are forwarded as soon as a worker
   thread can route them; the game thread does not perform the fan-out work.
-* **`dispatch_all` is a barrier** — call it when you need to wait until every
-  event dispatched so far has reached its subscribers.
 * **Fan-out** — every active [`Consumer`] for a given type receives its own
   independent clone of each event.
 * **Type-isolated** — consumers only receive events of the exact type they
@@ -157,7 +153,8 @@ into as many systems as you like:
 ```rust
 use dirk_events::EventManager;
 
-let mgr = EventManager::new();
+let workers = dirk_threads::WorkerPool::new("pool");
+let mgr = EventManager::new(workers);
 
 let input_system_mgr  = mgr.clone();
 let render_system_mgr = mgr.clone();
@@ -168,7 +165,7 @@ let render_system_mgr = mgr.clone();
 ## Multiple Dispatchers for the Same Type
 
 Several systems can independently produce events of the same type. All of
-their events are delivered to all subscribers in the next `dispatch_all`.
+their events are delivered to all subscribers.
 
 ```rust
 use dirk_events::{EventManager, Event};
@@ -176,15 +173,16 @@ use dirk_events::{EventManager, Event};
 #[derive(Debug, Clone, Event)]
 struct DamageEvent(u32);
 
-let mgr = EventManager::new();
+let workers = dirk_threads::WorkerPool::new("pool");
+let mgr = EventManager::new(workers);
 let d1 = mgr.register::<DamageEvent>(); // melee system
 let d2 = mgr.register::<DamageEvent>(); // projectile system
 let mut consumer = mgr.subscribe::<DamageEvent>();
 
 d1.dispatch(DamageEvent(10));
 d2.dispatch(DamageEvent(25));
-mgr.dispatch_all();
 
+# std::thread::sleep(std::time::Duration::from_millis(10));
 let total: u32 = consumer.consume_all().map(|e| e.0).sum();
 assert_eq!(total, 35);
 ```
@@ -195,31 +193,10 @@ Cloning a [`Dispatcher`] registers a **new, independent producer** with the
 same manager. Cloning a [`Consumer`] creates a **fresh, independent
 subscription** — it does not share the receiver of the original.
 
-```rust
-use dirk_events::{EventManager, Event};
-
-#[derive(Debug, Clone, Event)]
-struct Ping;
-
-let mgr  = EventManager::new();
-let d1   = mgr.register::<Ping>();
-let d2   = d1.clone(); // independent dispatcher
-let mut c1   = mgr.subscribe::<Ping>();
-let mut c2   = c1.clone(); // independent consumer — its own subscription
-
-d1.dispatch(Ping);
-d2.dispatch(Ping);
-mgr.dispatch_all();
-
-assert_eq!(c1.consume_all().count(), 2); // receives from both dispatchers
-assert_eq!(c2.consume_all().count(), 2);
-```
-
 ## Thread Safety
 
 [`Dispatcher`] is [`Send`], so it can be moved into background threads to
-produce events off the main thread. [`EventManager::dispatch_all`] is
-typically called from the main game-loop thread.
+produce events off the main thread.
 
 ```rust
 use dirk_events::{EventManager, Event};
@@ -228,7 +205,8 @@ use std::thread;
 #[derive(Debug, Clone, Event)]
 struct WorkDone(u32);
 
-let mgr = EventManager::new();
+let workers = dirk_threads::WorkerPool::new("pool");
+let mgr = EventManager::new(workers);
 let dispatcher = mgr.register::<WorkDone>();
 let mut consumer   = mgr.subscribe::<WorkDone>();
 
@@ -237,8 +215,5 @@ thread::spawn(move || {
     dispatcher.dispatch(WorkDone(2));
 }).join().unwrap();
 
-mgr.dispatch_all();
 assert_eq!(consumer.consume_all().count(), 2);
 ```
-
-[`dispatch_all`]: EventManager::dispatch_all

--- a/crates/dirk_events/README.md
+++ b/crates/dirk_events/README.md
@@ -27,7 +27,7 @@ let mgr = EventManager::new();
 
 // 3. Obtain a dispatcher (producer side) and a consumer (subscriber side).
 let dispatcher = mgr.register::<PlayerScored>();
-let consumer   = mgr.subscribe::<PlayerScored>();
+let mut consumer   = mgr.subscribe::<PlayerScored>();
 
 // 4. Queue an event from anywhere that holds the dispatcher.
 dispatcher.dispatch(PlayerScored { points: 42 });
@@ -177,7 +177,7 @@ struct DamageEvent(u32);
 let mgr = EventManager::new();
 let d1 = mgr.register::<DamageEvent>(); // melee system
 let d2 = mgr.register::<DamageEvent>(); // projectile system
-let consumer = mgr.subscribe::<DamageEvent>();
+let mut consumer = mgr.subscribe::<DamageEvent>();
 
 d1.dispatch(DamageEvent(10));
 d2.dispatch(DamageEvent(25));
@@ -202,8 +202,8 @@ struct Ping;
 let mgr  = EventManager::new();
 let d1   = mgr.register::<Ping>();
 let d2   = d1.clone(); // independent dispatcher
-let c1   = mgr.subscribe::<Ping>();
-let c2   = c1.clone(); // independent consumer — its own subscription
+let mut c1   = mgr.subscribe::<Ping>();
+let mut c2   = c1.clone(); // independent consumer — its own subscription
 
 d1.dispatch(Ping);
 d2.dispatch(Ping);
@@ -228,7 +228,7 @@ struct WorkDone(u32);
 
 let mgr = EventManager::new();
 let dispatcher = mgr.register::<WorkDone>();
-let consumer   = mgr.subscribe::<WorkDone>();
+let mut consumer   = mgr.subscribe::<WorkDone>();
 
 thread::spawn(move || {
     dispatcher.dispatch(WorkDone(1));

--- a/crates/dirk_events/README.md
+++ b/crates/dirk_events/README.md
@@ -8,9 +8,9 @@ use inside a game-engine loop.
 | Term | Type | Role |
 |------|------|------|
 | **Event** | any `T: [events::Event]` | A value that travels through the bus |
-| **Dispatcher** | [`Dispatcher<T>`] | Queues events for the next tick |
-| **Consumer** | [`Consumer<T>`] | Reads events that were forwarded this tick |
-| **Event Manager** | [`EventManager`] | Wires everything together; call [`dispatch_all`] once per frame |
+| **Dispatcher** | [`Dispatcher<T>`] | Queues events for immediate background routing |
+| **Consumer** | [`Consumer<T>`] | Reads events that have already been routed |
+| **Event Manager** | [`EventManager`] | Wires everything together; [`dispatch_all`] waits for all pending to be distributed |
 
 ## Quick Start
 
@@ -32,7 +32,7 @@ let mut consumer   = mgr.subscribe::<PlayerScored>();
 // 4. Queue an event from anywhere that holds the dispatcher.
 dispatcher.dispatch(PlayerScored { points: 42 });
 
-// 5. Once per frame / tick: forward queued events to all subscribers.
+// 5. Optionally wait until everything dispatched so far has been routed.
 mgr.dispatch_all();
 
 // 6. Read events on the consumer side.
@@ -47,23 +47,25 @@ for event in consumer.consume_all() {
  dispatcher.dispatch(e)
        │
        ▼
- [internal channel buffer]   ← events accumulate here between ticks
+ [background worker queue]
        │
- mgr.dispatch_all()          ← call exactly once per frame
+ [worker thread routes event]
        │
        ├──▶ consumer A
        ├──▶ consumer B
        └──▶ consumer C       ← every live consumer receives a clone
 ```
 
-* **Buffered until `dispatch_all`** — events queued before `dispatch_all`
-  are invisible to consumers. Call `dispatch_all` once per frame.
+* **Immediate background routing** — events are forwarded as soon as a worker
+  thread can route them; the game thread does not perform the fan-out work.
+* **`dispatch_all` is a barrier** — call it when you need to wait until every
+  event dispatched so far has reached its subscribers.
 * **Fan-out** — every active [`Consumer`] for a given type receives its own
   independent clone of each event.
 * **Type-isolated** — consumers only receive events of the exact type they
   subscribed to; other event types are never delivered to them.
 * **Dropped-consumer pruning** — if a [`Consumer`] is dropped, its entry is
-  silently removed on the next `dispatch_all`; no panic, no leak.
+  silently removed on the next routing attempt; no panic, no leak.
 
 ## Using the `#[derive(Event)]` Macro
 

--- a/crates/dirk_events/src/common.rs
+++ b/crates/dirk_events/src/common.rs
@@ -1,0 +1,20 @@
+//! This module contains common event types used throughout the engine.
+
+use crate::Event;
+
+/// An event to request to the engine to exit.
+///
+/// This event is used by various engine systems.
+/// It can be used by the platform to signal to the engine that the windows
+/// have all been closed. It is also used when users manually exit the engine.
+#[derive(Debug, Clone, Event)]
+#[event("App exit requested: {0}")]
+pub struct AppExit(pub String);
+
+/// An event run at the beginning of every tick.
+///
+/// This event contains the frame number.
+/// Used for thread synchronization.
+#[derive(Debug, Clone, Event)]
+#[event("Begin frame number {0}")]
+pub struct BeginFrame(pub u64);

--- a/crates/dirk_events/src/common.rs
+++ b/crates/dirk_events/src/common.rs
@@ -8,6 +8,17 @@ use crate::Event;
 /// It can be used by the platform to signal to the engine that the windows
 /// have all been closed. It is also used when users manually exit the engine.
 #[derive(Debug, Clone, Event)]
+#[event("Exiting")]
+pub struct Exiting;
+
+/// An event to request to the engine to exit.
+///
+/// This event is used by various engine systems.
+/// It can be used by the platform to signal to the engine that the windows
+/// have all been closed. It is also used when users manually exit the engine.
+///
+/// TODO: pass an engine handle around & allow calling engine exit
+#[derive(Debug, Clone, Event)]
 #[event("App exit requested: {0}")]
 pub struct AppExit(pub String);
 

--- a/crates/dirk_events/src/lib.rs
+++ b/crates/dirk_events/src/lib.rs
@@ -11,6 +11,9 @@ use tracing::trace;
 
 use dirk_threads::WorkerPool;
 
+mod common;
+pub use common::*;
+
 mod tests;
 
 /// The marker trait that every event type must implement.
@@ -561,20 +564,3 @@ impl<T: Event> std::fmt::Debug for Consumer<T> {
         f.debug_struct("Consumer").finish_non_exhaustive()
     }
 }
-
-/// An event to request to the engine to exit.
-///
-/// This event is used by various engine systems.
-/// It can be used by the platform to signal to the engine that the windows
-/// have all been closed. It is also used when users manually exit the engine.
-#[derive(Debug, Clone, Event)]
-#[event("App exit requested: {0}")]
-pub struct AppExit(pub String);
-
-/// An event run at the beginning of every tick.
-///
-/// This event contains the frame number.
-/// Used for thread synchronization.
-#[derive(Debug, Clone, Event)]
-#[event("Begin frame number {0}")]
-pub struct BeginFrame(pub u64);

--- a/crates/dirk_events/src/lib.rs
+++ b/crates/dirk_events/src/lib.rs
@@ -71,29 +71,10 @@ pub use dirk_proc::Event;
 /// ```rust
 /// use dirk_events::EventManager;
 ///
-/// let mgr_a = EventManager::new();
+/// let workers = dirk_threads::WorkerPool::new("pool");
+/// let mgr_a = EventManager::new(workers);
 /// let mgr_b = mgr_a.clone(); // same bus, different handle
 /// ```
-///
-/// # Frame Loop Integration
-///
-/// ```rust
-/// use dirk_events::EventManager;
-///
-/// let mgr = EventManager::new();
-///
-/// loop {
-///     // … collect input, run systems …
-///
-///     // Wait for events dispatched so far to finish routing.
-///     mgr.dispatch_all();
-///
-///     // … render …
-///     # break; // stop the doc-test loop
-/// }
-/// ```
-///
-/// [`dispatch_all`]: EventManager::dispatch_all
 #[derive(Clone)]
 pub struct EventManager {
     subscribers: Arc<RwLock<HashMap<TypeId, Vec<Subscriber>>>>, // TODO: see about better HashMap where we can lock just the value instead of entire thing
@@ -101,15 +82,7 @@ pub struct EventManager {
 }
 
 impl EventManager {
-    /// Creates a new, empty event manager.
-    ///
-    /// Equivalent to [`EventManager::default`].
-    ///
-    /// ```rust
-    /// use dirk_events::EventManager;
-    ///
-    /// let mgr = EventManager::new();
-    /// ```
+    /// Creates a new, empty event manager with a [`WorkerPool`].
     #[must_use]
     pub fn new(workers: WorkerPool) -> Self {
         Self {
@@ -123,26 +96,6 @@ impl EventManager {
     /// Every call to `register` creates an **independent** producer channel and
     /// a matching background routing task. Multiple dispatchers for the same
     /// event type are fully supported.
-    ///
-    /// # Type Inference
-    ///
-    /// The event type can be inferred from context or specified with the
-    /// turbofish syntax:
-    ///
-    /// ```rust
-    /// use dirk_events::{EventManager, Dispatcher, Event};
-    ///
-    /// #[derive(Debug, Clone, Event)]
-    /// struct MyEvent;
-    ///
-    /// let mgr = EventManager::new();
-    ///
-    /// // Turbofish syntax:
-    /// let d1 = mgr.register::<MyEvent>();
-    ///
-    /// // Type annotation on the binding:
-    /// let d2: Dispatcher<MyEvent> = mgr.register();
-    /// ```
     ///
     /// [`dispatch_all`]: EventManager::dispatch_all
     #[must_use]
@@ -163,22 +116,6 @@ impl EventManager {
     ///
     /// A consumer can be created before or after a dispatcher is registered for
     /// the same type.
-    ///
-    /// # Type Inference
-    ///
-    /// ```rust
-    /// use dirk_events::{EventManager, Consumer, Event};
-    ///
-    /// #[derive(Debug, Clone, Event)]
-    /// struct MyEvent;
-    ///
-    /// let mgr = EventManager::new();
-    ///
-    /// // Turbofish syntax:
-    /// let c1 = mgr.subscribe::<MyEvent>();
-    ///
-    /// // Type annotation on the binding:
-    /// let c2: Consumer<MyEvent> = mgr.subscribe();
     /// ```
     #[must_use]
     pub fn subscribe<T: Event>(&self) -> Consumer<T> {
@@ -236,25 +173,6 @@ struct Subscriber {
 /// same [`EventManager`]. This means the clone and the original each have their
 /// own internal routing channel, but both sets of events are delivered to all
 /// subscribers.
-///
-/// ```rust
-/// use dirk_events::{EventManager, Event};
-///
-/// #[derive(Debug, Clone, Event)]
-/// struct Hit(u32);
-///
-/// let mgr = EventManager::new();
-/// let d1  = mgr.register::<Hit>();
-/// let d2  = d1.clone(); // independent producer
-/// let mut c   = mgr.subscribe::<Hit>();
-///
-/// d1.dispatch(Hit(1));
-/// d2.dispatch(Hit(2));
-/// mgr.dispatch_all();
-///
-/// let hits: Vec<u32> = c.consume_all().map(|h| h.0).collect();
-/// assert_eq!(hits.len(), 2);
-/// ```
 pub struct Dispatcher<T: Event> {
     sender: UnboundedSender<T>,
     manager: EventManager,
@@ -266,25 +184,6 @@ impl<T: Event> Dispatcher<T> {
     ///
     /// This method is non-blocking and returns immediately. The event is not
     /// routed on the caller thread.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use dirk_events::{EventManager, Event};
-    ///
-    /// #[derive(Debug, Clone, Event)]
-    /// #[event("enemy spawned at ({x}, {y})")]
-    /// struct EnemySpawned { x: f32, y: f32 }
-    ///
-    /// let mgr = EventManager::new();
-    /// let dispatcher = mgr.register::<EnemySpawned>();
-    /// let mut consumer   = mgr.subscribe::<EnemySpawned>();
-    ///
-    /// // Routed asynchronously.
-    /// dispatcher.dispatch(EnemySpawned { x: 10.0, y: 20.0 });
-    /// mgr.dispatch_all();
-    /// assert!(consumer.try_consume().is_some());
-    /// ```
     pub fn dispatch(&self, event: T) {
         trace!("dispatching event {}", event.debug());
         let _ = self.sender.send(event);
@@ -317,24 +216,6 @@ impl<T: Event> std::fmt::Debug for Dispatcher<T> {
 /// *after* it was created; it does **not** inherit any events already queued
 /// in the original.
 ///
-/// ```rust
-/// use dirk_events::{EventManager, Event};
-///
-/// #[derive(Debug, Clone, Event)]
-/// struct Signal;
-///
-/// let mgr = EventManager::new();
-/// let d   = mgr.register::<Signal>();
-/// let mut c1  = mgr.subscribe::<Signal>();
-/// let mut c2  = c1.clone(); // fresh, independent subscription
-///
-/// d.dispatch(Signal);
-/// mgr.dispatch_all();
-///
-/// assert_eq!(c1.consume_all().count(), 1);
-/// assert_eq!(c2.consume_all().count(), 1); // independent — also gets the event
-/// ```
-///
 /// # Dropping
 ///
 /// When a `Consumer` is dropped its subscription is automatically removed the
@@ -351,27 +232,6 @@ impl<T: Event> Consumer<T> {
     ///
     /// This is non-blocking. Use [`consume_all`] if you want to drain every
     /// event that arrived so far.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use dirk_events::{EventManager, Event};
-    ///
-    /// #[derive(Debug, Clone, Event)]
-    /// struct Counter(u32);
-    ///
-    /// let mgr = EventManager::new();
-    /// let d   = mgr.register::<Counter>();
-    /// let mut c   = mgr.subscribe::<Counter>();
-    ///
-    /// d.dispatch(Counter(1));
-    /// d.dispatch(Counter(2));
-    /// mgr.dispatch_all();
-    ///
-    /// assert_eq!(c.try_consume().unwrap().0, 1);
-    /// assert_eq!(c.try_consume().unwrap().0, 2);
-    /// assert!(c.try_consume().is_none()); // queue is now empty
-    /// ```
     ///
     /// [`consume_all`]: Consumer::consume_all
     pub fn try_consume(&mut self) -> Option<T> {
@@ -406,49 +266,6 @@ impl<T: Event> Consumer<T> {
     ///
     /// The iterator calls [`try_consume`] repeatedly and stops as soon as the
     /// queue is empty. Collect it into a `Vec` or drive it with a `for` loop.
-    ///
-    /// # Example — Collect into a Vec
-    ///
-    /// ```rust
-    /// use dirk_events::{EventManager, Event};
-    ///
-    /// #[derive(Debug, Clone, Event)]
-    /// struct Score(u32);
-    ///
-    /// let mgr = EventManager::new();
-    /// let d   = mgr.register::<Score>();
-    /// let mut c   = mgr.subscribe::<Score>();
-    ///
-    /// for i in 0..5 { d.dispatch(Score(i)); }
-    /// mgr.dispatch_all();
-    ///
-    /// let scores: Vec<u32> = c.consume_all().map(|s| s.0).collect();
-    /// assert_eq!(scores, vec![0, 1, 2, 3, 4]);
-    /// ```
-    ///
-    /// # Example — `for` Loop
-    ///
-    /// ```rust
-    /// use dirk_events::{EventManager, Event};
-    ///
-    /// #[derive(Debug, Clone, Event)]
-    /// #[event("damage={0}")]
-    /// struct DamageEvent(u32);
-    ///
-    /// let mgr = EventManager::new();
-    /// let d   = mgr.register::<DamageEvent>();
-    /// let mut c   = mgr.subscribe::<DamageEvent>();
-    ///
-    /// d.dispatch(DamageEvent(10));
-    /// d.dispatch(DamageEvent(5));
-    /// mgr.dispatch_all();
-    ///
-    /// let mut total_damage = 0u32;
-    /// for event in c.consume_all() {
-    ///     total_damage += event.0;
-    /// }
-    /// assert_eq!(total_damage, 15);
-    /// ```
     ///
     /// [`try_consume`]: Consumer::try_consume
     pub fn consume_all(&mut self) -> impl Iterator<Item = T> {

--- a/crates/dirk_events/src/lib.rs
+++ b/crates/dirk_events/src/lib.rs
@@ -218,8 +218,8 @@ impl EventManager {
     /// struct TickEvent(u32);
     ///
     /// let mgr = EventManager::new();
-    /// let dispatcher = mgr.register::<TickEvent>();
-    /// let consumer   = mgr.subscribe::<TickEvent>();
+    /// let mut dispatcher = mgr.register::<TickEvent>();
+    /// let mut consumer   = mgr.subscribe::<TickEvent>();
     ///
     /// // Frame 1
     /// dispatcher.dispatch(TickEvent(1));
@@ -303,7 +303,7 @@ struct Subscriber {
 /// let mgr = EventManager::new();
 /// let d1  = mgr.register::<Hit>();
 /// let d2  = d1.clone(); // independent producer
-/// let c   = mgr.subscribe::<Hit>();
+/// let mut c   = mgr.subscribe::<Hit>();
 ///
 /// d1.dispatch(Hit(1));
 /// d2.dispatch(Hit(2));
@@ -335,7 +335,7 @@ impl<T: Event> Dispatcher<T> {
     ///
     /// let mgr = EventManager::new();
     /// let dispatcher = mgr.register::<EnemySpawned>();
-    /// let consumer   = mgr.subscribe::<EnemySpawned>();
+    /// let mut consumer   = mgr.subscribe::<EnemySpawned>();
     ///
     /// // Queued — not yet visible.
     /// dispatcher.dispatch(EnemySpawned { x: 10.0, y: 20.0 });
@@ -385,8 +385,8 @@ impl<T: Event> std::fmt::Debug for Dispatcher<T> {
 ///
 /// let mgr = EventManager::new();
 /// let d   = mgr.register::<Signal>();
-/// let c1  = mgr.subscribe::<Signal>();
-/// let c2  = c1.clone(); // fresh, independent subscription
+/// let mut c1  = mgr.subscribe::<Signal>();
+/// let mut c2  = c1.clone(); // fresh, independent subscription
 ///
 /// d.dispatch(Signal);
 /// mgr.dispatch_all();
@@ -422,7 +422,7 @@ impl<T: Event> Consumer<T> {
     ///
     /// let mgr = EventManager::new();
     /// let d   = mgr.register::<Counter>();
-    /// let c   = mgr.subscribe::<Counter>();
+    /// let mut c   = mgr.subscribe::<Counter>();
     ///
     /// d.dispatch(Counter(1));
     /// d.dispatch(Counter(2));
@@ -459,7 +459,7 @@ impl<T: Event> Consumer<T> {
     ///
     /// let mgr = EventManager::new();
     /// let d   = mgr.register::<Score>();
-    /// let c   = mgr.subscribe::<Score>();
+    /// let mut c   = mgr.subscribe::<Score>();
     ///
     /// for i in 0..5 { d.dispatch(Score(i)); }
     /// mgr.dispatch_all();
@@ -479,7 +479,7 @@ impl<T: Event> Consumer<T> {
     ///
     /// let mgr = EventManager::new();
     /// let d   = mgr.register::<DamageEvent>();
-    /// let c   = mgr.subscribe::<DamageEvent>();
+    /// let mut c   = mgr.subscribe::<DamageEvent>();
     ///
     /// d.dispatch(DamageEvent(10));
     /// d.dispatch(DamageEvent(5));

--- a/crates/dirk_events/src/lib.rs
+++ b/crates/dirk_events/src/lib.rs
@@ -96,11 +96,6 @@ pub use dirk_proc::Event;
 /// [`dispatch_all`]: EventManager::dispatch_all
 #[derive(Clone)]
 pub struct EventManager {
-    /// We only store the producers to be able to sync them
-    /// with [`dispatch_all`].
-    ///
-    /// [`dispatch_all`]: EventManager::dispatch_all
-    producers: Arc<RwLock<Vec<Box<dyn AnyProducer>>>>,
     subscribers: Arc<RwLock<HashMap<TypeId, Vec<Subscriber>>>>, // TODO: see about better HashMap where we can lock just the value instead of entire thing
     workers: WorkerPool,
 }
@@ -118,7 +113,6 @@ impl EventManager {
     #[must_use]
     pub fn new(workers: WorkerPool) -> Self {
         Self {
-            producers: Arc::default(),
             subscribers: Arc::default(),
             workers,
         }
@@ -153,10 +147,7 @@ impl EventManager {
     /// [`dispatch_all`]: EventManager::dispatch_all
     #[must_use]
     pub fn register<T: Event>(&self) -> Dispatcher<T> {
-        let (sender, receiver) = mpsc::unbounded_channel::<ProducerMessage<T>>();
-        self.producers.write().push(Box::new(TypedProducer {
-            sender: sender.clone(),
-        }));
+        let (sender, receiver) = mpsc::unbounded_channel::<T>();
         self.spawn_router(receiver);
         Dispatcher {
             sender,
@@ -206,111 +197,25 @@ impl EventManager {
         }
     }
 
-    /// Waits until all events queued before this call have been forwarded to
-    /// their subscribers.
-    ///
-    /// This remains useful as a frame barrier for systems that want to observe
-    /// a quiescent event state, but delivery itself happens immediately on
-    /// background worker threads.
-    ///
-    /// Dropped consumers are silently pruned during this call — no panic, no
-    /// memory leak.
-    ///
-    /// # Behaviour Summary
-    ///
-    /// * Iterates over all registered producers.
-    /// * Inserts a barrier into each producer queue.
-    /// * Waits until each producer has routed every event queued before that barrier.
-    /// * Dead subscribers (those whose [`Consumer`] has been dropped) are pruned
-    ///   during routing.
-    ///
-    /// # Example — Two-Frame Simulation
-    ///
-    /// ```rust
-    /// use dirk_events::{EventManager, Event};
-    ///
-    /// #[derive(Debug, Clone, Event)]
-    /// struct TickEvent(u32);
-    ///
-    /// let mgr = EventManager::new();
-    /// let mut dispatcher = mgr.register::<TickEvent>();
-    /// let mut consumer   = mgr.subscribe::<TickEvent>();
-    ///
-    /// // Frame 1
-    /// dispatcher.dispatch(TickEvent(1));
-    /// mgr.dispatch_all();
-    /// assert_eq!(consumer.try_consume().unwrap().0, 1);
-    ///
-    /// // Frame 2
-    /// dispatcher.dispatch(TickEvent(2));
-    /// mgr.dispatch_all();
-    /// assert_eq!(consumer.try_consume().unwrap().0, 2);
-    /// ```
-    pub fn dispatch_all(&self) {
-        let producers = self.producers.read();
-        for producer in producers.iter() {
-            producer.sync();
-        }
-    }
-
-    fn spawn_router<T: Event>(&self, mut receiver: UnboundedReceiver<ProducerMessage<T>>) {
+    fn spawn_router<T: Event>(&self, mut receiver: UnboundedReceiver<T>) {
         let subscribers = Arc::clone(&self.subscribers);
         self.workers.spawn(async move {
-            while let Some(message) = receiver.recv().await {
-                match message {
-                    ProducerMessage::Event(event) => {
-                        let mut subscribers = subscribers.write();
-                        let Some(listeners) = subscribers.get_mut(&TypeId::of::<T>()) else {
-                            continue;
-                        };
+            while let Some(event) = receiver.recv().await {
+                let mut subscribers = subscribers.write();
+                let Some(listeners) = subscribers.get_mut(&TypeId::of::<T>()) else {
+                    continue;
+                };
 
-                        listeners.retain(|sub| {
-                            let Some(sender) = sub.sender.downcast_ref::<UnboundedSender<T>>()
-                            else {
-                                // TODO: do we really want to keep what isn't being downcasted?
-                                return true;
-                            };
-                            sender.send(event.clone()).is_ok()
-                        });
-                    }
-                    ProducerMessage::Barrier(barrier) => {
-                        let _ = barrier.send(());
-                    }
-                }
+                listeners.retain(|sub| {
+                    let Some(sender) = sub.sender.downcast_ref::<UnboundedSender<T>>() else {
+                        // TODO: do we really want to keep what isn't being downcasted?
+                        return true;
+                    };
+                    sender.send(event.clone()).is_ok()
+                });
             }
         });
     }
-}
-
-/// The Type Erasure Trait.
-/// Allows the `EventManager` to forward pending events without knowing `T`.
-trait AnyProducer: Send + Sync {
-    fn sync(&self);
-}
-
-/// A producer is an object that will be queried for events.
-/// On event collection, the event manager loops through every
-/// producer and collects pending events.
-///
-/// This is a typed producer as it stores the actual type of the
-/// event it is producing. It is then wrapped by the [`AnyProducer`]
-/// trait to hide the event type from the event manager.
-struct TypedProducer<T: Event> {
-    sender: UnboundedSender<ProducerMessage<T>>,
-}
-
-impl<T: Event> AnyProducer for TypedProducer<T> {
-    fn sync(&self) {
-        let (tx, rx) = std::sync::mpsc::channel();
-        if self.sender.send(ProducerMessage::Barrier(tx)).is_ok() {
-            let _ = rx.recv();
-        }
-    }
-}
-
-enum ProducerMessage<T: Event> {
-    Event(T),
-    Barrier(std::sync::mpsc::Sender<()>),
 }
 
 /// A subscriber is a sender for events.
@@ -351,7 +256,7 @@ struct Subscriber {
 /// assert_eq!(hits.len(), 2);
 /// ```
 pub struct Dispatcher<T: Event> {
-    sender: UnboundedSender<ProducerMessage<T>>,
+    sender: UnboundedSender<T>,
     manager: EventManager,
 }
 
@@ -382,7 +287,7 @@ impl<T: Event> Dispatcher<T> {
     /// ```
     pub fn dispatch(&self, event: T) {
         trace!("dispatching event {}", event.debug());
-        let _ = self.sender.send(ProducerMessage::Event(event));
+        let _ = self.sender.send(event);
     }
 }
 

--- a/crates/dirk_events/src/lib.rs
+++ b/crates/dirk_events/src/lib.rs
@@ -9,6 +9,8 @@ use std::{
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::trace;
 
+use dirk_threads::WorkerPool;
+
 mod tests;
 
 /// The marker trait that every event type must implement.
@@ -54,8 +56,8 @@ pub use dirk_proc::Event;
 /// The central event bus.
 ///
 /// `EventManager` owns the internal channel infrastructure and is responsible
-/// for forwarding buffered events to the right subscribers on every call to
-/// [`dispatch_all`].
+/// for routing dispatched events to the right subscribers on background worker
+/// threads.
 ///
 /// # Cloning
 ///
@@ -80,7 +82,7 @@ pub use dirk_proc::Event;
 /// loop {
 ///     // … collect input, run systems …
 ///
-///     // Forward all queued events to subscribers.
+///     // Wait for events dispatched so far to finish routing.
 ///     mgr.dispatch_all();
 ///
 ///     // … render …
@@ -89,10 +91,15 @@ pub use dirk_proc::Event;
 /// ```
 ///
 /// [`dispatch_all`]: EventManager::dispatch_all
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct EventManager {
+    /// We only store the producers to be able to sync them
+    /// with [`dispatch_all`].
+    ///
+    /// [`dispatch_all`]: EventManager::dispatch_all
     producers: Arc<RwLock<Vec<Box<dyn AnyProducer>>>>,
-    subscribers: Arc<RwLock<HashMap<TypeId, Vec<Subscriber>>>>,
+    subscribers: Arc<RwLock<HashMap<TypeId, Vec<Subscriber>>>>, // TODO: see about better HashMap where we can lock just the value instead of entire thing
+    workers: WorkerPool,
 }
 
 impl EventManager {
@@ -106,15 +113,19 @@ impl EventManager {
     /// let mgr = EventManager::new();
     /// ```
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(workers: WorkerPool) -> Self {
+        Self {
+            producers: Arc::default(),
+            subscribers: Arc::default(),
+            workers,
+        }
     }
 
     /// Registers a new event type and returns a [`Dispatcher`] for it.
     ///
-    /// Every call to `register` creates an **independent** producer channel.
-    /// Multiple dispatchers for the same event type are fully supported — their
-    /// events are all forwarded on the next [`dispatch_all`].
+    /// Every call to `register` creates an **independent** producer channel and
+    /// a matching background routing task. Multiple dispatchers for the same
+    /// event type are fully supported.
     ///
     /// # Type Inference
     ///
@@ -139,11 +150,11 @@ impl EventManager {
     /// [`dispatch_all`]: EventManager::dispatch_all
     #[must_use]
     pub fn register<T: Event>(&self) -> Dispatcher<T> {
-        let (sender, receiver) = mpsc::unbounded_channel::<T>();
+        let (sender, receiver) = mpsc::unbounded_channel::<ProducerMessage<T>>();
         self.producers.write().push(Box::new(TypedProducer {
-            type_id: TypeId::of::<T>(),
-            receiver,
+            sender: sender.clone(),
         }));
+        self.spawn_router(receiver);
         Dispatcher {
             sender,
             manager: self.clone(),
@@ -192,22 +203,23 @@ impl EventManager {
         }
     }
 
-    /// Drains all registered producers and forwards their pending events to
-    /// every matching subscriber.
+    /// Waits until all events queued before this call have been forwarded to
+    /// their subscribers.
     ///
-    /// **Call this exactly once per frame / tick** from your main engine loop.
-    /// Events queued via [`Dispatcher::dispatch`] are invisible to consumers
-    /// until this method is called.
+    /// This remains useful as a frame barrier for systems that want to observe
+    /// a quiescent event state, but delivery itself happens immediately on
+    /// background worker threads.
     ///
     /// Dropped consumers are silently pruned during this call — no panic, no
     /// memory leak.
     ///
     /// # Behaviour Summary
     ///
-    /// * Iterates over all registered producers in registration order.
-    /// * For each producer, drains all pending events from its internal channel.
-    /// * Clones each event and sends it to every live subscriber of that type.
-    /// * Removes dead subscribers (those whose [`Consumer`] has been dropped).
+    /// * Iterates over all registered producers.
+    /// * Inserts a barrier into each producer queue.
+    /// * Waits until each producer has routed every event queued before that barrier.
+    /// * Dead subscribers (those whose [`Consumer`] has been dropped) are pruned
+    ///   during routing.
     ///
     /// # Example — Two-Frame Simulation
     ///
@@ -232,18 +244,45 @@ impl EventManager {
     /// assert_eq!(consumer.try_consume().unwrap().0, 2);
     /// ```
     pub fn dispatch_all(&self) {
-        let mut producers = self.producers.write();
-        let mut subscribers = self.subscribers.write();
-        for producer in producers.iter_mut() {
-            producer.forward_pending(&mut subscribers);
+        let producers = self.producers.read();
+        for producer in producers.iter() {
+            producer.sync();
         }
+    }
+
+    fn spawn_router<T: Event>(&self, mut receiver: UnboundedReceiver<ProducerMessage<T>>) {
+        let subscribers = Arc::clone(&self.subscribers);
+        self.workers.spawn(async move {
+            while let Some(message) = receiver.recv().await {
+                match message {
+                    ProducerMessage::Event(event) => {
+                        let mut subscribers = subscribers.write();
+                        let Some(listeners) = subscribers.get_mut(&TypeId::of::<T>()) else {
+                            continue;
+                        };
+
+                        listeners.retain(|sub| {
+                            let Some(sender) = sub.sender.downcast_ref::<UnboundedSender<T>>()
+                            else {
+                                // TODO: do we really want to keep what isn't being downcasted?
+                                return true;
+                            };
+                            sender.send(event.clone()).is_ok()
+                        });
+                    }
+                    ProducerMessage::Barrier(barrier) => {
+                        let _ = barrier.send(());
+                    }
+                }
+            }
+        });
     }
 }
 
 /// The Type Erasure Trait.
 /// Allows the `EventManager` to forward pending events without knowing `T`.
 trait AnyProducer: Send + Sync {
-    fn forward_pending(&mut self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>);
+    fn sync(&self);
 }
 
 /// A producer is an object that will be queried for events.
@@ -254,24 +293,21 @@ trait AnyProducer: Send + Sync {
 /// event it is producing. It is then wrapped by the [`AnyProducer`]
 /// trait to hide the event type from the event manager.
 struct TypedProducer<T: Event> {
-    type_id: TypeId,
-    receiver: UnboundedReceiver<T>,
+    sender: UnboundedSender<ProducerMessage<T>>,
 }
 
 impl<T: Event> AnyProducer for TypedProducer<T> {
-    fn forward_pending(&mut self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>) {
-        let Some(subscribers) = subscribers.get_mut(&self.type_id) else {
-            return;
-        };
-        while let Ok(event) = self.receiver.try_recv() {
-            subscribers.retain(|sub| {
-                let Some(sender) = sub.sender.downcast_ref::<UnboundedSender<T>>() else {
-                    return true;
-                };
-                sender.send(event.clone()).is_ok()
-            });
+    fn sync(&self) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        if self.sender.send(ProducerMessage::Barrier(tx)).is_ok() {
+            let _ = rx.recv();
         }
     }
+}
+
+enum ProducerMessage<T: Event> {
+    Event(T),
+    Barrier(std::sync::mpsc::Sender<()>),
 }
 
 /// A subscriber is a sender for events.
@@ -281,8 +317,7 @@ struct Subscriber {
     sender: Box<dyn Any + Send + Sync>,
 }
 
-/// Queues events to be forwarded to subscribers on the next
-/// [`EventManager::dispatch_all`].
+/// Queues events to be forwarded to subscribers by a background worker task.
 ///
 /// Created by [`EventManager::register`]. Cheaply shareable — pass it by clone
 /// into any number of systems.
@@ -291,8 +326,8 @@ struct Subscriber {
 ///
 /// Cloning a `Dispatcher` registers a **new, independent producer** with the
 /// same [`EventManager`]. This means the clone and the original each have their
-/// own internal channel, but both sets of events are delivered to all
-/// subscribers on the next `dispatch_all`.
+/// own internal routing channel, but both sets of events are delivered to all
+/// subscribers.
 ///
 /// ```rust
 /// use dirk_events::{EventManager, Event};
@@ -313,16 +348,16 @@ struct Subscriber {
 /// assert_eq!(hits.len(), 2);
 /// ```
 pub struct Dispatcher<T: Event> {
-    sender: UnboundedSender<T>,
+    sender: UnboundedSender<ProducerMessage<T>>,
     manager: EventManager,
 }
 
 impl<T: Event> Dispatcher<T> {
-    /// Queues `event` to be forwarded to all subscribers on the next call to
-    /// [`EventManager::dispatch_all`].
+    /// Queues `event` to be forwarded to all subscribers as soon as a worker
+    /// thread can route it.
     ///
     /// This method is non-blocking and returns immediately. The event is not
-    /// visible to consumers until `dispatch_all` is called.
+    /// routed on the caller thread.
     ///
     /// # Example
     ///
@@ -337,17 +372,14 @@ impl<T: Event> Dispatcher<T> {
     /// let dispatcher = mgr.register::<EnemySpawned>();
     /// let mut consumer   = mgr.subscribe::<EnemySpawned>();
     ///
-    /// // Queued — not yet visible.
+    /// // Routed asynchronously.
     /// dispatcher.dispatch(EnemySpawned { x: 10.0, y: 20.0 });
-    /// assert!(consumer.try_consume().is_none());
-    ///
-    /// // Now forwarded.
     /// mgr.dispatch_all();
     /// assert!(consumer.try_consume().is_some());
     /// ```
     pub fn dispatch(&self, event: T) {
         trace!("dispatching event {}", event.debug());
-        let _ = self.sender.send(event);
+        let _ = self.sender.send(ProducerMessage::Event(event));
     }
 }
 
@@ -365,7 +397,7 @@ impl<T: Event> std::fmt::Debug for Dispatcher<T> {
     }
 }
 
-/// Receives events forwarded by [`EventManager::dispatch_all`].
+/// Receives events routed by background worker tasks.
 ///
 /// Created by [`EventManager::subscribe`]. Each `Consumer` holds an independent
 /// subscription — it is **not** shared with other consumers of the same type.
@@ -374,7 +406,7 @@ impl<T: Event> std::fmt::Debug for Dispatcher<T> {
 ///
 /// Cloning a `Consumer` creates a **fresh subscription** backed by the same
 /// [`EventManager`]. The clone starts empty and receives events dispatched
-/// *after* it was created; it does **not** inherit any events already buffered
+/// *after* it was created; it does **not** inherit any events already queued
 /// in the original.
 ///
 /// ```rust
@@ -397,9 +429,9 @@ impl<T: Event> std::fmt::Debug for Dispatcher<T> {
 ///
 /// # Dropping
 ///
-/// When a `Consumer` is dropped its subscription is automatically removed on
-/// the next [`EventManager::dispatch_all`]. No explicit unsubscribe call is
-/// needed.
+/// When a `Consumer` is dropped its subscription is automatically removed the
+/// next time a worker attempts to route an event to it. No explicit
+/// unsubscribe call is needed.
 pub struct Consumer<T: Event> {
     receiver: UnboundedReceiver<T>,
     manager: EventManager,
@@ -410,7 +442,7 @@ impl<T: Event> Consumer<T> {
     /// empty.
     ///
     /// This is non-blocking. Use [`consume_all`] if you want to drain every
-    /// event that arrived this tick.
+    /// event that arrived so far.
     ///
     /// # Example
     ///
@@ -442,7 +474,25 @@ impl<T: Event> Consumer<T> {
         res
     }
 
-    // TODO: async consume function
+    /// Async consumption function. Returns a future that resolved to the next
+    /// event that is dispatched to this [`Consumer`].
+    pub async fn consume(&mut self) -> Option<T> {
+        let res = self.receiver.recv().await;
+        if let Some(event) = res.clone() {
+            trace!("consuming {}", event.debug());
+        }
+        res
+    }
+
+    /// Blocks the current thread until the next event arrives, or all
+    /// dispatchers for this subscription are dropped.
+    pub fn consume_blocking(&mut self) -> Option<T> {
+        let res = self.receiver.blocking_recv();
+        if let Some(event) = res.clone() {
+            trace!("consuming {}", event.debug());
+        }
+        res
+    }
 
     /// Returns a lazy iterator that **drains all currently pending events**.
     ///

--- a/crates/dirk_events/src/lib.rs
+++ b/crates/dirk_events/src/lib.rs
@@ -1,15 +1,14 @@
 #![doc = include_str!("../README.md")]
 
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    sync::{
-        Arc,
-        mpsc::{self, Receiver, Sender},
-    },
+    sync::Arc,
 };
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::trace;
+
 mod tests;
 
 /// The marker trait that every event type must implement.
@@ -52,13 +51,6 @@ pub trait Event: Send + Clone + 'static {
 #[doc(hidden)]
 pub use dirk_proc::Event;
 
-/// Private inner state, held behind the `Arc<Mutex<>>`.
-#[derive(Default)]
-struct EventManagerInner {
-    producers: Vec<Box<dyn AnyProducer>>,
-    subscribers: HashMap<TypeId, Vec<Subscriber>>,
-}
-
 /// The central event bus.
 ///
 /// `EventManager` owns the internal channel infrastructure and is responsible
@@ -99,7 +91,8 @@ struct EventManagerInner {
 /// [`dispatch_all`]: EventManager::dispatch_all
 #[derive(Clone, Default)]
 pub struct EventManager {
-    inner: Arc<Mutex<EventManagerInner>>,
+    producers: Arc<RwLock<Vec<Box<dyn AnyProducer>>>>,
+    subscribers: Arc<RwLock<HashMap<TypeId, Vec<Subscriber>>>>,
 }
 
 impl EventManager {
@@ -146,8 +139,8 @@ impl EventManager {
     /// [`dispatch_all`]: EventManager::dispatch_all
     #[must_use]
     pub fn register<T: Event>(&self) -> Dispatcher<T> {
-        let (sender, receiver) = mpsc::channel::<T>();
-        self.inner.lock().producers.push(Box::new(TypedProducer {
+        let (sender, receiver) = mpsc::unbounded_channel::<T>();
+        self.producers.write().push(Box::new(TypedProducer {
             type_id: TypeId::of::<T>(),
             receiver,
         }));
@@ -184,11 +177,10 @@ impl EventManager {
     /// ```
     #[must_use]
     pub fn subscribe<T: Event>(&self) -> Consumer<T> {
-        let (sender, receiver) = mpsc::channel::<T>();
+        let (sender, receiver) = mpsc::unbounded_channel::<T>();
         let type_id = TypeId::of::<T>();
-        self.inner
-            .lock()
-            .subscribers
+        self.subscribers
+            .write()
             .entry(type_id)
             .or_default()
             .push(Subscriber {
@@ -240,21 +232,18 @@ impl EventManager {
     /// assert_eq!(consumer.try_consume().unwrap().0, 2);
     /// ```
     pub fn dispatch_all(&self) {
-        let mut inner = self.inner.lock();
-        let EventManagerInner {
-            producers,
-            subscribers,
-        } = &mut *inner;
-        for producer in producers.iter() {
-            producer.forward_pending(subscribers);
+        let mut producers = self.producers.write();
+        let mut subscribers = self.subscribers.write();
+        for producer in producers.iter_mut() {
+            producer.forward_pending(&mut subscribers);
         }
     }
 }
 
 /// The Type Erasure Trait.
 /// Allows the `EventManager` to forward pending events without knowing `T`.
-trait AnyProducer: Send {
-    fn forward_pending(&self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>);
+trait AnyProducer: Send + Sync {
+    fn forward_pending(&mut self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>);
 }
 
 /// A producer is an object that will be queried for events.
@@ -266,17 +255,17 @@ trait AnyProducer: Send {
 /// trait to hide the event type from the event manager.
 struct TypedProducer<T: Event> {
     type_id: TypeId,
-    receiver: Receiver<T>,
+    receiver: UnboundedReceiver<T>,
 }
 
 impl<T: Event> AnyProducer for TypedProducer<T> {
-    fn forward_pending(&self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>) {
+    fn forward_pending(&mut self, subscribers: &mut HashMap<TypeId, Vec<Subscriber>>) {
         let Some(subscribers) = subscribers.get_mut(&self.type_id) else {
             return;
         };
         while let Ok(event) = self.receiver.try_recv() {
             subscribers.retain(|sub| {
-                let Some(sender) = sub.sender.downcast_ref::<Sender<T>>() else {
+                let Some(sender) = sub.sender.downcast_ref::<UnboundedSender<T>>() else {
                     return true;
                 };
                 sender.send(event.clone()).is_ok()
@@ -289,7 +278,7 @@ impl<T: Event> AnyProducer for TypedProducer<T> {
 /// On event dispatching, will send the events through the
 /// channels of every subscriber.
 struct Subscriber {
-    sender: Box<dyn Any + Send>,
+    sender: Box<dyn Any + Send + Sync>,
 }
 
 /// Queues events to be forwarded to subscribers on the next
@@ -324,7 +313,7 @@ struct Subscriber {
 /// assert_eq!(hits.len(), 2);
 /// ```
 pub struct Dispatcher<T: Event> {
-    sender: Sender<T>,
+    sender: UnboundedSender<T>,
     manager: EventManager,
 }
 
@@ -412,7 +401,7 @@ impl<T: Event> std::fmt::Debug for Dispatcher<T> {
 /// the next [`EventManager::dispatch_all`]. No explicit unsubscribe call is
 /// needed.
 pub struct Consumer<T: Event> {
-    receiver: Receiver<T>,
+    receiver: UnboundedReceiver<T>,
     manager: EventManager,
 }
 
@@ -445,13 +434,15 @@ impl<T: Event> Consumer<T> {
     /// ```
     ///
     /// [`consume_all`]: Consumer::consume_all
-    pub fn try_consume(&self) -> Option<T> {
+    pub fn try_consume(&mut self) -> Option<T> {
         let res = self.receiver.try_recv().ok();
         if let Some(event) = res.clone() {
             trace!("consuming {}", event.debug());
         }
         res
     }
+
+    // TODO: async consume function
 
     /// Returns a lazy iterator that **drains all currently pending events**.
     ///
@@ -502,7 +493,7 @@ impl<T: Event> Consumer<T> {
     /// ```
     ///
     /// [`try_consume`]: Consumer::try_consume
-    pub fn consume_all(&self) -> impl Iterator<Item = T> {
+    pub fn consume_all(&mut self) -> impl Iterator<Item = T> {
         std::iter::from_fn(|| self.try_consume())
     }
 }

--- a/crates/dirk_events/src/tests.rs
+++ b/crates/dirk_events/src/tests.rs
@@ -15,7 +15,7 @@ use crate::{Consumer, Dispatcher, Event, EventManager};
 // Helper: drain every pending event from a Consumer into a Vec.
 // =========================================================================
 
-fn collect<T: Event>(consumer: &Consumer<T>) -> Vec<T> {
+fn collect<T: Event>(consumer: &mut Consumer<T>) -> Vec<T> {
     consumer.consume_all().collect()
 }
 
@@ -378,12 +378,12 @@ mod event_manager {
     fn single_event_reaches_single_subscriber() {
         let mgr = EventManager::new();
         let dispatcher: Dispatcher<CounterEvent> = mgr.register();
-        let consumer: Consumer<CounterEvent> = mgr.subscribe();
+        let mut consumer: Consumer<CounterEvent> = mgr.subscribe();
 
         dispatcher.dispatch(CounterEvent(1));
         mgr.dispatch_all();
 
-        let events = collect(&consumer);
+        let events = collect(&mut consumer);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].0, 1);
     }
@@ -392,14 +392,14 @@ mod event_manager {
     fn multiple_events_all_reach_subscriber() {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         for i in 0..5 {
             dispatcher.dispatch(CounterEvent(i));
         }
         mgr.dispatch_all();
 
-        let values: Vec<u32> = collect(&consumer).into_iter().map(|e| e.0).collect();
+        let values: Vec<u32> = collect(&mut consumer).into_iter().map(|e| e.0).collect();
         assert_eq!(values, vec![0, 1, 2, 3, 4]);
     }
 
@@ -409,35 +409,35 @@ mod event_manager {
     fn events_are_buffered_until_dispatch_all() {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         dispatcher.dispatch(CounterEvent(42));
 
         // Nothing delivered yet.
-        assert!(collect(&consumer).is_empty());
+        assert!(collect(&mut consumer).is_empty());
 
         mgr.dispatch_all();
-        assert_eq!(collect(&consumer).len(), 1);
+        assert_eq!(collect(&mut consumer).len(), 1);
     }
 
     #[test]
     fn dispatch_all_can_be_called_multiple_times() {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         // Each tick delivers one event.
         dispatcher.dispatch(CounterEvent(1));
         mgr.dispatch_all();
 
-        let first = collect(&consumer);
+        let first = collect(&mut consumer);
         assert_eq!(first.len(), 1);
         assert_eq!(first[0].0, 1);
 
         dispatcher.dispatch(CounterEvent(2));
         mgr.dispatch_all();
 
-        let second = collect(&consumer);
+        let second = collect(&mut consumer);
         assert_eq!(second.len(), 1);
         assert_eq!(second[0].0, 2);
     }
@@ -446,10 +446,10 @@ mod event_manager {
     fn no_events_means_empty_consumer() {
         let mgr = EventManager::new();
         let _dispatcher = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         mgr.dispatch_all();
-        assert!(collect(&consumer).is_empty());
+        assert!(collect(&mut consumer).is_empty());
     }
 
     // ── 3.3  Fan-out: multiple subscribers ────────────────────────────────
@@ -458,14 +458,14 @@ mod event_manager {
     fn single_event_reaches_all_subscribers() {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
-        let c1 = mgr.subscribe::<CounterEvent>();
-        let c2 = mgr.subscribe::<CounterEvent>();
-        let c3 = mgr.subscribe::<CounterEvent>();
+        let mut c1 = mgr.subscribe::<CounterEvent>();
+        let mut c2 = mgr.subscribe::<CounterEvent>();
+        let mut c3 = mgr.subscribe::<CounterEvent>();
 
         dispatcher.dispatch(CounterEvent(99));
         mgr.dispatch_all();
 
-        for consumer in [&c1, &c2, &c3] {
+        for consumer in [&mut c1, &mut c2, &mut c3] {
             let events = collect(consumer);
             assert_eq!(events.len(), 1);
             assert_eq!(events[0].0, 99);
@@ -476,15 +476,15 @@ mod event_manager {
     fn multiple_events_fan_out_to_all_subscribers() {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
-        let c1 = mgr.subscribe::<CounterEvent>();
-        let c2 = mgr.subscribe::<CounterEvent>();
+        let mut c1 = mgr.subscribe::<CounterEvent>();
+        let mut c2 = mgr.subscribe::<CounterEvent>();
 
         for i in 0..3 {
             dispatcher.dispatch(CounterEvent(i));
         }
         mgr.dispatch_all();
 
-        for consumer in [&c1, &c2] {
+        for consumer in [&mut c1, &mut c2] {
             let values: Vec<u32> = collect(consumer).into_iter().map(|e| e.0).collect();
             assert_eq!(values, vec![0, 1, 2]);
         }
@@ -498,18 +498,18 @@ mod event_manager {
         let counter_dispatcher = mgr.register::<CounterEvent>();
         let label_dispatcher = mgr.register::<LabelEvent>();
 
-        let counter_consumer = mgr.subscribe::<CounterEvent>();
-        let label_consumer = mgr.subscribe::<LabelEvent>();
+        let mut counter_consumer = mgr.subscribe::<CounterEvent>();
+        let mut label_consumer = mgr.subscribe::<LabelEvent>();
 
         counter_dispatcher.dispatch(CounterEvent(7));
         label_dispatcher.dispatch(LabelEvent("hello".into()));
         mgr.dispatch_all();
 
-        let counters = collect(&counter_consumer);
+        let counters = collect(&mut counter_consumer);
         assert_eq!(counters.len(), 1);
         assert_eq!(counters[0].0, 7);
 
-        let labels = collect(&label_consumer);
+        let labels = collect(&mut label_consumer);
         assert_eq!(labels.len(), 1);
         assert_eq!(labels[0].0, "hello");
     }
@@ -520,15 +520,15 @@ mod event_manager {
         let counter_dispatcher = mgr.register::<CounterEvent>();
         let _label_dispatcher = mgr.register::<LabelEvent>();
 
-        let counter_consumer = mgr.subscribe::<CounterEvent>();
-        let label_consumer = mgr.subscribe::<LabelEvent>();
+        let mut counter_consumer = mgr.subscribe::<CounterEvent>();
+        let mut label_consumer = mgr.subscribe::<LabelEvent>();
 
         // Only fire a CounterEvent.
         counter_dispatcher.dispatch(CounterEvent(1));
         mgr.dispatch_all();
 
-        assert_eq!(collect(&counter_consumer).len(), 1);
-        assert!(collect(&label_consumer).is_empty()); // Must not receive anything.
+        assert_eq!(collect(&mut counter_consumer).len(), 1);
+        assert!(collect(&mut label_consumer).is_empty()); // Must not receive anything.
     }
 
     // ── 3.5  No subscribers registered ───────────────────────────────────
@@ -556,7 +556,7 @@ mod event_manager {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
 
-        let alive = mgr.subscribe::<CounterEvent>();
+        let mut alive = mgr.subscribe::<CounterEvent>();
         {
             let _dead = mgr.subscribe::<CounterEvent>();
             // `_dead` is dropped here; its receiver is gone.
@@ -566,7 +566,7 @@ mod event_manager {
         dispatcher.dispatch(CounterEvent(5));
         mgr.dispatch_all();
 
-        let events = collect(&alive);
+        let events = collect(&mut alive);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].0, 5);
     }
@@ -591,13 +591,13 @@ mod event_manager {
     fn subscribing_without_dispatcher_gives_empty_consumer() {
         let mgr = EventManager::new();
         // Subscribe before any dispatcher is registered for this type.
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         let _dispatcher = mgr.register::<CounterEvent>();
         // No events dispatched.
         mgr.dispatch_all();
 
-        assert!(collect(&consumer).is_empty());
+        assert!(collect(&mut consumer).is_empty());
     }
 
     // ── 3.8  High-volume stress ───────────────────────────────────────────
@@ -608,14 +608,14 @@ mod event_manager {
 
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         for i in 0..N {
             dispatcher.dispatch(CounterEvent(i));
         }
         mgr.dispatch_all();
 
-        let events = collect(&consumer);
+        let events = collect(&mut consumer);
         assert_eq!(events.len() as u32, N);
         for (i, event) in events.iter().enumerate() {
             assert_eq!(event.0, i as u32);
@@ -628,7 +628,7 @@ mod event_manager {
     fn events_accumulate_correctly_across_many_ticks() {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         let ticks = 10u32;
         let per_tick = 3u32;
@@ -641,7 +641,7 @@ mod event_manager {
         }
 
         // Drain everything accumulated.
-        let all: Vec<u32> = collect(&consumer).into_iter().map(|e| e.0).collect();
+        let all: Vec<u32> = collect(&mut consumer).into_iter().map(|e| e.0).collect();
         let expected: Vec<u32> = (0..ticks * per_tick).collect();
         assert_eq!(all, expected);
     }
@@ -652,7 +652,7 @@ mod event_manager {
     fn try_consume_returns_none_when_empty() {
         let mgr = EventManager::new();
         let _dispatcher = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         mgr.dispatch_all();
         assert!(consumer.try_consume().is_none());
@@ -662,7 +662,7 @@ mod event_manager {
     fn try_consume_drains_one_at_a_time() {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         dispatcher.dispatch(CounterEvent(1));
         dispatcher.dispatch(CounterEvent(2));
@@ -680,13 +680,13 @@ mod event_manager {
         let mgr = EventManager::new();
         let d1 = mgr.register::<CounterEvent>();
         let d2 = mgr.register::<CounterEvent>();
-        let consumer = mgr.subscribe::<CounterEvent>();
+        let mut consumer = mgr.subscribe::<CounterEvent>();
 
         d1.dispatch(CounterEvent(1));
         d2.dispatch(CounterEvent(2));
         mgr.dispatch_all();
 
-        let mut values: Vec<u32> = collect(&consumer).into_iter().map(|e| e.0).collect();
+        let mut values: Vec<u32> = collect(&mut consumer).into_iter().map(|e| e.0).collect();
         values.sort(); // Order across producers is not guaranteed.
         assert_eq!(values, vec![1, 2]);
     }
@@ -699,15 +699,15 @@ mod event_manager {
         let mgr_default = EventManager::default();
 
         let d1 = mgr_new.register::<CounterEvent>();
-        let c1 = mgr_new.subscribe::<CounterEvent>();
+        let mut c1 = mgr_new.subscribe::<CounterEvent>();
         d1.dispatch(CounterEvent(1));
         mgr_new.dispatch_all();
-        assert_eq!(collect(&c1).len(), 1);
+        assert_eq!(collect(&mut c1).len(), 1);
 
         let d2 = mgr_default.register::<CounterEvent>();
-        let c2 = mgr_default.subscribe::<CounterEvent>();
+        let mut c2 = mgr_default.subscribe::<CounterEvent>();
         d2.dispatch(CounterEvent(1));
         mgr_default.dispatch_all();
-        assert_eq!(collect(&c2).len(), 1);
+        assert_eq!(collect(&mut c2).len(), 1);
     }
 }

--- a/crates/dirk_events/src/tests.rs
+++ b/crates/dirk_events/src/tests.rs
@@ -16,6 +16,8 @@ use crate::{Consumer, Dispatcher, Event, EventManager};
 // =========================================================================
 
 fn collect<T: Event>(consumer: &mut Consumer<T>) -> Vec<T> {
+    // wait for the event to be dispatched
+    std::thread::sleep(std::time::Duration::from_millis(5));
     consumer.consume_all().collect()
 }
 
@@ -366,6 +368,8 @@ mod macro_debug_output {
 // =========================================================================
 
 mod event_manager {
+    use dirk_threads::WorkerPool;
+
     use super::*;
 
     // A minimal event used by most tests below.
@@ -382,12 +386,12 @@ mod event_manager {
 
     #[test]
     fn single_event_reaches_single_subscriber() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher: Dispatcher<CounterEvent> = mgr.register();
         let mut consumer: Consumer<CounterEvent> = mgr.subscribe();
 
         dispatcher.dispatch(CounterEvent(1));
-        mgr.dispatch_all();
 
         let events = collect(&mut consumer);
         assert_eq!(events.len(), 1);
@@ -396,14 +400,14 @@ mod event_manager {
 
     #[test]
     fn multiple_events_all_reach_subscriber() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
         for i in 0..5 {
             dispatcher.dispatch(CounterEvent(i));
         }
-        mgr.dispatch_all();
 
         let values: Vec<u32> = collect(&mut consumer).into_iter().map(|e| e.0).collect();
         assert_eq!(values, vec![0, 1, 2, 3, 4]);
@@ -413,7 +417,8 @@ mod event_manager {
 
     #[test]
     fn events_are_delivered_without_dispatch_all() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
@@ -423,20 +428,19 @@ mod event_manager {
 
     #[test]
     fn dispatch_all_can_be_called_multiple_times() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
         // Each barrier waits for the event routed so far.
         dispatcher.dispatch(CounterEvent(1));
-        mgr.dispatch_all();
 
         let first = collect(&mut consumer);
         assert_eq!(first.len(), 1);
         assert_eq!(first[0].0, 1);
 
         dispatcher.dispatch(CounterEvent(2));
-        mgr.dispatch_all();
 
         let second = collect(&mut consumer);
         assert_eq!(second.len(), 1);
@@ -445,11 +449,11 @@ mod event_manager {
 
     #[test]
     fn no_events_means_empty_consumer() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let _dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
-        mgr.dispatch_all();
         assert!(collect(&mut consumer).is_empty());
     }
 
@@ -457,14 +461,14 @@ mod event_manager {
 
     #[test]
     fn single_event_reaches_all_subscribers() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
         let mut c1 = mgr.subscribe::<CounterEvent>();
         let mut c2 = mgr.subscribe::<CounterEvent>();
         let mut c3 = mgr.subscribe::<CounterEvent>();
 
         dispatcher.dispatch(CounterEvent(99));
-        mgr.dispatch_all();
 
         for consumer in [&mut c1, &mut c2, &mut c3] {
             let events = collect(consumer);
@@ -475,7 +479,8 @@ mod event_manager {
 
     #[test]
     fn multiple_events_fan_out_to_all_subscribers() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
         let mut c1 = mgr.subscribe::<CounterEvent>();
         let mut c2 = mgr.subscribe::<CounterEvent>();
@@ -483,7 +488,6 @@ mod event_manager {
         for i in 0..3 {
             dispatcher.dispatch(CounterEvent(i));
         }
-        mgr.dispatch_all();
 
         for consumer in [&mut c1, &mut c2] {
             let values: Vec<u32> = collect(consumer).into_iter().map(|e| e.0).collect();
@@ -495,7 +499,8 @@ mod event_manager {
 
     #[test]
     fn subscribers_only_receive_their_event_type() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let counter_dispatcher = mgr.register::<CounterEvent>();
         let label_dispatcher = mgr.register::<LabelEvent>();
 
@@ -504,7 +509,6 @@ mod event_manager {
 
         counter_dispatcher.dispatch(CounterEvent(7));
         label_dispatcher.dispatch(LabelEvent("hello".into()));
-        mgr.dispatch_all();
 
         let counters = collect(&mut counter_consumer);
         assert_eq!(counters.len(), 1);
@@ -517,7 +521,8 @@ mod event_manager {
 
     #[test]
     fn no_cross_contamination_between_event_types() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let counter_dispatcher = mgr.register::<CounterEvent>();
         let _label_dispatcher = mgr.register::<LabelEvent>();
 
@@ -526,7 +531,6 @@ mod event_manager {
 
         // Only fire a CounterEvent.
         counter_dispatcher.dispatch(CounterEvent(1));
-        mgr.dispatch_all();
 
         assert_eq!(collect(&mut counter_consumer).len(), 1);
         assert!(collect(&mut label_consumer).is_empty()); // Must not receive anything.
@@ -536,25 +540,20 @@ mod event_manager {
 
     #[test]
     fn dispatching_with_no_subscribers_does_not_panic() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
 
         dispatcher.dispatch(CounterEvent(0));
         // Must not panic even though nobody is listening.
-        mgr.dispatch_all();
-    }
-
-    #[test]
-    fn dispatch_all_on_empty_manager_does_not_panic() {
-        let mgr = EventManager::new();
-        mgr.dispatch_all(); // Nothing registered at all.
     }
 
     // ── 3.6  Dropped-consumer pruning ────────────────────────────────────
 
     #[test]
     fn dropped_consumer_is_pruned_silently() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
 
         let mut alive = mgr.subscribe::<CounterEvent>();
@@ -565,7 +564,6 @@ mod event_manager {
 
         // Subsequent dispatches must not panic.
         dispatcher.dispatch(CounterEvent(5));
-        mgr.dispatch_all();
 
         let events = collect(&mut alive);
         assert_eq!(events.len(), 1);
@@ -574,7 +572,8 @@ mod event_manager {
 
     #[test]
     fn all_consumers_dropped_does_not_panic() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
 
         {
@@ -583,20 +582,19 @@ mod event_manager {
         } // Both dropped here.
 
         dispatcher.dispatch(CounterEvent(1));
-        mgr.dispatch_all(); // Must not panic.
     }
 
     // ── 3.7  Dropped Dispatcher ────────────────────────────────────────────
 
     #[test]
     fn subscribing_without_dispatcher_gives_empty_consumer() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         // Subscribe before any dispatcher is registered for this type.
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
         let _dispatcher = mgr.register::<CounterEvent>();
         // No events dispatched.
-        mgr.dispatch_all();
 
         assert!(collect(&mut consumer).is_empty());
     }
@@ -607,15 +605,17 @@ mod event_manager {
     fn high_volume_events_all_delivered() {
         const N: u32 = 10_000;
 
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
         for i in 0..N {
             dispatcher.dispatch(CounterEvent(i));
         }
-        mgr.dispatch_all();
 
+        // threre are a lot of events so we wait extra long
+        std::thread::sleep(std::time::Duration::from_millis(100));
         let events = collect(&mut consumer);
         assert_eq!(events.len() as u32, N);
         for (i, event) in events.iter().enumerate() {
@@ -627,7 +627,8 @@ mod event_manager {
 
     #[test]
     fn events_accumulate_correctly_across_many_ticks() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
@@ -638,7 +639,6 @@ mod event_manager {
             for j in 0..per_tick {
                 dispatcher.dispatch(CounterEvent(tick * per_tick + j));
             }
-            mgr.dispatch_all();
         }
 
         // Drain everything accumulated.
@@ -651,23 +651,28 @@ mod event_manager {
 
     #[test]
     fn try_consume_returns_none_when_empty() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let _dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
-        mgr.dispatch_all();
+        // wait for the event to be dispatched
+        std::thread::sleep(std::time::Duration::from_millis(5));
         assert!(consumer.try_consume().is_none());
     }
 
     #[test]
     fn try_consume_drains_one_at_a_time() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
         dispatcher.dispatch(CounterEvent(1));
         dispatcher.dispatch(CounterEvent(2));
-        mgr.dispatch_all();
+
+        // wait for the event to be dispatched
+        std::thread::sleep(std::time::Duration::from_millis(5));
 
         assert_eq!(consumer.try_consume().unwrap().0, 1);
         assert_eq!(consumer.try_consume().unwrap().0, 2);
@@ -678,37 +683,17 @@ mod event_manager {
 
     #[test]
     fn two_dispatchers_for_same_type_both_reach_subscriber() {
-        let mgr = EventManager::new();
+        let workers = WorkerPool::new("test");
+        let mgr = EventManager::new(workers);
         let d1 = mgr.register::<CounterEvent>();
         let d2 = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
         d1.dispatch(CounterEvent(1));
         d2.dispatch(CounterEvent(2));
-        mgr.dispatch_all();
 
         let mut values: Vec<u32> = collect(&mut consumer).into_iter().map(|e| e.0).collect();
         values.sort(); // Order across producers is not guaranteed.
         assert_eq!(values, vec![1, 2]);
-    }
-
-    // ── 3.12  EventManager::new() vs Default ─────────────────────────────
-
-    #[test]
-    fn new_and_default_are_equivalent() {
-        let mgr_new = EventManager::new();
-        let mgr_default = EventManager::default();
-
-        let d1 = mgr_new.register::<CounterEvent>();
-        let mut c1 = mgr_new.subscribe::<CounterEvent>();
-        d1.dispatch(CounterEvent(1));
-        mgr_new.dispatch_all();
-        assert_eq!(collect(&mut c1).len(), 1);
-
-        let d2 = mgr_default.register::<CounterEvent>();
-        let mut c2 = mgr_default.subscribe::<CounterEvent>();
-        d2.dispatch(CounterEvent(1));
-        mgr_default.dispatch_all();
-        assert_eq!(collect(&mut c2).len(), 1);
     }
 }

--- a/crates/dirk_events/src/tests.rs
+++ b/crates/dirk_events/src/tests.rs
@@ -19,6 +19,12 @@ fn collect<T: Event>(consumer: &mut Consumer<T>) -> Vec<T> {
     consumer.consume_all().collect()
 }
 
+fn wait_for<T: Event>(consumer: &mut Consumer<T>) -> T {
+    consumer
+        .consume_blocking()
+        .expect("dispatcher should still be alive")
+}
+
 // =========================================================================
 // Section 1 – Derive-macro test types
 //
@@ -403,21 +409,16 @@ mod event_manager {
         assert_eq!(values, vec![0, 1, 2, 3, 4]);
     }
 
-    // ── 3.2  Buffering ────────────────────────────────────────────────────
+    // ── 3.2  Async routing ────────────────────────────────────────────────
 
     #[test]
-    fn events_are_buffered_until_dispatch_all() {
+    fn events_are_delivered_without_dispatch_all() {
         let mgr = EventManager::new();
         let dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
         dispatcher.dispatch(CounterEvent(42));
-
-        // Nothing delivered yet.
-        assert!(collect(&mut consumer).is_empty());
-
-        mgr.dispatch_all();
-        assert_eq!(collect(&mut consumer).len(), 1);
+        assert_eq!(wait_for(&mut consumer).0, 42);
     }
 
     #[test]
@@ -426,7 +427,7 @@ mod event_manager {
         let dispatcher = mgr.register::<CounterEvent>();
         let mut consumer = mgr.subscribe::<CounterEvent>();
 
-        // Each tick delivers one event.
+        // Each barrier waits for the event routed so far.
         dispatcher.dispatch(CounterEvent(1));
         mgr.dispatch_all();
 

--- a/crates/dirk_events/tests/integrations.rs
+++ b/crates/dirk_events/tests/integrations.rs
@@ -15,6 +15,12 @@ fn collect_all<T: Event>(consumer: &mut Consumer<T>) -> Vec<T> {
     consumer.consume_all().collect()
 }
 
+fn wait_for<T: Event>(consumer: &mut Consumer<T>) -> T {
+    consumer
+        .consume_blocking()
+        .expect("dispatcher should still be alive")
+}
+
 // =============================================================================
 // Section A – Derive macro: Event types defined outside the crate
 //
@@ -317,16 +323,15 @@ fn mid_simulation_consumer_drop_is_handled() {
     assert_eq!(events, vec![1, 2]);
 }
 
-/// consume_all returns an empty iterator when called before dispatch_all.
+/// Events are routed without waiting for dispatch_all.
 #[test]
-fn consume_all_before_dispatch_all_is_empty() {
+fn events_are_visible_before_dispatch_all() {
     let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
     let mut consumer = mgr.subscribe::<KeyPressed>();
 
     dispatcher.dispatch(KeyPressed(42));
-    // Not yet dispatched.
-    assert!(collect_all(&mut consumer).is_empty());
+    assert_eq!(wait_for(&mut consumer).0, 42);
 }
 
 /// Verifies that an enum event (NetworkEvent) goes through the full pipeline.

--- a/crates/dirk_events/tests/integrations.rs
+++ b/crates/dirk_events/tests/integrations.rs
@@ -5,6 +5,7 @@
 //! simulations, and concurrency safety.
 
 use dirk_events::{Consumer, Dispatcher, Event, EventManager};
+use dirk_threads::WorkerPool;
 use std::thread;
 
 // =============================================================================
@@ -12,6 +13,8 @@ use std::thread;
 // =============================================================================
 
 fn collect_all<T: Event>(consumer: &mut Consumer<T>) -> Vec<T> {
+    // wait for the event to be dispatched
+    std::thread::sleep(std::time::Duration::from_millis(5));
     consumer.consume_all().collect()
 }
 
@@ -168,7 +171,8 @@ fn raw_enum_event_each_variant_falls_back_to_debug() {
 /// listen to each.
 #[test]
 fn realistic_multi_system_engine_loop() {
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
 
     let key_dispatcher: Dispatcher<KeyPressed> = mgr.register();
     let win_dispatcher: Dispatcher<WindowResized> = mgr.register();
@@ -186,8 +190,6 @@ fn realistic_multi_system_engine_loop() {
                 height: 600,
             });
         }
-
-        mgr.dispatch_all();
     }
 
     // Drain and verify.
@@ -207,7 +209,8 @@ fn realistic_multi_system_engine_loop() {
 fn fan_out_to_many_consumers() {
     const N: usize = 500;
 
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
     let dispatcher = mgr.register::<KeyPressed>();
 
     let mut consumers: Vec<Consumer<KeyPressed>> = (0..8).map(|_| mgr.subscribe()).collect();
@@ -215,7 +218,6 @@ fn fan_out_to_many_consumers() {
     for i in 0..N as u32 {
         dispatcher.dispatch(KeyPressed(i));
     }
-    mgr.dispatch_all();
 
     for consumer in &mut consumers {
         let events = collect_all(consumer);
@@ -230,7 +232,8 @@ fn fan_out_to_many_consumers() {
 /// main thread. Tests `Send` bounds on Dispatcher and Event.
 #[test]
 fn dispatcher_is_send_and_can_be_moved_to_thread() {
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
     let dispatcher = mgr.register::<KeyPressed>();
     let mut consumer = mgr.subscribe::<KeyPressed>();
 
@@ -241,7 +244,6 @@ fn dispatcher_is_send_and_can_be_moved_to_thread() {
     });
 
     handle.join().expect("thread panicked");
-    mgr.dispatch_all();
 
     let events = collect_all(&mut consumer);
     assert_eq!(events.len(), 10);
@@ -251,13 +253,13 @@ fn dispatcher_is_send_and_can_be_moved_to_thread() {
 /// all subscribers.
 #[test]
 fn unit_event_reaches_all_consumers() {
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
     let dispatcher = mgr.register::<ShutdownRequested>();
     let mut c1 = mgr.subscribe::<ShutdownRequested>();
     let mut c2 = mgr.subscribe::<ShutdownRequested>();
 
     dispatcher.dispatch(ShutdownRequested);
-    mgr.dispatch_all();
 
     assert_eq!(collect_all(&mut c1).len(), 1);
     assert_eq!(collect_all(&mut c2).len(), 1);
@@ -270,32 +272,19 @@ fn unit_event_reaches_all_consumers() {
 /// Registering but never subscribing: must not panic on dispatch_all.
 #[test]
 fn register_without_subscribe_is_safe() {
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
     let dispatcher = mgr.register::<KeyPressed>();
     dispatcher.dispatch(KeyPressed(1));
-    mgr.dispatch_all();
     // No assertion needed – we just must not panic.
 }
 
 /// Subscribing but never registering any dispatcher: consumer stays empty.
 #[test]
 fn subscribe_without_register_yields_empty_consumer() {
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
     let mut consumer = mgr.subscribe::<KeyPressed>();
-    mgr.dispatch_all();
-    assert!(collect_all(&mut consumer).is_empty());
-}
-
-/// Calling dispatch_all repeatedly without any events in between is a no-op.
-#[test]
-fn repeated_dispatch_all_with_no_events() {
-    let mgr = EventManager::new();
-    let _d = mgr.register::<KeyPressed>();
-    let mut consumer = mgr.subscribe::<KeyPressed>();
-
-    for _ in 0..100 {
-        mgr.dispatch_all();
-    }
     assert!(collect_all(&mut consumer).is_empty());
 }
 
@@ -303,20 +292,19 @@ fn repeated_dispatch_all_with_no_events() {
 /// consumers and subsequent dispatches must be unaffected.
 #[test]
 fn mid_simulation_consumer_drop_is_handled() {
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
     let dispatcher = mgr.register::<KeyPressed>();
     let mut alive = mgr.subscribe::<KeyPressed>();
 
     {
         let _dying = mgr.subscribe::<KeyPressed>();
         dispatcher.dispatch(KeyPressed(1));
-        mgr.dispatch_all();
         // `_dying` dropped here.
     }
 
     // After the dropped consumer is pruned, further dispatches must work fine.
     dispatcher.dispatch(KeyPressed(2));
-    mgr.dispatch_all();
 
     let events: Vec<u32> = collect_all(&mut alive).into_iter().map(|e| e.0).collect();
     // Both events delivered to `alive` (which was never dropped).
@@ -326,7 +314,8 @@ fn mid_simulation_consumer_drop_is_handled() {
 /// Events are routed without waiting for dispatch_all.
 #[test]
 fn events_are_visible_before_dispatch_all() {
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
     let dispatcher = mgr.register::<KeyPressed>();
     let mut consumer = mgr.subscribe::<KeyPressed>();
 
@@ -337,7 +326,8 @@ fn events_are_visible_before_dispatch_all() {
 /// Verifies that an enum event (NetworkEvent) goes through the full pipeline.
 #[test]
 fn enum_event_round_trips_through_manager() {
-    let mgr = EventManager::new();
+    let workers = WorkerPool::new("test");
+    let mgr = EventManager::new(workers);
     let dispatcher = mgr.register::<NetworkEvent>();
     let mut consumer = mgr.subscribe::<NetworkEvent>();
 
@@ -347,7 +337,6 @@ fn enum_event_round_trips_through_manager() {
     });
     dispatcher.dispatch(NetworkEvent::PacketReceived(1024));
     dispatcher.dispatch(NetworkEvent::Disconnected);
-    mgr.dispatch_all();
 
     let events = collect_all(&mut consumer);
     assert_eq!(events.len(), 3);

--- a/crates/dirk_events/tests/integrations.rs
+++ b/crates/dirk_events/tests/integrations.rs
@@ -11,7 +11,7 @@ use std::thread;
 // Helper
 // =============================================================================
 
-fn collect_all<T: Event>(consumer: &Consumer<T>) -> Vec<T> {
+fn collect_all<T: Event>(consumer: &mut Consumer<T>) -> Vec<T> {
     consumer.consume_all().collect()
 }
 
@@ -167,8 +167,8 @@ fn realistic_multi_system_engine_loop() {
     let key_dispatcher: Dispatcher<KeyPressed> = mgr.register();
     let win_dispatcher: Dispatcher<WindowResized> = mgr.register();
 
-    let key_consumer: Consumer<KeyPressed> = mgr.subscribe();
-    let win_consumer: Consumer<WindowResized> = mgr.subscribe();
+    let mut key_consumer: Consumer<KeyPressed> = mgr.subscribe();
+    let mut win_consumer: Consumer<WindowResized> = mgr.subscribe();
 
     // Simulate three frames.
     for frame in 0u32..3 {
@@ -185,13 +185,13 @@ fn realistic_multi_system_engine_loop() {
     }
 
     // Drain and verify.
-    let keys: Vec<u32> = collect_all(&key_consumer)
+    let keys: Vec<u32> = collect_all(&mut key_consumer)
         .into_iter()
         .map(|e| e.0)
         .collect();
     assert_eq!(keys, vec![65, 66, 67]);
 
-    let wins = collect_all(&win_consumer);
+    let wins = collect_all(&mut win_consumer);
     assert_eq!(wins.len(), 1);
     assert_eq!(wins[0].width, 800);
 }
@@ -204,14 +204,14 @@ fn fan_out_to_many_consumers() {
     let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
 
-    let consumers: Vec<Consumer<KeyPressed>> = (0..8).map(|_| mgr.subscribe()).collect();
+    let mut consumers: Vec<Consumer<KeyPressed>> = (0..8).map(|_| mgr.subscribe()).collect();
 
     for i in 0..N as u32 {
         dispatcher.dispatch(KeyPressed(i));
     }
     mgr.dispatch_all();
 
-    for consumer in &consumers {
+    for consumer in &mut consumers {
         let events = collect_all(consumer);
         assert_eq!(events.len(), N, "consumer did not receive all events");
         for (i, event) in events.iter().enumerate() {
@@ -226,7 +226,7 @@ fn fan_out_to_many_consumers() {
 fn dispatcher_is_send_and_can_be_moved_to_thread() {
     let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
-    let consumer = mgr.subscribe::<KeyPressed>();
+    let mut consumer = mgr.subscribe::<KeyPressed>();
 
     let handle = thread::spawn(move || {
         for i in 0..10u32 {
@@ -237,7 +237,7 @@ fn dispatcher_is_send_and_can_be_moved_to_thread() {
     handle.join().expect("thread panicked");
     mgr.dispatch_all();
 
-    let events = collect_all(&consumer);
+    let events = collect_all(&mut consumer);
     assert_eq!(events.len(), 10);
 }
 
@@ -247,14 +247,14 @@ fn dispatcher_is_send_and_can_be_moved_to_thread() {
 fn unit_event_reaches_all_consumers() {
     let mgr = EventManager::new();
     let dispatcher = mgr.register::<ShutdownRequested>();
-    let c1 = mgr.subscribe::<ShutdownRequested>();
-    let c2 = mgr.subscribe::<ShutdownRequested>();
+    let mut c1 = mgr.subscribe::<ShutdownRequested>();
+    let mut c2 = mgr.subscribe::<ShutdownRequested>();
 
     dispatcher.dispatch(ShutdownRequested);
     mgr.dispatch_all();
 
-    assert_eq!(collect_all(&c1).len(), 1);
-    assert_eq!(collect_all(&c2).len(), 1);
+    assert_eq!(collect_all(&mut c1).len(), 1);
+    assert_eq!(collect_all(&mut c2).len(), 1);
 }
 
 // =============================================================================
@@ -275,9 +275,9 @@ fn register_without_subscribe_is_safe() {
 #[test]
 fn subscribe_without_register_yields_empty_consumer() {
     let mgr = EventManager::new();
-    let consumer = mgr.subscribe::<KeyPressed>();
+    let mut consumer = mgr.subscribe::<KeyPressed>();
     mgr.dispatch_all();
-    assert!(collect_all(&consumer).is_empty());
+    assert!(collect_all(&mut consumer).is_empty());
 }
 
 /// Calling dispatch_all repeatedly without any events in between is a no-op.
@@ -285,12 +285,12 @@ fn subscribe_without_register_yields_empty_consumer() {
 fn repeated_dispatch_all_with_no_events() {
     let mgr = EventManager::new();
     let _d = mgr.register::<KeyPressed>();
-    let consumer = mgr.subscribe::<KeyPressed>();
+    let mut consumer = mgr.subscribe::<KeyPressed>();
 
     for _ in 0..100 {
         mgr.dispatch_all();
     }
-    assert!(collect_all(&consumer).is_empty());
+    assert!(collect_all(&mut consumer).is_empty());
 }
 
 /// Consumers that are dropped mid-simulation are silently pruned; remaining
@@ -299,7 +299,7 @@ fn repeated_dispatch_all_with_no_events() {
 fn mid_simulation_consumer_drop_is_handled() {
     let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
-    let alive = mgr.subscribe::<KeyPressed>();
+    let mut alive = mgr.subscribe::<KeyPressed>();
 
     {
         let _dying = mgr.subscribe::<KeyPressed>();
@@ -312,7 +312,7 @@ fn mid_simulation_consumer_drop_is_handled() {
     dispatcher.dispatch(KeyPressed(2));
     mgr.dispatch_all();
 
-    let events: Vec<u32> = collect_all(&alive).into_iter().map(|e| e.0).collect();
+    let events: Vec<u32> = collect_all(&mut alive).into_iter().map(|e| e.0).collect();
     // Both events delivered to `alive` (which was never dropped).
     assert_eq!(events, vec![1, 2]);
 }
@@ -322,11 +322,11 @@ fn mid_simulation_consumer_drop_is_handled() {
 fn consume_all_before_dispatch_all_is_empty() {
     let mgr = EventManager::new();
     let dispatcher = mgr.register::<KeyPressed>();
-    let consumer = mgr.subscribe::<KeyPressed>();
+    let mut consumer = mgr.subscribe::<KeyPressed>();
 
     dispatcher.dispatch(KeyPressed(42));
     // Not yet dispatched.
-    assert!(collect_all(&consumer).is_empty());
+    assert!(collect_all(&mut consumer).is_empty());
 }
 
 /// Verifies that an enum event (NetworkEvent) goes through the full pipeline.
@@ -334,7 +334,7 @@ fn consume_all_before_dispatch_all_is_empty() {
 fn enum_event_round_trips_through_manager() {
     let mgr = EventManager::new();
     let dispatcher = mgr.register::<NetworkEvent>();
-    let consumer = mgr.subscribe::<NetworkEvent>();
+    let mut consumer = mgr.subscribe::<NetworkEvent>();
 
     dispatcher.dispatch(NetworkEvent::Connected {
         host: "example.com".into(),
@@ -344,7 +344,7 @@ fn enum_event_round_trips_through_manager() {
     dispatcher.dispatch(NetworkEvent::Disconnected);
     mgr.dispatch_all();
 
-    let events = collect_all(&consumer);
+    let events = collect_all(&mut consumer);
     assert_eq!(events.len(), 3);
     assert_eq!(events[0].debug(), "connected to example.com:443");
     assert_eq!(events[1].debug(), "packet received: 1024 bytes");

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -573,9 +573,7 @@ impl Renderer {
         for player in self.players.values() {
             let frame = &self.frames[self.current_frame()];
             let Some(window) = self.windows.get_mut(&player.window) else {
-                // TODO: return an error, this needs fixing.
-                // return Err(Error::WindowDoesNotExist(player.window));
-                return Ok(());
+                return Err(Error::WindowDoesNotExist(player.window));
             };
 
             let size = window.extent();
@@ -804,10 +802,6 @@ impl Drop for Renderer {
             self.render_device.device.device_wait_idle().ok();
         }
         info!("cleaning up renderer");
-
-        self.windows.clear();
-        self.frames.iter().for_each(utils::Frame::destroy);
-        self.render_device.flush_all();
     }
 }
 

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -86,8 +86,6 @@ pub struct RendererCreateInfo {
 /// The Renderer struct that holds all render state and is called upon to handle
 /// all rendering operations
 pub struct Renderer {
-    entry: Entry,
-
     // Heavy renderer state:
     /// All of the [`window::Window`]s constructed from [`platform::Window`]s.
     windows: HashMap<WindowId, Window>,
@@ -393,7 +391,7 @@ impl Renderer {
 
         // RENDER DEVICE
         let render_device = RenderDevice::new(
-            &entry,
+            entry.clone(),
             instance.clone(),
             device.clone(),
             physical_device,
@@ -441,11 +439,15 @@ impl Renderer {
 
         let scene_manager = SceneManager::init(&render_device, extent)?;
 
+        // create the first window as we do not receive a create event for it
+        let window = window::Window::build(&render_device, window)?;
+        let mut windows = HashMap::new();
+        windows.insert(window.id(), window);
+
         Ok(Self {
-            entry,
             render_device,
 
-            windows: HashMap::new(),
+            windows,
             scene_manager,
             players: HashMap::new(),
             models,
@@ -512,23 +514,7 @@ impl Renderer {
                         continue;
                     };
 
-                    let surface = unsafe {
-                        ash_window::create_surface(
-                            &self.entry,
-                            &self.render_device.instance,
-                            plat_window.display_handle()?.as_raw(),
-                            plat_window.window_handle()?.as_raw(),
-                            None,
-                        )?
-                    };
-
-                    let window_size = plat_window.size();
-                    let size = vk::Extent2D {
-                        width: window_size.width,
-                        height: window_size.height,
-                    };
-
-                    let window = window::Window::build(plat_window.id(), self, surface, size)?;
+                    let window = window::Window::build(&self.render_device, plat_window)?;
                     self.windows.insert(window.id(), window);
 
                     debug!("created renderer window with id {}", id.into_raw());
@@ -547,19 +533,10 @@ impl Renderer {
         for event in window_events {
             match event {
                 WindowEvent::Resized { id, width, height } => {
-                    let Some(window) = self.windows.get(&id) else {
-                        continue;
-                    };
-                    let surface = window.surface();
-                    let (swapchain, extent, images) = self.create_swap_chain(
-                        surface,
-                        vk::Extent2D { width, height },
-                        window.swapchain(),
-                    )?;
                     let Some(window) = self.windows.get_mut(&id) else {
                         continue;
                     };
-                    window.update_swapcahin(swapchain, extent, images);
+                    window.resize(vk::Extent2D { width, height })?;
                 }
                 WindowEvent::Occluded { id, occluded } => {
                     let Some(window) = self.windows.get_mut(&id) else {
@@ -593,6 +570,7 @@ impl Renderer {
     ///
     /// Vulkan errors can occur during rendering
     pub fn render(&mut self) -> Result<()> {
+        // TODO: is engine is shutting down, window will no longer exist so engine stops with error
         for player in self.players.values() {
             let frame = &self.frames[self.current_frame()];
             let Some(window) = self.windows.get_mut(&player.window) else {
@@ -689,18 +667,15 @@ impl Renderer {
     // WINDOW MANAGEMENT
 
     fn create_swap_chain(
-        &self,
+        device: &RenderDevice,
         surface: vk::SurfaceKHR,
         window_size: vk::Extent2D,
         old_swapchain: vk::SwapchainKHR,
     ) -> Result<(vk::SwapchainKHR, vk::Extent2D, Vec<SwapchainImage>)> {
         let capabilities = unsafe {
-            self.render_device
+            device
                 .surface_loader
-                .get_physical_device_surface_capabilities(
-                    self.render_device.physical_device,
-                    surface,
-                )?
+                .get_physical_device_surface_capabilities(device.physical_device, surface)?
         };
 
         let extent = if capabilities.current_extent.width == u32::MAX {
@@ -723,7 +698,7 @@ impl Renderer {
             image_count = capabilities.max_image_count;
         }
 
-        let indices = &self.render_device.properties.queue_family_indices;
+        let indices = &device.properties.queue_family_indices;
         // Deduplicate — concurrent mode requires unique family indices
         let mut unique_indices: Vec<u32> =
             vec![indices.graphics, indices.present, indices.transfer];
@@ -739,8 +714,8 @@ impl Renderer {
         let create_info = vk::SwapchainCreateInfoKHR::default()
             .surface(surface)
             .min_image_count(image_count)
-            .image_format(self.render_device.properties.surface_format.format)
-            .image_color_space(self.render_device.properties.surface_format.color_space)
+            .image_format(device.properties.surface_format.format)
+            .image_color_space(device.properties.surface_format.color_space)
             .image_extent(extent)
             .image_array_layers(1)
             .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT)
@@ -748,34 +723,26 @@ impl Renderer {
             .queue_family_indices(indices_slice)
             .pre_transform(capabilities.current_transform)
             .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE)
-            .present_mode(self.render_device.properties.present_mode)
+            .present_mode(device.properties.present_mode)
             .clipped(true)
             .old_swapchain(old_swapchain);
 
         let swapchain = unsafe {
-            self.render_device
+            device
                 .swapchain_loader
                 .create_swapchain(&create_info, None)?
         };
-        let images = unsafe {
-            self.render_device
-                .swapchain_loader
-                .get_swapchain_images(swapchain)?
-        };
+        let images = unsafe { device.swapchain_loader.get_swapchain_images(swapchain)? };
 
         let swap_images = images
             .into_iter()
             .map(|image| {
-                SwapchainImage::new(
-                    &self.render_device,
-                    image,
-                    self.render_device.properties.surface_format.format,
-                )
+                SwapchainImage::new(device, image, device.properties.surface_format.format)
             })
             .collect::<Result<Vec<_>>>()?;
 
         unsafe {
-            self.render_device
+            device
                 .swapchain_loader
                 .destroy_swapchain(old_swapchain, None);
         };

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -570,11 +570,12 @@ impl Renderer {
     ///
     /// Vulkan errors can occur during rendering
     pub fn render(&mut self) -> Result<()> {
-        // TODO: is engine is shutting down, window will no longer exist so engine stops with error
         for player in self.players.values() {
             let frame = &self.frames[self.current_frame()];
             let Some(window) = self.windows.get_mut(&player.window) else {
-                return Err(Error::WindowDoesNotExist(player.window));
+                // TODO: return an error, this needs fixing.
+                // return Err(Error::WindowDoesNotExist(player.window));
+                return Ok(());
             };
 
             let size = window.extent();

--- a/crates/dirk_renderer/src/models.rs
+++ b/crates/dirk_renderer/src/models.rs
@@ -346,6 +346,10 @@ impl ModelRegistry {
 
 impl Drop for ModelRegistry {
     fn drop(&mut self) {
+        self.textures.clear();
+        self.meshes.clear();
+        self.materials.clear();
+        self.models.clear();
         unsafe {
             self.device
                 .device

--- a/crates/dirk_renderer/src/proxy/scene.rs
+++ b/crates/dirk_renderer/src/proxy/scene.rs
@@ -253,6 +253,9 @@ impl SceneManager {
 
 impl Drop for SceneManager {
     fn drop(&mut self) {
+        self.scenes.clear();
+        self.entities.clear();
+        self.proxies.clear();
         self.device
             .destroy(Garbage::DescriptorPool(self.descriptor_pool));
     }

--- a/crates/dirk_renderer/src/resources/device.rs
+++ b/crates/dirk_renderer/src/resources/device.rs
@@ -58,7 +58,7 @@ pub struct RenderDeviceInner {
     #[cfg(validation)]
     debug_messenger: vk::DebugUtilsMessengerEXT,
 
-    allocator: Mutex<Allocator>,
+    allocator: Option<Mutex<Allocator>>,
     deletion_queue: Mutex<DeletionQueue>,
     current_frame: Arc<AtomicUsize>,
 }
@@ -161,7 +161,7 @@ impl RenderDevice {
             graphics_pool,
             layouts,
             properties,
-            allocator: Mutex::new(allocator),
+            allocator: Some(Mutex::new(allocator)),
             deletion_queue: Mutex::new(DeletionQueue::new(
                 current_frame.clone(),
                 MAX_FRAMES_IN_FLIGHT,
@@ -179,7 +179,12 @@ impl RenderDevice {
     }
 
     pub fn allocate(&self, desc: &AllocationCreateDesc<'_>) -> Result<Allocation> {
-        Ok(self.allocator.lock().allocate(desc)?)
+        Ok(self
+            .allocator
+            .as_ref()
+            .expect("allocator should exist")
+            .lock()
+            .allocate(desc)?)
     }
 
     pub fn destroy(&mut self, garbage: Garbage) {
@@ -199,7 +204,12 @@ impl RenderDevice {
 
 impl RenderDeviceInner {
     fn free(&self, allocation: Allocation) -> Result<()> {
-        Ok(self.allocator.lock().free(allocation)?)
+        Ok(self
+            .allocator
+            .as_ref()
+            .expect("allocator should exist")
+            .lock()
+            .free(allocation)?)
     }
 }
 
@@ -210,6 +220,7 @@ impl Drop for RenderDeviceInner {
         self.transfer_pool.destroy();
 
         self.deletion_queue.lock().flush_all(self);
+        drop(self.allocator.take());
 
         unsafe {
             self.device.destroy_device(None);

--- a/crates/dirk_renderer/src/resources/device.rs
+++ b/crates/dirk_renderer/src/resources/device.rs
@@ -181,9 +181,6 @@ impl RenderDevice {
     pub fn allocate(&self, desc: &AllocationCreateDesc<'_>) -> Result<Allocation> {
         Ok(self.allocator.lock().allocate(desc)?)
     }
-    pub fn free(&self, allocation: Allocation) -> Result<()> {
-        Ok(self.allocator.lock().free(allocation)?)
-    }
 
     pub fn destroy(&mut self, garbage: Garbage) {
         self.deletion_queue.lock().enqueue(garbage);
@@ -195,30 +192,30 @@ impl RenderDevice {
         queue.flush(self, self.current_frame());
     }
 
-    /// Call once before shutdown to flush the entire queue
-    pub fn flush_all(&self) {
-        let mut queue = self.deletion_queue.lock();
-        queue.flush_all(self);
-    }
-
     pub fn current_frame(&self) -> usize {
         self.current_frame.load(Ordering::Relaxed)
     }
 }
 
+impl RenderDeviceInner {
+    fn free(&self, allocation: Allocation) -> Result<()> {
+        Ok(self.allocator.lock().free(allocation)?)
+    }
+}
+
 impl Drop for RenderDeviceInner {
     fn drop(&mut self) {
-        // TODO: find a way to flush all here
         self.layouts.destroy(&self.device);
         self.graphics_pool.destroy();
         self.transfer_pool.destroy();
+
+        self.deletion_queue.lock().flush_all(self);
+
         unsafe {
-            // TODO: this causes a segfault (idk)
             self.device.destroy_device(None);
             #[cfg(validation)]
             self.debug_utils_loader
                 .destroy_debug_utils_messenger(self.debug_messenger, None);
-
             self.instance.destroy_instance(None);
         }
     }
@@ -246,14 +243,14 @@ struct PendingDeletion {
     death_frame: usize, // frame index after which it's safe to delete
 }
 
-pub struct DeletionQueue {
+struct DeletionQueue {
     pending: Vec<PendingDeletion>,
     current_frame: Arc<AtomicUsize>,
     frames_in_flight: usize,
 }
 
 impl DeletionQueue {
-    pub fn new(current_frame: Arc<AtomicUsize>, frames_in_flight: usize) -> Self {
+    fn new(current_frame: Arc<AtomicUsize>, frames_in_flight: usize) -> Self {
         Self {
             pending: Vec::new(),
             current_frame,
@@ -262,7 +259,7 @@ impl DeletionQueue {
     }
 
     /// Call this when you're done with a resource.
-    pub fn enqueue(&mut self, garbage: Garbage) {
+    fn enqueue(&mut self, garbage: Garbage) {
         self.pending.push(PendingDeletion {
             garbage: Some(garbage),
             death_frame: self.current_frame.load(Ordering::Relaxed) + 2 * self.frames_in_flight, // wait two frames before destroying
@@ -270,7 +267,7 @@ impl DeletionQueue {
     }
 
     /// Call once per frame. Destroys anything safe to destroy.
-    pub fn flush(&mut self, device: &RenderDevice, current_frame: usize) {
+    fn flush(&mut self, device: &RenderDevice, current_frame: usize) {
         self.pending.retain_mut(|item| {
             if current_frame >= item.death_frame {
                 if let Some(garbage) = item.garbage.take() {
@@ -284,7 +281,7 @@ impl DeletionQueue {
     }
 
     /// Call on shutdown — destroys everything regardless of frame.
-    pub fn flush_all(&mut self, device: &RenderDevice) {
+    fn flush_all(&mut self, device: &RenderDeviceInner) {
         for mut item in self.pending.drain(..) {
             if let Some(garbage) = item.garbage.take() {
                 garbage.destroy(device);
@@ -294,7 +291,7 @@ impl DeletionQueue {
 }
 
 impl Garbage {
-    fn destroy(self, render_device: &RenderDevice) {
+    fn destroy(self, render_device: &RenderDeviceInner) {
         let device = &render_device.device;
         unsafe {
             match self {

--- a/crates/dirk_renderer/src/resources/device.rs
+++ b/crates/dirk_renderer/src/resources/device.rs
@@ -40,6 +40,7 @@ pub struct RenderDeviceInner {
     pub swapchain_loader: swapchain::Device,
 
     pub instance: ash::Instance,
+    pub entry: ash::Entry,
     pub physical_device: vk::PhysicalDevice,
     pub queues: Queues,
     /// For single use buffers.
@@ -64,7 +65,7 @@ pub struct RenderDeviceInner {
 
 impl RenderDevice {
     pub fn new(
-        entry: &ash::Entry,
+        entry: ash::Entry,
         instance: ash::Instance,
         device: ash::Device,
         physical_device: vk::PhysicalDevice,
@@ -152,7 +153,7 @@ impl RenderDevice {
 
         Ok(Self(Arc::new(RenderDeviceInner {
             device,
-            surface_loader: surface::Instance::new(entry, &instance),
+            surface_loader: surface::Instance::new(&entry, &instance),
             swapchain_loader,
             physical_device,
             queues,
@@ -168,11 +169,12 @@ impl RenderDevice {
             current_frame,
 
             #[cfg(validation)]
-            debug_utils_loader: debug_utils::Instance::new(entry, &instance),
+            debug_utils_loader: debug_utils::Instance::new(&entry, &instance),
             #[cfg(validation)]
             debug_messenger,
 
             instance,
+            entry,
         })))
     }
 

--- a/crates/dirk_renderer/src/resources/image.rs
+++ b/crates/dirk_renderer/src/resources/image.rs
@@ -186,6 +186,7 @@ impl Image {
         image.generate_mipmaps(&cmd, tex.width, tex.height, mip_levels)?;
         cmd.end_and_submit()?;
 
+        let old_view = image.view;
         image.view = Self::create_image_view(
             device,
             image.image(),
@@ -193,6 +194,9 @@ impl Image {
             vk::ImageAspectFlags::COLOR,
             mip_levels,
         )?;
+        unsafe {
+            device.device.destroy_image_view(old_view, None);
+        }
         let sampler = Renderer::create_sampler(device, mip_levels)?;
 
         Ok(Texture {

--- a/crates/dirk_renderer/src/utils.rs
+++ b/crates/dirk_renderer/src/utils.rs
@@ -64,8 +64,8 @@ pub struct Frame {
     // there is a change in scene count. If not reallocated, reset.
 }
 
-impl Frame {
-    pub fn destroy(&self) {
+impl Drop for Frame {
+    fn drop(&mut self) {
         self.command_pool.destroy();
         unsafe {
             self.device.destroy_fence(self.fence, None);

--- a/crates/dirk_renderer/src/window.rs
+++ b/crates/dirk_renderer/src/window.rs
@@ -1,5 +1,6 @@
 use ash::vk;
 use dirk_platform::WindowId;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 
 use crate::{
     Error, Renderer, Result,
@@ -42,23 +43,29 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn build(
-        id: WindowId,
-        renderer: &Renderer,
-        surface: vk::SurfaceKHR,
-        size: vk::Extent2D,
-    ) -> Result<Self> {
+    pub fn build(device: &RenderDevice, plat_window: &dirk_platform::Window) -> Result<Self> {
+        let surface = unsafe {
+            ash_window::create_surface(
+                &device.entry,
+                &device.instance,
+                plat_window.display_handle()?.as_raw(),
+                plat_window.window_handle()?.as_raw(),
+                None,
+            )?
+        };
+
+        let window_size = plat_window.size();
+        let size = vk::Extent2D {
+            width: window_size.width,
+            height: window_size.height,
+        };
+
         let (swapchain, extent, images) =
-            renderer.create_swap_chain(surface, size, vk::SwapchainKHR::null())?;
+            Renderer::create_swap_chain(device, surface, size, vk::SwapchainKHR::null())?;
 
         let semaphore_info = vk::SemaphoreCreateInfo::default();
         let create_semaphore = || unsafe {
-            Ok::<vk::Semaphore, Error>(
-                renderer
-                    .render_device
-                    .device
-                    .create_semaphore(&semaphore_info, None)?,
-            )
+            Ok::<vk::Semaphore, Error>(device.device.create_semaphore(&semaphore_info, None)?)
         };
 
         let semaphores = (0..images.len())
@@ -66,8 +73,8 @@ impl Window {
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {
-            id,
-            device: renderer.render_device.clone(),
+            id: plat_window.id(),
+            device: device.clone(),
             surface,
             swapchain,
             extent,
@@ -83,12 +90,6 @@ impl Window {
     }
     pub fn extent(&self) -> vk::Extent2D {
         self.extent
-    }
-    pub fn swapchain(&self) -> vk::SwapchainKHR {
-        self.swapchain
-    }
-    pub fn surface(&self) -> vk::SurfaceKHR {
-        self.surface
     }
     pub fn next_image(&mut self) -> Result<RenderImage<'_>> {
         self.semaphore_count = (self.semaphore_count + 1) % self.semaphores.len();
@@ -116,15 +117,13 @@ impl Window {
             render_finished_semaphore,
         })
     }
-    pub fn update_swapcahin(
-        &mut self,
-        swapchain: vk::SwapchainKHR,
-        extent: vk::Extent2D,
-        images: Vec<SwapchainImage>,
-    ) {
+    pub fn resize(&mut self, extent: vk::Extent2D) -> Result<()> {
+        let (swapchain, extent, images) =
+            Renderer::create_swap_chain(&self.device, self.surface, extent, self.swapchain)?;
         self.swapchain = swapchain;
         self.extent = extent;
         self.images = images;
+        Ok(())
     }
     pub fn set_occluded(&mut self, occluded: bool) {
         self.occluded = occluded;

--- a/crates/dirk_renderer/src/window.rs
+++ b/crates/dirk_renderer/src/window.rs
@@ -136,6 +136,7 @@ impl Drop for Window {
             self.device.destroy(Garbage::Semaphore(s1));
             self.device.destroy(Garbage::Semaphore(s2));
         });
+        self.images.clear();
         self.device.destroy(Garbage::Swapchain(self.swapchain));
         self.device.destroy(Garbage::Surface(self.surface));
     }

--- a/crates/dirk_threads/Cargo.toml
+++ b/crates/dirk_threads/Cargo.toml
@@ -13,6 +13,7 @@ documentation.workspace = true
 
 [dependencies]
 tokio.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/dirk_threads/Cargo.toml
+++ b/crates/dirk_threads/Cargo.toml
@@ -12,6 +12,7 @@ authors.workspace = true
 documentation.workspace = true
 
 [dependencies]
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/dirk_threads/Cargo.toml
+++ b/crates/dirk_threads/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dirk_threads"
+description = "DirkEngine multithreading primitives"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+homepage.workspace = true
+authors.workspace = true
+documentation.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/dirk_threads/src/lib.rs
+++ b/crates/dirk_threads/src/lib.rs
@@ -1,0 +1,172 @@
+//! This crate contains DirkEngine's async threading primitives.
+
+use std::{
+    future::Future,
+    num::NonZeroUsize,
+    sync::Arc,
+    thread::{self, JoinHandle},
+};
+
+use tokio::{
+    runtime::{Builder, Handle},
+    sync::{Mutex, oneshot},
+    task::JoinHandle as TaskJoinHandle,
+};
+
+/// A cheap clonable handle to a pool of background worker threads.
+///
+/// The pool owns a dedicated Tokio runtime hosted on a non-game thread. Tasks
+/// spawned through this handle are therefore executed away from the primary
+/// engine thread.
+#[derive(Clone)]
+pub struct WorkerPool {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    handle: Handle,
+    shutdown: Mutex<Option<oneshot::Sender<()>>>,
+    coordinator: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl WorkerPool {
+    /// Creates a pool with the specified thread name prefix.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the runtime cannot be built.
+    #[must_use]
+    pub fn new(name: &str) -> Self {
+        let (handle_tx, handle_rx) = oneshot::channel::<Handle>();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let thread_name = name.to_owned();
+
+        let coordinator = thread::Builder::new()
+            .name(thread_name.clone())
+            .spawn(move || {
+                let runtime = Builder::new_multi_thread()
+                    .worker_threads(default_worker_count().get())
+                    .thread_name(thread_name)
+                    .enable_all()
+                    .build()
+                    .expect("failed to build worker runtime");
+
+                runtime.block_on(async move {
+                    let handle = Handle::current();
+                    handle_tx
+                        .send(handle)
+                        .expect("worker pool handle receiver should be open");
+                    let _ = shutdown_rx.await;
+                });
+            })
+            .expect("failed to spawn worker coordinator thread");
+
+        let handle = handle_rx
+            .blocking_recv()
+            .expect("worker pool runtime should initialize");
+
+        Self {
+            inner: Arc::new(Inner {
+                handle,
+                shutdown: Mutex::new(Some(shutdown_tx)),
+                coordinator: Mutex::new(Some(coordinator)),
+            }),
+        }
+    }
+
+    /// Returns the underlying Tokio runtime handle.
+    #[must_use]
+    pub fn handle(&self) -> &Handle {
+        &self.inner.handle
+    }
+
+    /// Spawns an async task onto the worker pool.
+    pub fn spawn<F>(&self, future: F) -> TaskJoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.inner.handle.spawn(future)
+    }
+
+    /// Spawns a blocking closure onto the worker pool's blocking executor.
+    pub fn spawn_blocking<F, R>(&self, operation: F) -> TaskJoinHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.inner.handle.spawn_blocking(operation)
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.get_mut().take() {
+            let _ = shutdown.send(());
+        }
+
+        if let Some(coordinator) = self.coordinator.get_mut().take() {
+            let _ = coordinator.join();
+        }
+    }
+}
+
+fn default_worker_count() -> NonZeroUsize {
+    thread::available_parallelism()
+        .unwrap_or(NonZeroUsize::MIN)
+        .max(NonZeroUsize::MIN)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        time::Duration,
+    };
+
+    use super::WorkerPool;
+
+    #[test]
+    fn spawned_tasks_run_on_background_threads() {
+        let pool = WorkerPool::new("test");
+        let main_thread = std::thread::current().id();
+        let (tx, rx) = mpsc::channel();
+
+        pool.spawn(async move {
+            tx.send(std::thread::current().id())
+                .expect("receiver should still be alive");
+        });
+
+        let worker_thread = rx.recv().expect("task should complete");
+
+        assert_ne!(worker_thread, main_thread);
+    }
+
+    #[test]
+    fn blocking_tasks_complete() {
+        let pool = WorkerPool::new("test");
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let counter = Arc::clone(&counter);
+            let (tx, rx) = mpsc::channel();
+            pool.spawn_blocking(move || {
+                std::thread::sleep(Duration::from_millis(5));
+                counter.fetch_add(1, Ordering::SeqCst);
+                tx.send(()).expect("receiver should still be alive");
+            });
+            tasks.push(rx);
+        }
+
+        for task in tasks {
+            task.recv().expect("blocking task should complete");
+        }
+
+        assert_eq!(counter.load(Ordering::SeqCst), 8);
+    }
+}

--- a/crates/dirk_threads/src/lib.rs
+++ b/crates/dirk_threads/src/lib.rs
@@ -33,7 +33,7 @@ struct Inner {
 }
 
 impl WorkerPool {
-    /// Creates a pool with the specified thread name prefix.
+    /// Creates a pool with the specified thread name.
     ///
     /// # Panics
     ///

--- a/crates/dirk_threads/src/lib.rs
+++ b/crates/dirk_threads/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate contains DirkEngine's async threading primitives.
+//! This crate contains `DirkEngine`'s async threading primitives.
 
 use std::{
     future::Future,
@@ -12,6 +12,7 @@ use tokio::{
     sync::{Mutex, oneshot},
     task::JoinHandle as TaskJoinHandle,
 };
+use tracing::info;
 
 /// A cheap clonable handle to a pool of background worker threads.
 ///
@@ -25,6 +26,8 @@ pub struct WorkerPool {
 
 struct Inner {
     handle: Handle,
+    /// Stored as an [`Option`] as the sender is consumed when sending
+    /// shutdown message.
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
     coordinator: Mutex<Option<JoinHandle<()>>>,
 }
@@ -46,17 +49,19 @@ impl WorkerPool {
             .spawn(move || {
                 let runtime = Builder::new_multi_thread()
                     .worker_threads(default_worker_count().get())
-                    .thread_name(thread_name)
+                    .thread_name(thread_name.clone())
                     .enable_all()
                     .build()
                     .expect("failed to build worker runtime");
 
                 runtime.block_on(async move {
+                    info!("starting worker pool: {thread_name}");
                     let handle = Handle::current();
                     handle_tx
                         .send(handle)
                         .expect("worker pool handle receiver should be open");
                     let _ = shutdown_rx.await;
+                    info!("shutdown worker pool {thread_name}");
                 });
             })
             .expect("failed to spawn worker coordinator thread");

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -36,6 +36,7 @@ impl ExitState {
 /// This is the main struct that holds global engine state.
 pub struct Engine {
     exit_consumer: dirk_events::Consumer<dirk_events::AppExit>,
+    exit_dispatcher: dirk_events::Dispatcher<dirk_events::Exiting>,
     frame_dispatcher: dirk_events::Dispatcher<dirk_events::BeginFrame>,
     event_manager: dirk_events::EventManager,
 
@@ -108,6 +109,7 @@ impl Engine {
         info!("engine initialised");
         Ok(Self {
             exit_consumer: event_manager.subscribe(),
+            exit_dispatcher: event_manager.register(),
             frame_dispatcher: event_manager.register(),
             event_manager,
             logger,
@@ -212,6 +214,10 @@ impl Engine {
             Some(err) => ExitState::Error(err),
             None => ExitState::Requested,
         };
+
+        if self.exit_state.exiting() {
+            self.exit_dispatcher.dispatch(dirk_events::Exiting);
+        }
     }
     /// Returns the exit error
     pub fn exit_state(&self) -> &ExitState {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -165,7 +165,6 @@ impl Engine {
             .dispatch(dirk_events::BeginFrame(self.frame));
 
         let delta_time = self.capture_delta_time();
-        self.event_manager.dispatch_all();
 
         // TODO: renders too fast and semaphores have problem.
         // remove when rendering takes longer

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,6 +4,7 @@
 use std::{collections::HashMap, ffi::CString, str::FromStr, time::Instant};
 
 use anyhow::Context;
+use dirk_threads::WorkerPool;
 use dirk_universe::{Entity, Universe, World, WorldId};
 use dirk_world::player::{Player, PlayerId};
 use tracing::info;
@@ -38,23 +39,25 @@ pub struct Engine {
     frame_dispatcher: dirk_events::Dispatcher<dirk_events::BeginFrame>,
     event_manager: dirk_events::EventManager,
 
+    /// This is a thread pool use by various engine systems for async tasks.
+    #[allow(unused)]
+    workers: WorkerPool,
+    #[allow(unused)]
+    logger: Logger,
+
     frame: u64,
     last_tick: Instant,
-
-    #[allow(unused)]
-    asset_registry: dirk_assets::AssetRegistry,
 
     renderer: dirk_renderer::Renderer,
     platform: dirk_platform::Platform,
     universe: dirk_universe::Universe,
+    #[allow(unused)]
+    asset_registry: dirk_assets::AssetRegistry,
 
     next_player_id: PlayerId,
     players: HashMap<PlayerId, Player>,
 
     exit_state: ExitState,
-
-    #[allow(unused)]
-    logger: Logger,
 }
 
 impl Engine {
@@ -75,7 +78,9 @@ impl Engine {
             .init()
             .context("initialising logger")?;
 
-        let event_manager = dirk_events::EventManager::new();
+        let workers = WorkerPool::new("dirk-workers");
+
+        let event_manager = dirk_events::EventManager::new(workers.clone());
         let asset_registry = dirk_assets::AssetRegistry::init(&event_manager)
             .context("initialising asset registry")?;
 
@@ -107,6 +112,7 @@ impl Engine {
             event_manager,
             logger,
             asset_registry,
+            workers,
 
             frame: 0,
             last_tick: Instant::now(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -187,12 +187,8 @@ impl Engine {
             .values_mut()
             .for_each(|player| player.tick(&mut self.universe));
 
-        self.render().context("rendering")?;
+        self.renderer.render().context("rendering")?;
         Ok(())
-    }
-
-    fn render(&mut self) -> anyhow::Result<()> {
-        Ok(self.renderer.render()?)
     }
 
     fn process_events(&mut self) {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -178,6 +178,16 @@ impl Engine {
         }
 
         self.platform.tick(delta_time);
+        if self.platform.windows().is_empty() {
+            self.exit(None);
+            return Ok(());
+        }
+
+        self.process_events();
+        if self.is_requesting_exit() {
+            return Ok(());
+        }
+
         self.universe.tick(delta_time);
         self.asset_registry.tick();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,5 @@ pub use dirk_universe as universe;
 pub use dirk_utils as utils;
 #[doc(inline)]
 pub use dirk_world as world;
+#[doc(inline)]
+pub use dirk_threads as threads;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,10 @@ pub use dirk_platform as platform;
 #[doc(inline)]
 pub use dirk_renderer as renderer;
 #[doc(inline)]
+pub use dirk_threads as threads;
+#[doc(inline)]
 pub use dirk_universe as universe;
 #[doc(inline)]
 pub use dirk_utils as utils;
 #[doc(inline)]
 pub use dirk_world as world;
-#[doc(inline)]
-pub use dirk_threads as threads;


### PR DESCRIPTION
## Summary

This PR moves DirkEngine’s event routing onto a dedicated worker pool and introduces a new `dirk_threads` crate to host the runtime.

### What changed
- Added `dirk_threads::WorkerPool` as a reusable Tokio runtime for background tasks.
- Reworked `dirk_events` so dispatchers enqueue work to background routers instead of relying on `dispatch_all()`.
- Updated `Consumer` polling APIs to use `&mut self` and added blocking/async consumption helpers.
- Moved shared event types like `AppExit`, `Exiting`, and `BeginFrame` into `dirk_events::common`.
- Wired the engine, platform, assets, renderer, and world systems to the new event API.
- Adjusted renderer/device/window ownership and shutdown cleanup to match the new threading model.
- Updated docs and tests throughout the workspace for the new event flow.

## TODO

- [x] Add the async runtime to Engine
- [x] Have the `EventManager`spawn tasks for when producers are added
- [x] Graceful shutdown when main window is closed and renderer no longer has window
- [x] Publish `dirk_threads`