### PR TITLE
feat: safe vulkan queue abstraction

### DIFF
--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -31,7 +31,7 @@ use dirk_universe::{Universe, UniverseBuilder};
 
 mod utils;
 use dirk_utils::Version;
-use utils::{DescriptorLayouts, Frame, Queues, RendererProperties, Vertex, make_version};
+use utils::{DescriptorLayouts, Frame, RendererProperties, Vertex, make_version};
 
 mod errors;
 pub use errors::{Error, Result};
@@ -53,7 +53,7 @@ use proxy::{
 mod render_commands;
 use render_commands::RenderCommandReceiver;
 
-use crate::proxy::PlayerProxy;
+use crate::{proxy::PlayerProxy, resources::queues::QueueType};
 
 mod models;
 mod physical_device;
@@ -406,7 +406,6 @@ impl Renderer {
         let build_frame = || -> Result<Frame> {
             let command_pool = CommandPool::build(
                 &device,
-                &render_device.queues,
                 &render_device.properties.queue_family_indices,
                 vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER,
             )?;
@@ -639,13 +638,11 @@ impl Renderer {
                     &render_image.render_finished_semaphore,
                 ));
 
-            unsafe {
-                self.render_device.device.queue_submit(
-                    self.render_device.queues.graphics,
-                    std::slice::from_ref(&submit_info),
-                    frame.fence,
-                )?;
-            }
+            self.render_device.queues.submit(
+                QueueType::Graphics,
+                std::slice::from_ref(&submit_info),
+                frame.fence,
+            )?;
 
             let present_info = vk::PresentInfoKHR::default()
                 .wait_semaphores(std::slice::from_ref(
@@ -654,11 +651,7 @@ impl Renderer {
                 .swapchains(std::slice::from_ref(&render_image.swapchain))
                 .image_indices(std::slice::from_ref(&render_image.image_index));
 
-            unsafe {
-                self.render_device
-                    .swapchain_loader
-                    .queue_present(self.render_device.queues.present, &present_info)?
-            };
+            self.render_device.queues.present(&present_info)?;
 
             self.current_frame.store(
                 (self.current_frame() + 1) % MAX_FRAMES_IN_FLIGHT,

--- a/crates/dirk_renderer/src/resources.rs
+++ b/crates/dirk_renderer/src/resources.rs
@@ -2,3 +2,4 @@ pub mod buffer;
 pub mod command_pool;
 pub mod device;
 pub mod image;
+pub mod queues;

--- a/crates/dirk_renderer/src/resources/buffer.rs
+++ b/crates/dirk_renderer/src/resources/buffer.rs
@@ -140,7 +140,7 @@ impl<Type: BuffType> Buffer<Type> {
         };
         cmd.copy_buffer(src.buffer(), self.buffer(), &[region]);
 
-        cmd.end_and_submit()?;
+        cmd.end_and_submit(&self.device.queues)?;
         Ok(())
     }
 }

--- a/crates/dirk_renderer/src/resources/command_pool.rs
+++ b/crates/dirk_renderer/src/resources/command_pool.rs
@@ -2,7 +2,11 @@ use std::{marker::PhantomData, ops::Deref};
 
 use ash::{Device, prelude::VkResult, vk};
 
-use crate::{Queues, Result, physical_device::QueueFamilyIndices};
+use crate::{
+    Result,
+    physical_device::QueueFamilyIndices,
+    resources::queues::{QueueType, Queues},
+};
 
 #[derive(Debug)]
 pub struct Graphics;
@@ -17,22 +21,22 @@ pub struct CommandPool<Type: Pool> {
     device: Device,
     /// The command pool
     pool: vk::CommandPool,
-    /// The queue commands will be submitted to
-    queue: vk::Queue,
+    /// The type of queue commands will be submitted to
+    queue_type: QueueType,
     pool_type: PhantomData<Type>,
 }
 
 pub trait Pool {
     fn get_index(families: &QueueFamilyIndices) -> u32;
-    fn get_queue(queues: &Queues) -> vk::Queue;
+    fn get_queue_type() -> QueueType;
 }
 
 impl Pool for Compute {
     fn get_index(families: &QueueFamilyIndices) -> u32 {
         families.compute
     }
-    fn get_queue(queues: &Queues) -> vk::Queue {
-        queues.compute
+    fn get_queue_type() -> QueueType {
+        QueueType::Compute
     }
 }
 
@@ -40,8 +44,8 @@ impl Pool for Transfer {
     fn get_index(families: &QueueFamilyIndices) -> u32 {
         families.transfer
     }
-    fn get_queue(queues: &Queues) -> vk::Queue {
-        queues.transfer
+    fn get_queue_type() -> QueueType {
+        QueueType::Transfer
     }
 }
 
@@ -49,8 +53,8 @@ impl Pool for Graphics {
     fn get_index(families: &QueueFamilyIndices) -> u32 {
         families.graphics
     }
-    fn get_queue(queues: &Queues) -> vk::Queue {
-        queues.graphics
+    fn get_queue_type() -> QueueType {
+        QueueType::Graphics
     }
 }
 
@@ -58,12 +62,11 @@ impl<Type: Pool> CommandPool<Type> {
     /// Will build a command pool with the specified settings.
     pub fn build(
         device: &Device,
-        queues: &Queues,
         families: &QueueFamilyIndices,
         flags: vk::CommandPoolCreateFlags,
     ) -> Result<Self> {
         let index = Type::get_index(families);
-        let queue = Type::get_queue(queues);
+        let queue_type = Type::get_queue_type();
 
         let info = vk::CommandPoolCreateInfo::default()
             .flags(flags)
@@ -74,7 +77,7 @@ impl<Type: Pool> CommandPool<Type> {
         Ok(Self {
             device: device.clone(),
             pool,
-            queue,
+            queue_type,
             pool_type: PhantomData,
         })
     }
@@ -93,7 +96,7 @@ impl<Type: Pool> CommandPool<Type> {
         Ok(CommandBuffer {
             device: self.device.clone(),
             buff,
-            queue: self.queue,
+            queue_type: self.queue_type,
         })
     }
 
@@ -113,8 +116,8 @@ pub struct CommandBuffer {
     device: Device,
     /// The buffer
     buff: vk::CommandBuffer,
-    /// The queue to submit to
-    queue: vk::Queue,
+    /// The type of queue to submit to
+    queue_type: QueueType,
 }
 
 impl CommandBuffer {
@@ -286,18 +289,20 @@ impl CommandBuffer {
         }
     }
 
-    pub fn submit(&self, submit_info: vk::SubmitInfo, fence: vk::Fence) -> VkResult<()> {
-        unsafe {
-            self.device
-                .queue_submit(self.queue, std::slice::from_ref(&submit_info), fence)
-        }
+    pub fn submit(
+        &self,
+        queues: &Queues,
+        submit_info: vk::SubmitInfo,
+        fence: vk::Fence,
+    ) -> VkResult<()> {
+        queues.submit(self.queue_type, std::slice::from_ref(&submit_info), fence)
     }
-    pub fn end_and_submit(&self) -> VkResult<()> {
+    pub fn end_and_submit(&self, queues: &Queues) -> VkResult<()> {
         let info = vk::SubmitInfo::default().command_buffers(std::slice::from_ref(&self.buff));
         unsafe {
             self.device.end_command_buffer(self.buff)?;
         };
-        self.submit(info, vk::Fence::null())
+        self.submit(queues, info, vk::Fence::null())
     }
 }
 

--- a/crates/dirk_renderer/src/resources/device.rs
+++ b/crates/dirk_renderer/src/resources/device.rs
@@ -19,8 +19,11 @@ use gpu_allocator::{
 use parking_lot::Mutex;
 
 use crate::{
-    DescriptorLayouts, MAX_FRAMES_IN_FLIGHT, Queues, RendererProperties, Result,
-    resources::command_pool::{CommandPool, Graphics, Transfer},
+    DescriptorLayouts, MAX_FRAMES_IN_FLIGHT, RendererProperties, Result,
+    resources::{
+        command_pool::{CommandPool, Graphics, Transfer},
+        queues::Queues,
+    },
 };
 
 /// The device that stores all vulkan objects.
@@ -127,26 +130,16 @@ impl RenderDevice {
         };
 
         // QUEUES
-        let queues = {
-            let indices = &properties.queue_family_indices;
-            Queues {
-                graphics: unsafe { device.get_device_queue(indices.graphics, 0) },
-                present: unsafe { device.get_device_queue(indices.present, 0) },
-                compute: unsafe { device.get_device_queue(indices.compute, 0) },
-                transfer: unsafe { device.get_device_queue(indices.transfer, 0) },
-            }
-        };
+        let queues = Queues::new(&instance, &device, &properties.queue_family_indices);
 
         // COMMAND POOLS
         let transfer_pool = CommandPool::build(
             &device,
-            &queues,
             &properties.queue_family_indices,
             vk::CommandPoolCreateFlags::TRANSIENT,
         )?;
         let graphics_pool = CommandPool::build(
             &device,
-            &queues,
             &properties.queue_family_indices,
             vk::CommandPoolCreateFlags::TRANSIENT,
         )?;

--- a/crates/dirk_renderer/src/resources/image.rs
+++ b/crates/dirk_renderer/src/resources/image.rs
@@ -181,7 +181,7 @@ impl Image {
 
         // TODO: start in transfer queue, swap to graphics and then go back
         image.generate_mipmaps(&cmd, tex.width, tex.height, mip_levels)?;
-        cmd.end_and_submit()?;
+        cmd.end_and_submit(&device.queues)?;
 
         let old_view = image.view;
         image.view = Self::create_image_view(

--- a/crates/dirk_renderer/src/resources/queues.rs
+++ b/crates/dirk_renderer/src/resources/queues.rs
@@ -1,0 +1,53 @@
+//! This module holds a safe abstraction to the [`vk::Queue`]s used by the renderer.
+
+use ash::{Device, Instance, khr::swapchain, prelude::VkResult, vk};
+
+use crate::physical_device::QueueFamilyIndices;
+
+/// The type of queue you would like to submit to.
+#[derive(Copy, Clone)]
+pub enum QueueType {
+    Graphics,
+    Transfer,
+    Compute,
+}
+
+pub struct Queues {
+    device: Device,
+    swapchain_loader: swapchain::Device,
+    graphics: vk::Queue,
+    compute: vk::Queue,
+    transfer: vk::Queue,
+    present: vk::Queue,
+}
+
+impl Queues {
+    pub fn new(instance: &Instance, device: &Device, indices: &QueueFamilyIndices) -> Self {
+        Self {
+            device: device.clone(),
+            swapchain_loader: swapchain::Device::new(instance, device),
+            graphics: unsafe { device.get_device_queue(indices.graphics, 0) },
+            present: unsafe { device.get_device_queue(indices.present, 0) },
+            compute: unsafe { device.get_device_queue(indices.compute, 0) },
+            transfer: unsafe { device.get_device_queue(indices.transfer, 0) },
+        }
+    }
+
+    pub fn submit(
+        &self,
+        queue_type: QueueType,
+        submits: &[vk::SubmitInfo],
+        fence: vk::Fence,
+    ) -> VkResult<()> {
+        let queue = match queue_type {
+            QueueType::Compute => self.compute,
+            QueueType::Graphics => self.graphics,
+            QueueType::Transfer => self.transfer,
+        };
+        unsafe { self.device.queue_submit(queue, submits, fence) }
+    }
+
+    pub fn present(&self, info: &vk::PresentInfoKHR) -> VkResult<bool> {
+        unsafe { self.swapchain_loader.queue_present(self.present, info) }
+    }
+}

--- a/crates/dirk_renderer/src/utils.rs
+++ b/crates/dirk_renderer/src/utils.rs
@@ -99,13 +99,6 @@ impl DescriptorLayouts {
     }
 }
 
-pub struct Queues {
-    pub graphics: vk::Queue,
-    pub compute: vk::Queue,
-    pub transfer: vk::Queue,
-    pub present: vk::Queue,
-}
-
 pub struct RendererProperties {
     pub msaa_samples: vk::SampleCountFlags,
     #[allow(unused)]


### PR DESCRIPTION
The `Queues` object now has private methods for submitting directly without having to use unsafe code in the engine.