### PR TITLE
refactor swapchain handling into dedicated resource

### DIFF
--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -40,7 +40,7 @@ mod window;
 use window::Window;
 
 mod resources;
-use resources::{command_pool::CommandPool, device::RenderDevice, image::SwapchainImage};
+use resources::{command_pool::CommandPool, device::RenderDevice};
 
 mod proxy;
 use proxy::{
@@ -626,17 +626,15 @@ impl Renderer {
 
             cmd.end_command_buffer()?;
 
+            let image_available_semaphore = render_image.image_available_semaphore;
+            let render_finished_semaphore = render_image.render_finished_semaphore;
             let submit_info = vk::SubmitInfo::default()
                 .wait_dst_stage_mask(std::slice::from_ref(
                     &vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
                 ))
                 .command_buffers(std::slice::from_ref(&cmd))
-                .wait_semaphores(std::slice::from_ref(
-                    &render_image.image_available_semaphore,
-                ))
-                .signal_semaphores(std::slice::from_ref(
-                    &render_image.render_finished_semaphore,
-                ));
+                .wait_semaphores(std::slice::from_ref(&image_available_semaphore))
+                .signal_semaphores(std::slice::from_ref(&render_finished_semaphore));
 
             self.render_device.queues.submit(
                 QueueType::Graphics,
@@ -644,14 +642,7 @@ impl Renderer {
                 frame.fence,
             )?;
 
-            let present_info = vk::PresentInfoKHR::default()
-                .wait_semaphores(std::slice::from_ref(
-                    &render_image.render_finished_semaphore,
-                ))
-                .swapchains(std::slice::from_ref(&render_image.swapchain))
-                .image_indices(std::slice::from_ref(&render_image.image_index));
-
-            self.render_device.queues.present(&present_info)?;
+            render_image.present()?;
 
             self.current_frame.store(
                 (self.current_frame() + 1) % MAX_FRAMES_IN_FLIGHT,
@@ -659,92 +650,6 @@ impl Renderer {
             );
         }
         Ok(())
-    }
-
-    // WINDOW MANAGEMENT
-
-    fn create_swap_chain(
-        device: &RenderDevice,
-        surface: vk::SurfaceKHR,
-        window_size: vk::Extent2D,
-        old_swapchain: vk::SwapchainKHR,
-    ) -> Result<(vk::SwapchainKHR, vk::Extent2D, Vec<SwapchainImage>)> {
-        let capabilities = unsafe {
-            device
-                .surface_loader
-                .get_physical_device_surface_capabilities(device.physical_device, surface)?
-        };
-
-        let extent = if capabilities.current_extent.width == u32::MAX {
-            vk::Extent2D {
-                width: window_size.width.clamp(
-                    capabilities.min_image_extent.width,
-                    capabilities.max_image_extent.width,
-                ),
-                height: window_size.height.clamp(
-                    capabilities.min_image_extent.height,
-                    capabilities.max_image_extent.height,
-                ),
-            }
-        } else {
-            capabilities.current_extent
-        };
-
-        let mut image_count = capabilities.min_image_count + 1;
-        if capabilities.max_image_count > 0 && image_count > capabilities.max_image_count {
-            image_count = capabilities.max_image_count;
-        }
-
-        let indices = &device.properties.queue_family_indices;
-        // Deduplicate — concurrent mode requires unique family indices
-        let mut unique_indices: Vec<u32> =
-            vec![indices.graphics, indices.present, indices.transfer];
-        unique_indices.sort_unstable();
-        unique_indices.dedup();
-
-        let (sharing_mode, indices_slice): (vk::SharingMode, &[u32]) = if unique_indices.len() > 1 {
-            (vk::SharingMode::CONCURRENT, &unique_indices)
-        } else {
-            (vk::SharingMode::EXCLUSIVE, &[])
-        };
-
-        let create_info = vk::SwapchainCreateInfoKHR::default()
-            .surface(surface)
-            .min_image_count(image_count)
-            .image_format(device.properties.surface_format.format)
-            .image_color_space(device.properties.surface_format.color_space)
-            .image_extent(extent)
-            .image_array_layers(1)
-            .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT)
-            .image_sharing_mode(sharing_mode)
-            .queue_family_indices(indices_slice)
-            .pre_transform(capabilities.current_transform)
-            .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE)
-            .present_mode(device.properties.present_mode)
-            .clipped(true)
-            .old_swapchain(old_swapchain);
-
-        let swapchain = unsafe {
-            device
-                .swapchain_loader
-                .create_swapchain(&create_info, None)?
-        };
-        let images = unsafe { device.swapchain_loader.get_swapchain_images(swapchain)? };
-
-        let swap_images = images
-            .into_iter()
-            .map(|image| {
-                SwapchainImage::new(device, image, device.properties.surface_format.format)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        unsafe {
-            device
-                .swapchain_loader
-                .destroy_swapchain(old_swapchain, None);
-        };
-
-        Ok((swapchain, extent, swap_images))
     }
 
     // EXTRA UTILS

--- a/crates/dirk_renderer/src/resources.rs
+++ b/crates/dirk_renderer/src/resources.rs
@@ -3,3 +3,4 @@ pub mod command_pool;
 pub mod device;
 pub mod image;
 pub mod queues;
+pub mod swapchain;

--- a/crates/dirk_renderer/src/resources/image.rs
+++ b/crates/dirk_renderer/src/resources/image.rs
@@ -30,6 +30,7 @@ pub struct Image {
     #[allow(unused)]
     allocation: Option<Allocation>,
     // TODO: store current queue?
+    // TODO: store current layout?
 }
 
 // TODO: default

--- a/crates/dirk_renderer/src/resources/swapchain.rs
+++ b/crates/dirk_renderer/src/resources/swapchain.rs
@@ -1,0 +1,302 @@
+//! Safe swapchain abstraction for renderer windows.
+
+use ash::vk;
+
+use crate::{
+    Error, Result,
+    resources::{
+        device::{Garbage, RenderDevice},
+        image::SwapchainImage,
+    },
+};
+
+/// An acquired image from a [`Swapchain`].
+///
+/// The renderer records work against [`Self::image`] and then consumes this
+/// value with [`Self::present`] after the render-finished semaphore has been
+/// signalled.
+pub struct RenderImage<'a> {
+    pub image: &'a SwapchainImage,
+    pub image_index: u32,
+
+    pub image_available_semaphore: vk::Semaphore,
+    pub render_finished_semaphore: vk::Semaphore,
+
+    device: RenderDevice,
+    swapchain: vk::SwapchainKHR,
+}
+
+impl RenderImage<'_> {
+    /// Presents the acquired swapchain image.
+    pub fn present(self) -> Result<()> {
+        let wait_semaphores = [self.render_finished_semaphore];
+        let swapchains = [self.swapchain];
+        let image_indices = [self.image_index];
+        let present_info = vk::PresentInfoKHR::default()
+            .wait_semaphores(&wait_semaphores)
+            .swapchains(&swapchains)
+            .image_indices(&image_indices);
+
+        if self.device.queues.present(&present_info)? {
+            return Err(Error::SuboptimalSurface);
+        }
+
+        Ok(())
+    }
+}
+
+/// Swapchain and image resources for a single window surface.
+pub struct Swapchain {
+    device: RenderDevice,
+    surface: vk::SurfaceKHR,
+    raw: vk::SwapchainKHR,
+    images: Vec<SwapchainImage>,
+    extent: vk::Extent2D,
+    semaphores: Vec<(vk::Semaphore, vk::Semaphore)>,
+    semaphore_index: usize,
+}
+
+impl Swapchain {
+    /// Creates a swapchain for `surface` sized to `window_size`.
+    pub fn build(
+        device: &RenderDevice,
+        surface: vk::SurfaceKHR,
+        window_size: vk::Extent2D,
+    ) -> Result<Self> {
+        let (raw, extent, images) =
+            Self::create(device, surface, window_size, vk::SwapchainKHR::null())?;
+        let semaphores = match Self::create_semaphores(device, images.len()) {
+            Ok(semaphores) => semaphores,
+            Err(error) => {
+                drop(images);
+                Self::destroy_raw(device, raw);
+                return Err(error);
+            }
+        };
+
+        Ok(Self {
+            device: device.clone(),
+            surface,
+            raw,
+            images,
+            extent,
+            semaphores,
+            semaphore_index: 0,
+        })
+    }
+
+    /// Returns the swapchain extent selected by the surface.
+    pub fn extent(&self) -> vk::Extent2D {
+        self.extent
+    }
+
+    /// Acquires the next image and returns the semaphores required to render it.
+    pub fn acquire_next_image(&mut self) -> Result<RenderImage<'_>> {
+        self.semaphore_index = (self.semaphore_index + 1) % self.semaphores.len();
+        let (render_finished_semaphore, image_available_semaphore) =
+            self.semaphores[self.semaphore_index];
+
+        let (image_index, suboptimal) = unsafe {
+            self.device.swapchain_loader.acquire_next_image(
+                self.raw,
+                u64::MAX,
+                image_available_semaphore,
+                vk::Fence::null(),
+            )?
+        };
+
+        if suboptimal {
+            return Err(Error::SuboptimalSurface);
+        }
+
+        Ok(RenderImage {
+            image: &self.images[image_index as usize],
+            image_index,
+            image_available_semaphore,
+            render_finished_semaphore,
+            device: self.device.clone(),
+            swapchain: self.raw,
+        })
+    }
+
+    /// Recreates the swapchain for a new requested window extent.
+    pub fn recreate(&mut self, window_size: vk::Extent2D) -> Result<()> {
+        let old_raw = self.raw;
+        let (raw, extent, images) = Self::create(&self.device, self.surface, window_size, old_raw)?;
+        let semaphores = match Self::create_semaphores(&self.device, images.len()) {
+            Ok(semaphores) => semaphores,
+            Err(error) => {
+                drop(images);
+                Self::destroy_raw(&self.device, raw);
+                return Err(error);
+            }
+        };
+
+        let old_semaphores = std::mem::replace(&mut self.semaphores, semaphores);
+        for (render_finished, image_available) in old_semaphores {
+            self.device.destroy(Garbage::Semaphore(render_finished));
+            self.device.destroy(Garbage::Semaphore(image_available));
+        }
+
+        self.images = images;
+        self.raw = raw;
+        self.extent = extent;
+        self.semaphore_index = 0;
+
+        self.device.destroy(Garbage::Swapchain(old_raw));
+
+        Ok(())
+    }
+
+    fn create(
+        device: &RenderDevice,
+        surface: vk::SurfaceKHR,
+        window_size: vk::Extent2D,
+        old_swapchain: vk::SwapchainKHR,
+    ) -> Result<(vk::SwapchainKHR, vk::Extent2D, Vec<SwapchainImage>)> {
+        let capabilities = unsafe {
+            device
+                .surface_loader
+                .get_physical_device_surface_capabilities(device.physical_device, surface)?
+        };
+
+        let extent = if capabilities.current_extent.width == u32::MAX {
+            vk::Extent2D {
+                width: window_size.width.clamp(
+                    capabilities.min_image_extent.width,
+                    capabilities.max_image_extent.width,
+                ),
+                height: window_size.height.clamp(
+                    capabilities.min_image_extent.height,
+                    capabilities.max_image_extent.height,
+                ),
+            }
+        } else {
+            capabilities.current_extent
+        };
+
+        let mut image_count = capabilities.min_image_count + 1;
+        if capabilities.max_image_count > 0 && image_count > capabilities.max_image_count {
+            image_count = capabilities.max_image_count;
+        }
+
+        let indices = &device.properties.queue_family_indices;
+        let mut unique_indices = vec![indices.graphics, indices.present, indices.transfer];
+        unique_indices.sort_unstable();
+        unique_indices.dedup();
+
+        let (sharing_mode, indices_slice): (vk::SharingMode, &[u32]) = if unique_indices.len() > 1 {
+            (vk::SharingMode::CONCURRENT, &unique_indices)
+        } else {
+            (vk::SharingMode::EXCLUSIVE, &[])
+        };
+
+        let create_info = vk::SwapchainCreateInfoKHR::default()
+            .surface(surface)
+            .min_image_count(image_count)
+            .image_format(device.properties.surface_format.format)
+            .image_color_space(device.properties.surface_format.color_space)
+            .image_extent(extent)
+            .image_array_layers(1)
+            .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT)
+            .image_sharing_mode(sharing_mode)
+            .queue_family_indices(indices_slice)
+            .pre_transform(capabilities.current_transform)
+            .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE)
+            .present_mode(device.properties.present_mode)
+            .clipped(true)
+            .old_swapchain(old_swapchain);
+
+        let swapchain = unsafe {
+            device
+                .swapchain_loader
+                .create_swapchain(&create_info, None)?
+        };
+        let images = unsafe { device.swapchain_loader.get_swapchain_images(swapchain)? };
+
+        let swapchain_images = match images
+            .into_iter()
+            .map(|image| {
+                SwapchainImage::new(device, image, device.properties.surface_format.format)
+            })
+            .collect::<Result<Vec<_>>>()
+        {
+            Ok(images) => images,
+            Err(error) => {
+                Self::destroy_raw(device, swapchain);
+                return Err(error);
+            }
+        };
+
+        Ok((swapchain, extent, swapchain_images))
+    }
+
+    fn create_semaphores(
+        device: &RenderDevice,
+        count: usize,
+    ) -> Result<Vec<(vk::Semaphore, vk::Semaphore)>> {
+        let semaphore_info = vk::SemaphoreCreateInfo::default();
+        let mut semaphores = Vec::with_capacity(count);
+
+        for _ in 0..count {
+            let render_finished =
+                match unsafe { device.device.create_semaphore(&semaphore_info, None) } {
+                    Ok(semaphore) => semaphore,
+                    Err(error) => {
+                        Self::destroy_semaphores(device, semaphores);
+                        return Err(error.into());
+                    }
+                };
+
+            let image_available =
+                match unsafe { device.device.create_semaphore(&semaphore_info, None) } {
+                    Ok(semaphore) => semaphore,
+                    Err(error) => {
+                        let mut device = device.clone();
+                        device.destroy(Garbage::Semaphore(render_finished));
+                        Self::destroy_semaphores(&device, semaphores);
+                        return Err(error.into());
+                    }
+                };
+
+            semaphores.push((render_finished, image_available));
+        }
+
+        Ok(semaphores)
+    }
+
+    fn destroy_raw(device: &RenderDevice, raw: vk::SwapchainKHR) {
+        let mut device = device.clone();
+        device.destroy(Garbage::Swapchain(raw));
+    }
+
+    fn destroy_semaphores(device: &RenderDevice, semaphores: Vec<(vk::Semaphore, vk::Semaphore)>) {
+        let mut device = device.clone();
+        for (render_finished, image_available) in semaphores {
+            device.destroy(Garbage::Semaphore(render_finished));
+            device.destroy(Garbage::Semaphore(image_available));
+        }
+    }
+
+    /// Enqueues all swapchain-owned resources for destruction.
+    pub fn destroy(&mut self) {
+        self.semaphores
+            .drain(..)
+            .for_each(|(render_finished, image_available)| {
+                self.device.destroy(Garbage::Semaphore(render_finished));
+                self.device.destroy(Garbage::Semaphore(image_available));
+            });
+        self.images.clear();
+
+        if self.raw != vk::SwapchainKHR::null() {
+            self.device.destroy(Garbage::Swapchain(self.raw));
+            self.raw = vk::SwapchainKHR::null();
+        }
+    }
+}
+
+impl Drop for Swapchain {
+    fn drop(&mut self) {
+        self.destroy();
+    }
+}

--- a/crates/dirk_renderer/src/window.rs
+++ b/crates/dirk_renderer/src/window.rs
@@ -3,23 +3,12 @@ use dirk_platform::WindowId;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 
 use crate::{
-    Error, Renderer, Result,
+    Result,
     resources::{
         device::{Garbage, RenderDevice},
-        image::SwapchainImage,
+        swapchain::{RenderImage, Swapchain},
     },
 };
-
-/// This holds all the data required to render to the owning window's
-/// swap chain. These are created on `window::next_image`
-pub struct RenderImage<'a> {
-    pub image: &'a SwapchainImage,
-    pub image_index: u32,
-    pub swapchain: vk::SwapchainKHR,
-
-    pub image_available_semaphore: vk::Semaphore,
-    pub render_finished_semaphore: vk::Semaphore,
-}
 
 /// The renderer's representation of a platform window.
 /// Holds the swapchain, surface & other related state.
@@ -29,17 +18,10 @@ pub struct Window {
 
     id: WindowId,
     surface: vk::SurfaceKHR,
-    swapchain: vk::SwapchainKHR,
-    images: Vec<SwapchainImage>,
-    extent: vk::Extent2D,
+    swapchain: Swapchain,
 
     // TODO: stop rendering when the window is occluded
     occluded: bool,
-
-    /// The semaphores associated with each swapchain image
-    semaphores: Vec<(vk::Semaphore, vk::Semaphore)>,
-    /// The current index of the semaphores
-    semaphore_count: usize,
 }
 
 impl Window {
@@ -60,27 +42,13 @@ impl Window {
             height: window_size.height,
         };
 
-        let (swapchain, extent, images) =
-            Renderer::create_swap_chain(device, surface, size, vk::SwapchainKHR::null())?;
-
-        let semaphore_info = vk::SemaphoreCreateInfo::default();
-        let create_semaphore = || unsafe {
-            Ok::<vk::Semaphore, Error>(device.device.create_semaphore(&semaphore_info, None)?)
-        };
-
-        let semaphores = (0..images.len())
-            .map(|_| Ok((create_semaphore()?, create_semaphore()?)))
-            .collect::<Result<Vec<_>>>()?;
+        let swapchain = Swapchain::build(device, surface, size)?;
 
         Ok(Self {
             id: plat_window.id(),
             device: device.clone(),
             surface,
             swapchain,
-            extent,
-            images,
-            semaphores,
-            semaphore_count: 0,
             occluded: false,
         })
     }
@@ -89,41 +57,13 @@ impl Window {
         self.id
     }
     pub fn extent(&self) -> vk::Extent2D {
-        self.extent
+        self.swapchain.extent()
     }
     pub fn next_image(&mut self) -> Result<RenderImage<'_>> {
-        self.semaphore_count = (self.semaphore_count + 1) % self.semaphores.len();
-        let (render_finished_semaphore, image_available_semaphore) =
-            self.semaphores[self.semaphore_count];
-
-        let (image_index, suboptimal) = unsafe {
-            self.device.swapchain_loader.acquire_next_image(
-                self.swapchain,
-                u64::MAX,
-                image_available_semaphore,
-                vk::Fence::null(),
-            )?
-        };
-
-        if suboptimal {
-            return Err(Error::SuboptimalSurface);
-        }
-
-        Ok(RenderImage {
-            image: &self.images[image_index as usize],
-            image_index,
-            swapchain: self.swapchain,
-            image_available_semaphore,
-            render_finished_semaphore,
-        })
+        self.swapchain.acquire_next_image()
     }
     pub fn resize(&mut self, extent: vk::Extent2D) -> Result<()> {
-        let (swapchain, extent, images) =
-            Renderer::create_swap_chain(&self.device, self.surface, extent, self.swapchain)?;
-        self.swapchain = swapchain;
-        self.extent = extent;
-        self.images = images;
-        Ok(())
+        self.swapchain.recreate(extent)
     }
     pub fn set_occluded(&mut self, occluded: bool) {
         self.occluded = occluded;
@@ -132,12 +72,7 @@ impl Window {
 
 impl Drop for Window {
     fn drop(&mut self) {
-        self.semaphores.iter().for_each(|&(s1, s2)| {
-            self.device.destroy(Garbage::Semaphore(s1));
-            self.device.destroy(Garbage::Semaphore(s2));
-        });
-        self.images.clear();
-        self.device.destroy(Garbage::Swapchain(self.swapchain));
+        self.swapchain.destroy();
         self.device.destroy(Garbage::Surface(self.surface));
     }
 }


### PR DESCRIPTION
## Summary
- Move swapchain creation, recreation, image acquisition, and destruction into `resources::swapchain`.
- Introduce `Swapchain` and `RenderImage` abstractions to keep window lifecycle and present logic localized.
- Simplify `Window` and `Renderer` by delegating swapchain ownership and presentation to the new resource.