### PR TITLE
refactor renderer to use command buffer wrappers

### DIFF
--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -602,11 +602,7 @@ impl Renderer {
 
             let cmd = frame.command_pool.allocate_buffer()?;
 
-            unsafe {
-                self.render_device
-                    .device
-                    .begin_command_buffer(cmd.raw(), &vk::CommandBufferBeginInfo::default())?;
-            }
+            cmd.begin_command_buffer(&vk::CommandBufferBeginInfo::default())?;
 
             render_image.image.transition_image_layout(
                 &cmd,
@@ -629,7 +625,7 @@ impl Renderer {
                 vk::ImageLayout::PRESENT_SRC_KHR,
             )?;
 
-            unsafe { self.render_device.device.end_command_buffer(cmd.raw())? }
+            cmd.end_command_buffer()?;
 
             let submit_info = vk::SubmitInfo::default()
                 .wait_dst_stage_mask(std::slice::from_ref(

--- a/crates/dirk_renderer/src/models.rs
+++ b/crates/dirk_renderer/src/models.rs
@@ -172,31 +172,16 @@ impl ModelRegistry {
 
             descriptor_sets[2] = mat_set;
 
-            unsafe {
-                self.device.device.cmd_bind_descriptor_sets(
-                    cmd.raw(),
-                    vk::PipelineBindPoint::GRAPHICS,
-                    pipeline_layout,
-                    0,
-                    &descriptor_sets,
-                    &[],
-                );
-                self.device.device.cmd_bind_vertex_buffers(
-                    cmd.raw(),
-                    0,
-                    &[prim.vertex_buffer.buffer()],
-                    &[0],
-                );
-                self.device.device.cmd_bind_index_buffer(
-                    cmd.raw(),
-                    prim.index_buffer.buffer(),
-                    0,
-                    vk::IndexType::UINT32,
-                );
-                self.device
-                    .device
-                    .cmd_draw_indexed(cmd.raw(), prim.index_count, 1, 0, 0, 0);
-            }
+            cmd.bind_descriptor_sets(
+                vk::PipelineBindPoint::GRAPHICS,
+                pipeline_layout,
+                0,
+                &descriptor_sets,
+                &[],
+            );
+            cmd.bind_vertex_buffers(0, &[prim.vertex_buffer.buffer()], &[0]);
+            cmd.bind_index_buffer(prim.index_buffer.buffer(), 0, vk::IndexType::UINT32);
+            cmd.draw_indexed(prim.index_count, 1, 0, 0, 0);
         }
         Ok(())
     }

--- a/crates/dirk_renderer/src/pipeline.rs
+++ b/crates/dirk_renderer/src/pipeline.rs
@@ -127,13 +127,7 @@ impl GraphicsPipeline {
         })
     }
     pub fn bind(&self, cmd: &CommandBuffer) {
-        unsafe {
-            self.device.device.cmd_bind_pipeline(
-                cmd.raw(),
-                vk::PipelineBindPoint::GRAPHICS,
-                self.pipeline,
-            );
-        }
+        cmd.bind_pipeline(vk::PipelineBindPoint::GRAPHICS, self.pipeline);
     }
     pub fn layout(&self) -> vk::PipelineLayout {
         self.pipeline_layout

--- a/crates/dirk_renderer/src/proxy/scene.rs
+++ b/crates/dirk_renderer/src/proxy/scene.rs
@@ -152,14 +152,7 @@ impl SceneManager {
             proxy.write_ubo(frame);
         }
 
-        RenderPass::begin(
-            &self.device.device,
-            cmd,
-            size,
-            view,
-            &self.color,
-            &self.depth,
-        );
+        RenderPass::begin(cmd, size, view, &self.color, &self.depth);
         self.graphics_pipeline.bind(cmd);
 
         // the window size never gets anywhere near 2^23
@@ -169,16 +162,12 @@ impl SceneManager {
             .height(size.height as f32)
             .min_depth(0.)
             .max_depth(1.);
-        unsafe {
-            self.device
-                .device
-                .cmd_set_viewport(cmd.raw(), 0, &[viewport]);
-        };
+        cmd.set_viewport(0, &[viewport]);
 
         let scissor = vk::Rect2D::default()
             .offset(vk::Offset2D::default())
             .extent(size);
-        unsafe { self.device.device.cmd_set_scissor(cmd.raw(), 0, &[scissor]) };
+        cmd.set_scissor(0, &[scissor]);
 
         for proxy in &proxies {
             let Some(ref model) = proxy.model else {
@@ -197,7 +186,7 @@ impl SceneManager {
             }
         }
 
-        RenderPass::end(&self.device.device, cmd);
+        RenderPass::end(cmd);
         Ok(())
     }
     pub fn create_scene(&mut self, world: WorldId) -> Result<()> {

--- a/crates/dirk_renderer/src/render_pass.rs
+++ b/crates/dirk_renderer/src/render_pass.rs
@@ -1,4 +1,4 @@
-use ash::{Device, vk};
+use ash::vk;
 
 use crate::resources::{command_pool::CommandBuffer, image::Image};
 
@@ -9,7 +9,6 @@ pub struct RenderPass {}
 
 impl RenderPass {
     pub fn begin(
-        device: &Device,
         cmd: &CommandBuffer,
         size: vk::Extent2D,
         out: vk::ImageView,
@@ -51,9 +50,9 @@ impl RenderPass {
             .depth_attachment(&depth_info)
             .layer_count(1);
 
-        unsafe { device.cmd_begin_rendering(cmd.raw(), &rendering_info) };
+        cmd.begin_rendering(&rendering_info);
     }
-    pub fn end(device: &Device, cmd: &CommandBuffer) {
-        unsafe { device.cmd_end_rendering(cmd.raw()) }
+    pub fn end(cmd: &CommandBuffer) {
+        cmd.end_rendering();
     }
 }

--- a/crates/dirk_renderer/src/resources/buffer.rs
+++ b/crates/dirk_renderer/src/resources/buffer.rs
@@ -138,11 +138,7 @@ impl<Type: BuffType> Buffer<Type> {
             dst_offset: 0,
             size,
         };
-        unsafe {
-            self.device
-                .device
-                .cmd_copy_buffer(cmd.raw(), src.buffer(), self.buffer(), &[region]);
-        };
+        cmd.copy_buffer(src.buffer(), self.buffer(), &[region]);
 
         cmd.end_and_submit()?;
         Ok(())

--- a/crates/dirk_renderer/src/resources/command_pool.rs
+++ b/crates/dirk_renderer/src/resources/command_pool.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, ops::Deref};
 
-use ash::{Device, vk};
+use ash::{Device, prelude::VkResult, vk};
 
 use crate::{Queues, Result, physical_device::QueueFamilyIndices};
 
@@ -103,7 +103,7 @@ impl<Type: Pool> CommandPool<Type> {
         let begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
 
-        unsafe { self.device.begin_command_buffer(buff.raw(), &begin_info)? };
+        buff.begin_command_buffer(&begin_info)?;
         Ok(buff)
     }
 }
@@ -118,17 +118,181 @@ pub struct CommandBuffer {
 }
 
 impl CommandBuffer {
-    pub fn raw(&self) -> vk::CommandBuffer {
-        self.buff
+    pub fn begin_command_buffer(
+        &self,
+        begin_info: &vk::CommandBufferBeginInfo<'_>,
+    ) -> VkResult<()> {
+        unsafe { self.device.begin_command_buffer(self.buff, begin_info) }
     }
-    pub fn submit(&self, submit_info: vk::SubmitInfo, fence: vk::Fence) -> Result<()> {
+    pub fn end_command_buffer(&self) -> VkResult<()> {
+        unsafe { self.device.end_command_buffer(self.buff) }
+    }
+    pub fn bind_pipeline(&self, bind_point: vk::PipelineBindPoint, pipeline: vk::Pipeline) {
         unsafe {
             self.device
-                .queue_submit(self.queue, std::slice::from_ref(&submit_info), fence)?;
-        };
-        Ok(())
+                .cmd_bind_pipeline(self.buff, bind_point, pipeline);
+        }
     }
-    pub fn end_and_submit(&self) -> Result<()> {
+    pub fn begin_rendering(&self, rendering_info: &vk::RenderingInfo<'_>) {
+        unsafe {
+            self.device.cmd_begin_rendering(self.buff, rendering_info);
+        }
+    }
+    pub fn end_rendering(&self) {
+        unsafe {
+            self.device.cmd_end_rendering(self.buff);
+        }
+    }
+    pub fn set_viewport(&self, first_viewport: u32, viewports: &[vk::Viewport]) {
+        unsafe {
+            self.device
+                .cmd_set_viewport(self.buff, first_viewport, viewports);
+        }
+    }
+    pub fn set_scissor(&self, first_scissor: u32, scissors: &[vk::Rect2D]) {
+        unsafe {
+            self.device
+                .cmd_set_scissor(self.buff, first_scissor, scissors);
+        }
+    }
+    pub fn bind_descriptor_sets(
+        &self,
+        bind_point: vk::PipelineBindPoint,
+        layout: vk::PipelineLayout,
+        first_set: u32,
+        descriptor_sets: &[vk::DescriptorSet],
+        dynamic_offsets: &[u32],
+    ) {
+        unsafe {
+            self.device.cmd_bind_descriptor_sets(
+                self.buff,
+                bind_point,
+                layout,
+                first_set,
+                descriptor_sets,
+                dynamic_offsets,
+            );
+        }
+    }
+    pub fn bind_vertex_buffers(
+        &self,
+        first_binding: u32,
+        buffers: &[vk::Buffer],
+        offsets: &[vk::DeviceSize],
+    ) {
+        unsafe {
+            self.device
+                .cmd_bind_vertex_buffers(self.buff, first_binding, buffers, offsets);
+        }
+    }
+    pub fn bind_index_buffer(
+        &self,
+        buffer: vk::Buffer,
+        offset: vk::DeviceSize,
+        index_type: vk::IndexType,
+    ) {
+        unsafe {
+            self.device
+                .cmd_bind_index_buffer(self.buff, buffer, offset, index_type);
+        }
+    }
+    pub fn draw_indexed(
+        &self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        vertex_offset: i32,
+        first_instance: u32,
+    ) {
+        unsafe {
+            self.device.cmd_draw_indexed(
+                self.buff,
+                index_count,
+                instance_count,
+                first_index,
+                vertex_offset,
+                first_instance,
+            );
+        }
+    }
+    pub fn copy_buffer_to_image(
+        &self,
+        src_buffer: vk::Buffer,
+        dst_image: vk::Image,
+        dst_image_layout: vk::ImageLayout,
+        regions: &[vk::BufferImageCopy],
+    ) {
+        unsafe {
+            self.device.cmd_copy_buffer_to_image(
+                self.buff,
+                src_buffer,
+                dst_image,
+                dst_image_layout,
+                regions,
+            );
+        }
+    }
+    pub fn pipeline_barrier(
+        &self,
+        src_stage_mask: vk::PipelineStageFlags,
+        dst_stage_mask: vk::PipelineStageFlags,
+        dependency_flags: vk::DependencyFlags,
+        memory_barriers: &[vk::MemoryBarrier<'_>],
+        buffer_memory_barriers: &[vk::BufferMemoryBarrier<'_>],
+        image_memory_barriers: &[vk::ImageMemoryBarrier<'_>],
+    ) {
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                self.buff,
+                src_stage_mask,
+                dst_stage_mask,
+                dependency_flags,
+                memory_barriers,
+                buffer_memory_barriers,
+                image_memory_barriers,
+            );
+        }
+    }
+    pub fn blit_image(
+        &self,
+        src_image: vk::Image,
+        src_image_layout: vk::ImageLayout,
+        dst_image: vk::Image,
+        dst_image_layout: vk::ImageLayout,
+        regions: &[vk::ImageBlit],
+        filter: vk::Filter,
+    ) {
+        unsafe {
+            self.device.cmd_blit_image(
+                self.buff,
+                src_image,
+                src_image_layout,
+                dst_image,
+                dst_image_layout,
+                regions,
+                filter,
+            );
+        }
+    }
+    pub fn copy_buffer(
+        &self,
+        src_buffer: vk::Buffer,
+        dst_buffer: vk::Buffer,
+        regions: &[vk::BufferCopy],
+    ) {
+        unsafe {
+            self.device
+                .cmd_copy_buffer(self.buff, src_buffer, dst_buffer, regions);
+        }
+    }
+
+    pub fn submit(&self, submit_info: vk::SubmitInfo, fence: vk::Fence) -> VkResult<()> {
+        unsafe {
+            self.device
+                .queue_submit(self.queue, std::slice::from_ref(&submit_info), fence)
+        }
+    }
+    pub fn end_and_submit(&self) -> VkResult<()> {
         let info = vk::SubmitInfo::default().command_buffers(std::slice::from_ref(&self.buff));
         unsafe {
             self.device.end_command_buffer(self.buff)?;

--- a/crates/dirk_renderer/src/resources/image.rs
+++ b/crates/dirk_renderer/src/resources/image.rs
@@ -172,15 +172,12 @@ impl Image {
                 depth: 1,
             });
 
-        unsafe {
-            device.device.cmd_copy_buffer_to_image(
-                cmd.raw(),
-                staging_buf.buffer(),
-                image.image(),
-                vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-                &[region],
-            );
-        }
+        cmd.copy_buffer_to_image(
+            staging_buf.buffer(),
+            image.image(),
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            &[region],
+        );
 
         // TODO: start in transfer queue, swap to graphics and then go back
         image.generate_mipmaps(&cmd, tex.width, tex.height, mip_levels)?;

--- a/crates/dirk_renderer/src/resources/image/layouts.rs
+++ b/crates/dirk_renderer/src/resources/image/layouts.rs
@@ -33,17 +33,14 @@ impl Image {
                 layer_count: 1,
             });
 
-        unsafe {
-            self.device.device.cmd_pipeline_barrier(
-                cmd.raw(),
-                src_stage,
-                dst_stage,
-                vk::DependencyFlags::empty(),
-                &[],
-                &[],
-                &[barrier],
-            );
-        };
+        cmd.pipeline_barrier(
+            src_stage,
+            dst_stage,
+            vk::DependencyFlags::empty(),
+            &[],
+            &[],
+            &[barrier],
+        );
         Ok(())
     }
 

--- a/crates/dirk_renderer/src/resources/image/mips.rs
+++ b/crates/dirk_renderer/src/resources/image/mips.rs
@@ -67,17 +67,14 @@ impl Image {
                     },
                 ]);
 
-            unsafe {
-                self.device.device.cmd_blit_image(
-                    cmd.raw(),
-                    self.image(),
-                    vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
-                    self.image(),
-                    vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-                    &[blit],
-                    vk::Filter::LINEAR,
-                );
-            }
+            cmd.blit_image(
+                self.image(),
+                vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+                self.image(),
+                vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+                &[blit],
+                vk::Filter::LINEAR,
+            );
 
             // Previous level is fully consumed — transition to shader-readable
             self.transition_image_layout(


### PR DESCRIPTION
## Summary
- Added safe `CommandBuffer` wrapper methods for common Vulkan command buffer operations, including begin/end, pipeline binding, rendering, viewport/scissor state, draws, copies, barriers, and blits.
- Updated renderer, scene, model, buffer, and image code to call the new wrapper methods instead of reaching through `ash::Device` with raw command buffer handles.
- Simplified render-pass helpers to operate directly on `CommandBuffer`.