### PR TITLE
feat: descriptor allocation

### DIFF
--- a/crates/dirk_renderer/src/errors.rs
+++ b/crates/dirk_renderer/src/errors.rs
@@ -53,6 +53,9 @@ pub enum Error {
     /// The Vulkan surface is suboptimal
     #[error("suboptimal surface")]
     SuboptimalSurface,
+    /// The requested descriptor set allocation is too large for Vulkan.
+    #[error("descriptor set allocation count {0} exceeds u32::MAX")]
+    DescriptorSetCountTooLarge(usize),
 
     /// If there is no camera in the scene
     #[error("camera {0:?} does not exist")]

--- a/crates/dirk_renderer/src/errors.rs
+++ b/crates/dirk_renderer/src/errors.rs
@@ -56,6 +56,12 @@ pub enum Error {
     /// The requested descriptor set allocation is too large for Vulkan.
     #[error("descriptor set allocation count {0} exceeds u32::MAX")]
     DescriptorSetCountTooLarge(usize),
+    /// A glTF material has no base color texture, which is not yet supported.
+    #[error("glTF material at index {0} has no base color texture")]
+    MissingBaseColorTexture(usize),
+    /// A glTF material references an image index that does not exist.
+    #[error("glTF image index {0} is out of range")]
+    TextureIndexOutOfRange(usize),
 
     /// If there is no camera in the scene
     #[error("camera {0:?} does not exist")]

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -61,7 +61,6 @@ mod physical_device;
 mod pipeline;
 mod render_pass;
 
-const BASE_DESCRIPTOR_POOL_SIZE: u32 = 64;
 const MAX_FRAMES_IN_FLIGHT: usize = 2;
 const DEVICE_EXTENSIONS: &[&str] =
     &[unsafe { std::str::from_utf8_unchecked(swapchain::NAME.to_bytes()) }];

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -31,7 +31,8 @@ use dirk_universe::{Universe, UniverseBuilder};
 
 mod utils;
 use dirk_utils::Version;
-use utils::{DescriptorLayouts, Frame, RendererProperties, Vertex, make_version};
+use resources::descriptors::DescriptorLayouts;
+use utils::{Frame, RendererProperties, Vertex, make_version};
 
 mod errors;
 pub use errors::{Error, Result};
@@ -60,11 +61,7 @@ mod physical_device;
 mod pipeline;
 mod render_pass;
 
-/// The maximum numer of renderables in a scene.
-/// Used to construct Ubo samples.
-/// TODO: find a way to set this limit dynamically or have a error when the limit is reached.
-const MAX_RENDERABLES: u32 = 100;
-
+const BASE_DESCRIPTOR_POOL_SIZE: u32 = 64;
 const MAX_FRAMES_IN_FLIGHT: usize = 2;
 const DEVICE_EXTENSIONS: &[&str] =
     &[unsafe { std::str::from_utf8_unchecked(swapchain::NAME.to_bytes()) }];

--- a/crates/dirk_renderer/src/models.rs
+++ b/crates/dirk_renderer/src/models.rs
@@ -11,10 +11,11 @@ use std::{collections::HashMap, marker::PhantomData, ops::Deref};
 use ash::vk;
 
 use crate::{
-    Result,
+    BASE_DESCRIPTOR_POOL_SIZE, Result,
     resources::{
         buffer::{IndexBuffer, VertexBuffer},
         command_pool::CommandBuffer,
+        descriptors::{DescriptorAllocator, DescriptorPoolSize, DescriptorSet},
         device::{Garbage, RenderDevice},
         image::Image,
     },
@@ -76,7 +77,7 @@ struct Mesh {
 struct Material {
     #[allow(unused)]
     pub base_color: Handle<Texture>,
-    pub descriptor_set: vk::DescriptorSet,
+    pub descriptor_set: DescriptorSet,
 }
 
 struct Model {
@@ -92,28 +93,22 @@ pub struct ModelRegistry {
     materials: slotmap::SlotMap<slotmap::DefaultKey, Material>,
     models: HashMap<dirk_assets::AssetHandle, Model>,
 
-    material_pool: vk::DescriptorPool,
+    material_descriptors: DescriptorAllocator,
 
     asset_load_consumer: dirk_events::Consumer<::dirk_assets::AssetLoaded<::dirk_assets::Model>>,
     asset_unload_consumer: dirk_events::Consumer<::dirk_assets::AssetUnloaded>,
 }
 
-/// TODO: descriptor pool
-const MAX_MATERIAL_DESCRIPTOR_SET: u32 = 256;
-
 impl ModelRegistry {
     pub fn new(device: &RenderDevice, events: &dirk_events::EventManager) -> Result<Self> {
-        let material_pool = {
-            let pool_size = vk::DescriptorPoolSize {
-                ty: vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
-                descriptor_count: MAX_MATERIAL_DESCRIPTOR_SET,
-            };
-            let pool_info = vk::DescriptorPoolCreateInfo::default()
-                .pool_sizes(std::slice::from_ref(&pool_size))
-                .max_sets(MAX_MATERIAL_DESCRIPTOR_SET);
-
-            unsafe { device.device.create_descriptor_pool(&pool_info, None)? }
-        };
+        let material_descriptors = DescriptorAllocator::new(
+            device,
+            &[DescriptorPoolSize::new(
+                vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
+                1,
+            )],
+            BASE_DESCRIPTOR_POOL_SIZE,
+        )?;
 
         Ok(Self {
             device: device.clone(),
@@ -121,7 +116,7 @@ impl ModelRegistry {
             meshes: slotmap::SlotMap::new(),
             materials: slotmap::SlotMap::new(),
             models: HashMap::new(),
-            material_pool,
+            material_descriptors,
 
             asset_load_consumer: events.subscribe(),
             asset_unload_consumer: events.subscribe(),
@@ -143,11 +138,15 @@ impl ModelRegistry {
         &self,
         handle: &dirk_assets::AssetHandle,
         cmd: &CommandBuffer,
-        scene_set: vk::DescriptorSet,
-        proxy_set: vk::DescriptorSet,
+        scene_set: DescriptorSet,
+        proxy_set: DescriptorSet,
         pipeline_layout: vk::PipelineLayout,
     ) -> dirk_assets::Result<()> {
-        let mut descriptor_sets = [scene_set, proxy_set, vk::DescriptorSet::null()];
+        let mut descriptor_sets = [
+            scene_set.raw(),
+            proxy_set.raw(),
+            DescriptorSet::null().raw(),
+        ];
 
         if handle.asset_type() != dirk_assets::AssetType::Model {
             return Err(dirk_assets::Error::TypeMismatch(handle.to_string()));
@@ -167,7 +166,7 @@ impl ModelRegistry {
             let mat_set = prim
                 .material_handle
                 .map_or(vk::DescriptorSet::null(), |mat| {
-                    self.materials[*mat].descriptor_set
+                    self.materials[*mat].descriptor_set.raw()
                 });
 
             descriptor_sets[2] = mat_set;
@@ -225,19 +224,9 @@ impl ModelRegistry {
         texture_refs: &[Handle<Texture>],
     ) -> Result<Vec<Handle<Material>>> {
         let material_count = materials.len();
-        // Allocate one set per material
-        let layouts: Vec<vk::DescriptorSetLayout> =
-            vec![self.device.layouts.material; material_count];
-
-        let material_sets: Vec<vk::DescriptorSet> = if material_count > 0 {
-            let alloc_info = vk::DescriptorSetAllocateInfo::default()
-                .descriptor_pool(self.material_pool)
-                .set_layouts(&layouts);
-
-            unsafe { self.device.device.allocate_descriptor_sets(&alloc_info)? }
-        } else {
-            Vec::new()
-        };
+        let material_sets = self
+            .material_descriptors
+            .allocate_many(self.device.layouts.material, material_count)?;
 
         Ok(materials
             .into_iter()
@@ -250,18 +239,12 @@ impl ModelRegistry {
 
                 let tex_handle = texture_refs[tex];
                 let tex = &self.textures[*tex_handle];
-                let image_info = vk::DescriptorImageInfo::default()
-                    .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
-                    .image_view(tex.image.view())
-                    .sampler(tex.sampler);
-
-                let write = vk::WriteDescriptorSet::default()
-                    .dst_set(material_sets[i])
-                    .dst_binding(2) // matches layouts.material
-                    .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-                    .image_info(std::slice::from_ref(&image_info));
-
-                unsafe { self.device.device.update_descriptor_sets(&[write], &[]) };
+                self.material_descriptors.write_combined_image_sampler(
+                    material_sets[i],
+                    2, // matches layouts.material
+                    tex.image.view(),
+                    tex.sampler,
+                );
                 Handle::new(self.materials.insert(Material {
                     base_color: tex_handle,
                     descriptor_set: material_sets[i],
@@ -325,10 +308,5 @@ impl Drop for ModelRegistry {
         self.meshes.clear();
         self.materials.clear();
         self.models.clear();
-        unsafe {
-            self.device
-                .device
-                .destroy_descriptor_pool(self.material_pool, None);
-        };
     }
 }

--- a/crates/dirk_renderer/src/models.rs
+++ b/crates/dirk_renderer/src/models.rs
@@ -6,26 +6,53 @@
 //! is call [`ModelRegistry::render`] with their asset handle & a command buffer.
 //! We handle the rest.
 
-use std::{collections::HashMap, marker::PhantomData, ops::Deref};
+use std::{
+    collections::{HashMap, HashSet},
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    ops::Deref,
+};
 
 use ash::vk;
 
 use crate::{
-    BASE_DESCRIPTOR_POOL_SIZE, Result,
+    Error, Result,
     resources::{
         buffer::{IndexBuffer, VertexBuffer},
         command_pool::CommandBuffer,
-        descriptors::{DescriptorAllocator, DescriptorPoolSize, DescriptorSet},
+        descriptors::{
+            DescriptorAllocator, DescriptorSet, DescriptorWriter, MaterialLayout, ObjectLayout,
+            SceneLayout,
+        },
         device::{Garbage, RenderDevice},
         image::Image,
     },
     utils::Vertex,
 };
 
-#[derive(Debug, PartialEq, Eq, Hash)]
 struct Handle<T> {
     key: slotmap::DefaultKey,
     _marker: PhantomData<T>,
+}
+
+impl<T> std::fmt::Debug for Handle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.key.fmt(f)
+    }
+}
+
+impl<T> PartialEq for Handle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl<T> Eq for Handle<T> {}
+
+impl<T> Hash for Handle<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+    }
 }
 
 impl<T> Handle<T> {
@@ -77,7 +104,7 @@ struct Mesh {
 struct Material {
     #[allow(unused)]
     pub base_color: Handle<Texture>,
-    pub descriptor_set: DescriptorSet,
+    pub set: DescriptorSet<MaterialLayout>,
 }
 
 struct Model {
@@ -93,7 +120,7 @@ pub struct ModelRegistry {
     materials: slotmap::SlotMap<slotmap::DefaultKey, Material>,
     models: HashMap<dirk_assets::AssetHandle, Model>,
 
-    material_descriptors: DescriptorAllocator,
+    material_alloc: DescriptorAllocator<MaterialLayout>,
 
     asset_load_consumer: dirk_events::Consumer<::dirk_assets::AssetLoaded<::dirk_assets::Model>>,
     asset_unload_consumer: dirk_events::Consumer<::dirk_assets::AssetUnloaded>,
@@ -101,14 +128,7 @@ pub struct ModelRegistry {
 
 impl ModelRegistry {
     pub fn new(device: &RenderDevice, events: &dirk_events::EventManager) -> Result<Self> {
-        let material_descriptors = DescriptorAllocator::new(
-            device,
-            &[DescriptorPoolSize::new(
-                vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
-                1,
-            )],
-            BASE_DESCRIPTOR_POOL_SIZE,
-        )?;
+        let material_alloc = DescriptorAllocator::<MaterialLayout>::new(device, 64)?;
 
         Ok(Self {
             device: device.clone(),
@@ -116,7 +136,7 @@ impl ModelRegistry {
             meshes: slotmap::SlotMap::new(),
             materials: slotmap::SlotMap::new(),
             models: HashMap::new(),
-            material_descriptors,
+            material_alloc,
 
             asset_load_consumer: events.subscribe(),
             asset_unload_consumer: events.subscribe(),
@@ -130,7 +150,7 @@ impl ModelRegistry {
 
         let events = self.asset_unload_consumer.consume_all().collect::<Vec<_>>();
         for event in events {
-            self.models.remove(&event.handle);
+            self.unload_model(&event.handle);
         }
         Ok(())
     }
@@ -138,16 +158,10 @@ impl ModelRegistry {
         &self,
         handle: &dirk_assets::AssetHandle,
         cmd: &CommandBuffer,
-        scene_set: DescriptorSet,
-        proxy_set: DescriptorSet,
+        scene_set: &DescriptorSet<SceneLayout>,
+        proxy_set: &DescriptorSet<ObjectLayout>,
         pipeline_layout: vk::PipelineLayout,
     ) -> dirk_assets::Result<()> {
-        let mut descriptor_sets = [
-            scene_set.raw(),
-            proxy_set.raw(),
-            DescriptorSet::null().raw(),
-        ];
-
         if handle.asset_type() != dirk_assets::AssetType::Model {
             return Err(dirk_assets::Error::TypeMismatch(handle.to_string()));
         }
@@ -166,10 +180,9 @@ impl ModelRegistry {
             let mat_set = prim
                 .material_handle
                 .map_or(vk::DescriptorSet::null(), |mat| {
-                    self.materials[*mat].descriptor_set.raw()
+                    self.materials[*mat].set.raw()
                 });
-
-            descriptor_sets[2] = mat_set;
+            let descriptor_sets = [scene_set.raw(), proxy_set.raw(), mat_set];
 
             cmd.bind_descriptor_sets(
                 vk::PipelineBindPoint::GRAPHICS,
@@ -191,31 +204,49 @@ impl ModelRegistry {
             buffers,
             images,
         } = handle.get()?;
+        let asset_handle = handle.handle();
 
-        let texture_handles = images
-            .iter()
-            .map(|image| {
-                let tex = Image::upload_texture(&self.device, image)?;
-                Ok(Handle::new(self.textures.insert(tex)))
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let mut texture_handles = Vec::with_capacity(images.len());
+        for image in &images {
+            match Image::upload_texture(&self.device, image) {
+                Ok(tex) => texture_handles.push(Handle::new(self.textures.insert(tex))),
+                Err(error) => {
+                    self.remove_model_parts(&[], &[], &texture_handles);
+                    return Err(error);
+                }
+            }
+        }
 
-        let material_handles =
-            self.create_materials(gltf.materials().collect(), &texture_handles)?;
+        let mut material_handles = Vec::new();
+        let mut mesh_handles = Vec::new();
 
-        let meshes = gltf
-            .meshes()
-            .map(|mesh| {
+        let result = (|| -> Result<()> {
+            material_handles =
+                self.create_materials(gltf.materials().collect(), &texture_handles)?;
+
+            for mesh in gltf.meshes() {
                 let primitives = mesh
                     .primitives()
                     .map(|prim| self.upload_primitive(&prim, &buffers, &material_handles))
                     .collect::<Result<Vec<_>>>()?;
-                Ok(Handle::new(self.meshes.insert(Mesh { primitives })))
-            })
-            .collect::<Result<Vec<_>>>()?;
+                mesh_handles.push(Handle::new(self.meshes.insert(Mesh { primitives })));
+            }
 
-        self.models.insert(handle.handle(), Model { meshes });
-        Ok(())
+            self.unload_model(&asset_handle);
+            self.models.insert(
+                asset_handle,
+                Model {
+                    meshes: mesh_handles.clone(),
+                },
+            );
+            Ok(())
+        })();
+
+        if result.is_err() {
+            self.remove_model_parts(&mesh_handles, &material_handles, &texture_handles);
+        }
+
+        result
     }
 
     fn create_materials(
@@ -223,31 +254,37 @@ impl ModelRegistry {
         materials: Vec<gltf::Material>,
         texture_refs: &[Handle<Texture>],
     ) -> Result<Vec<Handle<Material>>> {
-        let material_count = materials.len();
-        let material_sets = self
-            .material_descriptors
-            .allocate_many(self.device.layouts.material, material_count)?;
+        let mut pending = Vec::with_capacity(materials.len());
 
-        Ok(materials
+        for (material_index, mat) in materials.into_iter().enumerate() {
+            let set = self.material_alloc.allocate()?;
+            let tex_index = mat
+                .pbr_metallic_roughness()
+                .base_color_texture()
+                .ok_or(Error::MissingBaseColorTexture(material_index))?
+                .texture()
+                .source()
+                .index();
+            let tex_handle = texture_refs
+                .get(tex_index)
+                .copied()
+                .ok_or(Error::TextureIndexOutOfRange(tex_index))?;
+            let tex = &self.textures[*tex_handle];
+            pending.push((tex_handle, set, tex.image.view(), tex.sampler));
+        }
+
+        let mut writer = DescriptorWriter::new(&self.device.device);
+        for (_, set, view, sampler) in &pending {
+            writer = writer.combined_image_sampler(set, *view, *sampler);
+        }
+        writer.flush();
+
+        Ok(pending
             .into_iter()
-            .enumerate()
-            .map(|(i, mat)| {
-                let pbr = mat.pbr_metallic_roughness();
-                // TODO: actually PBR materials
-                #[allow(clippy::unwrap_used)]
-                let tex = pbr.base_color_texture().unwrap().texture().source().index();
-
-                let tex_handle = texture_refs[tex];
-                let tex = &self.textures[*tex_handle];
-                self.material_descriptors.write_combined_image_sampler(
-                    material_sets[i],
-                    2, // matches layouts.material
-                    tex.image.view(),
-                    tex.sampler,
-                );
+            .map(|(tex_handle, set, _, _)| {
                 Handle::new(self.materials.insert(Material {
                     base_color: tex_handle,
-                    descriptor_set: material_sets[i],
+                    set,
                 }))
             })
             .collect())
@@ -300,13 +337,60 @@ impl ModelRegistry {
             material_handle: primitive.material().index().map(|idx| mat_refs[idx]),
         })
     }
+
+    fn unload_model(&mut self, handle: &dirk_assets::AssetHandle) {
+        let Some(model) = self.models.remove(handle) else {
+            return;
+        };
+
+        let mut material_handles = HashSet::new();
+        for mesh_handle in model.meshes {
+            if let Some(mesh) = self.meshes.remove(*mesh_handle) {
+                material_handles.extend(
+                    mesh.primitives
+                        .into_iter()
+                        .filter_map(|primitive| primitive.material_handle),
+                );
+            }
+        }
+
+        let mut texture_handles = HashSet::new();
+        for material_handle in material_handles {
+            if let Some(material) = self.materials.remove(*material_handle) {
+                texture_handles.insert(material.base_color);
+            }
+        }
+
+        for texture_handle in texture_handles {
+            self.textures.remove(*texture_handle);
+        }
+    }
+
+    fn remove_model_parts(
+        &mut self,
+        mesh_handles: &[Handle<Mesh>],
+        material_handles: &[Handle<Material>],
+        texture_handles: &[Handle<Texture>],
+    ) {
+        for mesh_handle in mesh_handles {
+            self.meshes.remove(**mesh_handle);
+        }
+        for material_handle in material_handles {
+            self.materials.remove(**material_handle);
+        }
+        for texture_handle in texture_handles {
+            self.textures.remove(**texture_handle);
+        }
+    }
 }
 
 impl Drop for ModelRegistry {
     fn drop(&mut self) {
+        // Materials hold DescriptorSet values; clear them before the allocator
+        // enqueues descriptor pool destruction.
+        self.materials.clear();
         self.textures.clear();
         self.meshes.clear();
-        self.materials.clear();
         self.models.clear();
     }
 }

--- a/crates/dirk_renderer/src/pipeline.rs
+++ b/crates/dirk_renderer/src/pipeline.rs
@@ -21,7 +21,7 @@ impl GraphicsPipeline {
         layouts: &DescriptorLayouts,
         properties: &RendererProperties,
     ) -> Result<Self> {
-        let set_layouts = [layouts.scene, layouts.object, layouts.material];
+        let set_layouts = layouts.pipeline_layouts();
         let layout_info = vk::PipelineLayoutCreateInfo::default().set_layouts(&set_layouts);
         let pipeline_layout = unsafe { device.device.create_pipeline_layout(&layout_info, None)? };
 

--- a/crates/dirk_renderer/src/proxy/scene.rs
+++ b/crates/dirk_renderer/src/proxy/scene.rs
@@ -5,14 +5,15 @@ use dirk_universe::{Entity, WorldId};
 use gpu_allocator::MemoryLocation;
 
 use crate::{
-    Error, MAX_FRAMES_IN_FLIGHT, MAX_RENDERABLES, Result,
+    BASE_DESCRIPTOR_POOL_SIZE, Error, MAX_FRAMES_IN_FLIGHT, Result,
     models::ModelRegistry,
     pipeline::GraphicsPipeline,
     render_pass::RenderPass,
     resources::{
         buffer::UniformBuffer,
         command_pool::CommandBuffer,
-        device::{Garbage, RenderDevice},
+        descriptors::{DescriptorAllocator, DescriptorPoolSize, DescriptorSet},
+        device::RenderDevice,
         image::{Image, ImageCreateInfo},
     },
 };
@@ -21,7 +22,7 @@ use crate::{
 /// most of the rendering state needed to render each scene.
 pub struct SceneManager {
     device: RenderDevice,
-    descriptor_pool: vk::DescriptorPool,
+    descriptor_allocator: DescriptorAllocator,
 
     scenes: HashMap<WorldId, Scene>,
     entities: HashMap<Entity, WorldId>,
@@ -36,28 +37,14 @@ pub struct SceneManager {
 
 impl SceneManager {
     pub fn init(device: &RenderDevice, size: vk::Extent2D) -> Result<Self> {
-        // MAX_FRAMES_IN_FLIGHT never gets anywhere near u32::MAX
-        #[allow(clippy::cast_possible_truncation)]
-        let pool_sizes = [
-            vk::DescriptorPoolSize {
-                ty: vk::DescriptorType::UNIFORM_BUFFER,
-                // scene UBOs + object UBOs, all × frames in flight
-                descriptor_count: (1 + MAX_RENDERABLES) * MAX_FRAMES_IN_FLIGHT as u32,
-            },
-            vk::DescriptorPoolSize {
-                ty: vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
-                // rough upper bound on material textures
-                descriptor_count: MAX_RENDERABLES * MAX_FRAMES_IN_FLIGHT as u32,
-            },
-        ];
-
-        // MAX_FRAMES_IN_FLIGHT never gets anywhere near u32::MAX
-        #[allow(clippy::cast_possible_truncation)]
-        let pool_info = vk::DescriptorPoolCreateInfo::default()
-            .pool_sizes(&pool_sizes)
-            .max_sets((1 + MAX_RENDERABLES * 2) * MAX_FRAMES_IN_FLIGHT as u32);
-
-        let descriptor_pool = unsafe { device.device.create_descriptor_pool(&pool_info, None)? };
+        let descriptor_allocator = DescriptorAllocator::new(
+            device,
+            &[DescriptorPoolSize::new(
+                vk::DescriptorType::UNIFORM_BUFFER,
+                1,
+            )],
+            BASE_DESCRIPTOR_POOL_SIZE,
+        )?;
 
         // TEMP
         let color_info = ImageCreateInfo {
@@ -89,7 +76,7 @@ impl SceneManager {
 
         Ok(Self {
             device: device.clone(),
-            descriptor_pool,
+            descriptor_allocator,
             entities: HashMap::new(),
             scenes: HashMap::new(),
             proxies: HashMap::new(),
@@ -264,8 +251,6 @@ impl Drop for SceneManager {
         self.scenes.clear();
         self.entities.clear();
         self.proxies.clear();
-        self.device
-            .destroy(Garbage::DescriptorPool(self.descriptor_pool));
     }
 }
 
@@ -289,57 +274,29 @@ struct Scene {
     entities: HashSet<Entity>,
 
     ubo: [UniformBuffer; MAX_FRAMES_IN_FLIGHT],
-    descriptor_sets: [vk::DescriptorSet; MAX_FRAMES_IN_FLIGHT],
+    descriptor_sets: [DescriptorSet; MAX_FRAMES_IN_FLIGHT],
 }
 
 impl Scene {
     /// Builds a [Scene].
     /// Constructs the renderer stuff like command pools, descriptor sets, ... from
     /// the [Renderer].
-    pub fn build(manager: &SceneManager) -> Result<Self> {
+    pub fn build(manager: &mut SceneManager) -> Result<Self> {
         // Allocate scene-level sets (one per frame)
-        let layouts = [manager.device.layouts.scene; MAX_FRAMES_IN_FLIGHT];
-        let alloc_info = vk::DescriptorSetAllocateInfo::default()
-            .descriptor_pool(manager.descriptor_pool)
-            .set_layouts(&layouts);
-
-        let scene_desc_sets: [vk::DescriptorSet; MAX_FRAMES_IN_FLIGHT] = unsafe {
-            manager
-                .device
-                .device
-                .allocate_descriptor_sets(&alloc_info)?
-                .try_into()
-                .expect("should be able to convert desc_sets to array")
-        };
+        let scene_desc_sets = manager
+            .descriptor_allocator
+            .allocate_array::<MAX_FRAMES_IN_FLIGHT>(manager.device.layouts.scene)?;
 
         let ubo_size = size_of::<SceneUbo>() as u64;
         let build_ubo =
             || UniformBuffer::create(&manager.device, ubo_size, MemoryLocation::CpuToGpu);
         let ubo = [build_ubo()?, build_ubo()?];
 
-        let buffer_infos: [vk::DescriptorBufferInfo; MAX_FRAMES_IN_FLIGHT] =
-            std::array::from_fn(|i| {
-                vk::DescriptorBufferInfo::default()
-                    .buffer(ubo[i].buffer())
-                    .range(size_of::<SceneUbo>() as u64)
-                    .offset(0)
-            });
-
-        let descriptor_writes: [vk::WriteDescriptorSet; MAX_FRAMES_IN_FLIGHT] =
-            std::array::from_fn(|i| {
-                vk::WriteDescriptorSet::default()
-                    .dst_set(scene_desc_sets[i])
-                    .dst_binding(0)
-                    .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
-                    .buffer_info(std::slice::from_ref(&buffer_infos[i]))
-            });
-
-        unsafe {
+        for (set, ubo) in scene_desc_sets.iter().zip(&ubo) {
             manager
-                .device
-                .device
-                .update_descriptor_sets(&descriptor_writes, &[]);
-        };
+                .descriptor_allocator
+                .write_uniform_buffer(*set, 0, ubo.buffer(), ubo_size);
+        }
 
         Ok(Self {
             entities: HashSet::new(),
@@ -361,53 +318,25 @@ pub struct SceneProxy {
 
     // Per frame render stuff
     ubo: [UniformBuffer; MAX_FRAMES_IN_FLIGHT],
-    sets: [vk::DescriptorSet; MAX_FRAMES_IN_FLIGHT],
+    sets: [DescriptorSet; MAX_FRAMES_IN_FLIGHT],
 }
 
 impl SceneProxy {
-    pub fn build(manager: &SceneManager) -> Result<Self> {
+    pub fn build(manager: &mut SceneManager) -> Result<Self> {
         let size = size_of::<ProxyUbo>() as u64;
         let build_ubo = || UniformBuffer::create(&manager.device, size, MemoryLocation::CpuToGpu);
         let ubo = [build_ubo()?, build_ubo()?];
 
         // Allocate scene-level sets (one per frame)
-        let layouts = [manager.device.layouts.object; MAX_FRAMES_IN_FLIGHT];
-        let alloc_info = vk::DescriptorSetAllocateInfo::default()
-            .descriptor_pool(manager.descriptor_pool)
-            .set_layouts(&layouts);
+        let sets = manager
+            .descriptor_allocator
+            .allocate_array::<MAX_FRAMES_IN_FLIGHT>(manager.device.layouts.object)?;
 
-        let sets: [vk::DescriptorSet; MAX_FRAMES_IN_FLIGHT] = unsafe {
+        for (set, ubo) in sets.iter().zip(&ubo) {
             manager
-                .device
-                .device
-                .allocate_descriptor_sets(&alloc_info)?
-                .try_into()
-                .expect("vec should be MAX_FRAMES_IN_FLIGHT large so Into shouldn't fail")
-        };
-
-        let buffer_infos: [vk::DescriptorBufferInfo; MAX_FRAMES_IN_FLIGHT] =
-            std::array::from_fn(|i| {
-                vk::DescriptorBufferInfo::default()
-                    .buffer(ubo[i].buffer())
-                    .range(size)
-                    .offset(0)
-            });
-
-        let descriptor_writes: [vk::WriteDescriptorSet; MAX_FRAMES_IN_FLIGHT] =
-            std::array::from_fn(|i| {
-                vk::WriteDescriptorSet::default()
-                    .dst_set(sets[i])
-                    .dst_binding(1)
-                    .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
-                    .buffer_info(std::slice::from_ref(&buffer_infos[i]))
-            });
-
-        unsafe {
-            manager
-                .device
-                .device
-                .update_descriptor_sets(&descriptor_writes, &[]);
-        };
+                .descriptor_allocator
+                .write_uniform_buffer(*set, 1, ubo.buffer(), size);
+        }
 
         Ok(Self {
             model: None,

--- a/crates/dirk_renderer/src/proxy/scene.rs
+++ b/crates/dirk_renderer/src/proxy/scene.rs
@@ -5,14 +5,16 @@ use dirk_universe::{Entity, WorldId};
 use gpu_allocator::MemoryLocation;
 
 use crate::{
-    BASE_DESCRIPTOR_POOL_SIZE, Error, MAX_FRAMES_IN_FLIGHT, Result,
+    Error, MAX_FRAMES_IN_FLIGHT, Result,
     models::ModelRegistry,
     pipeline::GraphicsPipeline,
     render_pass::RenderPass,
     resources::{
         buffer::UniformBuffer,
         command_pool::CommandBuffer,
-        descriptors::{DescriptorAllocator, DescriptorPoolSize, DescriptorSet},
+        descriptors::{
+            DescriptorAllocator, DescriptorSet, DescriptorWriter, ObjectLayout, SceneLayout,
+        },
         device::RenderDevice,
         image::{Image, ImageCreateInfo},
     },
@@ -22,7 +24,6 @@ use crate::{
 /// most of the rendering state needed to render each scene.
 pub struct SceneManager {
     device: RenderDevice,
-    descriptor_allocator: DescriptorAllocator,
 
     scenes: HashMap<WorldId, Scene>,
     entities: HashMap<Entity, WorldId>,
@@ -33,18 +34,15 @@ pub struct SceneManager {
     depth: Image,
     // render graph should fix this
     graphics_pipeline: GraphicsPipeline,
+
+    scene_alloc: DescriptorAllocator<SceneLayout>,
+    proxy_alloc: DescriptorAllocator<ObjectLayout>,
 }
 
 impl SceneManager {
     pub fn init(device: &RenderDevice, size: vk::Extent2D) -> Result<Self> {
-        let descriptor_allocator = DescriptorAllocator::new(
-            device,
-            &[DescriptorPoolSize::new(
-                vk::DescriptorType::UNIFORM_BUFFER,
-                1,
-            )],
-            BASE_DESCRIPTOR_POOL_SIZE,
-        )?;
+        let scene_alloc = DescriptorAllocator::<SceneLayout>::new(device, 16)?;
+        let proxy_alloc = DescriptorAllocator::<ObjectLayout>::new(device, 256)?;
 
         // TEMP
         let color_info = ImageCreateInfo {
@@ -76,13 +74,14 @@ impl SceneManager {
 
         Ok(Self {
             device: device.clone(),
-            descriptor_allocator,
             entities: HashMap::new(),
             scenes: HashMap::new(),
             proxies: HashMap::new(),
             color,
             depth,
             graphics_pipeline,
+            scene_alloc,
+            proxy_alloc,
         })
     }
     pub fn render(
@@ -164,8 +163,8 @@ impl SceneManager {
             match models.render_model(
                 model,
                 cmd,
-                scene.descriptor_sets[frame],
-                proxy.sets[frame],
+                &scene.sets[frame],
+                &proxy.sets[frame],
                 self.graphics_pipeline.layout(),
             ) {
                 Ok(()) | Err(dirk_assets::Error::NotFound(_)) => (),
@@ -248,6 +247,9 @@ impl SceneManager {
 
 impl Drop for SceneManager {
     fn drop(&mut self) {
+        // Clear collections before allocators are dropped. Scene and
+        // SceneProxy hold DescriptorSet values whose Drop impls enqueue descriptor
+        // set frees; the allocators enqueue descriptor pool destroys.
         self.scenes.clear();
         self.entities.clear();
         self.proxies.clear();
@@ -274,7 +276,7 @@ struct Scene {
     entities: HashSet<Entity>,
 
     ubo: [UniformBuffer; MAX_FRAMES_IN_FLIGHT],
-    descriptor_sets: [DescriptorSet; MAX_FRAMES_IN_FLIGHT],
+    sets: [DescriptorSet<SceneLayout>; MAX_FRAMES_IN_FLIGHT],
 }
 
 impl Scene {
@@ -283,25 +285,25 @@ impl Scene {
     /// the [Renderer].
     pub fn build(manager: &mut SceneManager) -> Result<Self> {
         // Allocate scene-level sets (one per frame)
-        let scene_desc_sets = manager
-            .descriptor_allocator
-            .allocate_array::<MAX_FRAMES_IN_FLIGHT>(manager.device.layouts.scene)?;
+        let sets = manager
+            .scene_alloc
+            .allocate_array::<MAX_FRAMES_IN_FLIGHT>()?;
 
         let ubo_size = size_of::<SceneUbo>() as u64;
         let build_ubo =
             || UniformBuffer::create(&manager.device, ubo_size, MemoryLocation::CpuToGpu);
         let ubo = [build_ubo()?, build_ubo()?];
 
-        for (set, ubo) in scene_desc_sets.iter().zip(&ubo) {
-            manager
-                .descriptor_allocator
-                .write_uniform_buffer(*set, 0, ubo.buffer(), ubo_size);
+        let mut writer = DescriptorWriter::new(&manager.device.device);
+        for (set, ubo) in sets.iter().zip(&ubo) {
+            writer = writer.uniform_buffer(set, ubo.buffer(), ubo_size);
         }
+        writer.flush();
 
         Ok(Self {
             entities: HashSet::new(),
             ubo,
-            descriptor_sets: scene_desc_sets,
+            sets,
         })
     }
 }
@@ -318,7 +320,7 @@ pub struct SceneProxy {
 
     // Per frame render stuff
     ubo: [UniformBuffer; MAX_FRAMES_IN_FLIGHT],
-    sets: [DescriptorSet; MAX_FRAMES_IN_FLIGHT],
+    sets: [DescriptorSet<ObjectLayout>; MAX_FRAMES_IN_FLIGHT],
 }
 
 impl SceneProxy {
@@ -329,14 +331,14 @@ impl SceneProxy {
 
         // Allocate scene-level sets (one per frame)
         let sets = manager
-            .descriptor_allocator
-            .allocate_array::<MAX_FRAMES_IN_FLIGHT>(manager.device.layouts.object)?;
+            .proxy_alloc
+            .allocate_array::<MAX_FRAMES_IN_FLIGHT>()?;
 
+        let mut writer = DescriptorWriter::new(&manager.device.device);
         for (set, ubo) in sets.iter().zip(&ubo) {
-            manager
-                .descriptor_allocator
-                .write_uniform_buffer(*set, 1, ubo.buffer(), size);
+            writer = writer.uniform_buffer(set, ubo.buffer(), size);
         }
+        writer.flush();
 
         Ok(Self {
             model: None,

--- a/crates/dirk_renderer/src/resources.rs
+++ b/crates/dirk_renderer/src/resources.rs
@@ -1,5 +1,6 @@
 pub mod buffer;
 pub mod command_pool;
+pub mod descriptors;
 pub mod device;
 pub mod image;
 pub mod queues;

--- a/crates/dirk_renderer/src/resources/descriptors.rs
+++ b/crates/dirk_renderer/src/resources/descriptors.rs
@@ -1,0 +1,291 @@
+//! Safe descriptor layout and descriptor pool helpers.
+
+use ash::{Device, prelude::VkResult, vk};
+
+use crate::{
+    Error, Result,
+    resources::device::{Garbage, RenderDevice},
+};
+
+/// All descriptor set layouts used by the renderer.
+pub struct DescriptorLayouts {
+    /// Per scene layout. Holds view and projection matrices for rendering.
+    pub scene: vk::DescriptorSetLayout,
+    /// Per object layout. Holds the model matrix.
+    pub object: vk::DescriptorSetLayout,
+    /// Per material layout. Holds a base color texture descriptor.
+    pub material: vk::DescriptorSetLayout,
+}
+
+impl DescriptorLayouts {
+    /// Creates the descriptor set layouts used by the renderer.
+    pub fn create(device: &Device) -> Result<Self> {
+        Ok(Self {
+            scene: create_layout(
+                device,
+                0,
+                vk::DescriptorType::UNIFORM_BUFFER,
+                vk::ShaderStageFlags::VERTEX,
+            )?,
+            object: create_layout(
+                device,
+                1,
+                vk::DescriptorType::UNIFORM_BUFFER,
+                vk::ShaderStageFlags::VERTEX,
+            )?,
+            material: create_layout(
+                device,
+                2,
+                vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
+                vk::ShaderStageFlags::FRAGMENT,
+            )?,
+        })
+    }
+
+    /// Returns the layouts in pipeline set order.
+    pub fn pipeline_layouts(&self) -> [vk::DescriptorSetLayout; 3] {
+        [self.scene, self.object, self.material]
+    }
+
+    /// Destroys every descriptor set layout.
+    pub fn destroy(&self, device: &Device) {
+        unsafe {
+            device.destroy_descriptor_set_layout(self.scene, None);
+            device.destroy_descriptor_set_layout(self.object, None);
+            device.destroy_descriptor_set_layout(self.material, None);
+        }
+    }
+}
+
+fn create_layout(
+    device: &Device,
+    binding: u32,
+    descriptor_type: vk::DescriptorType,
+    stage_flags: vk::ShaderStageFlags,
+) -> Result<vk::DescriptorSetLayout> {
+    let binding = vk::DescriptorSetLayoutBinding::default()
+        .binding(binding)
+        .descriptor_type(descriptor_type)
+        .descriptor_count(1)
+        .stage_flags(stage_flags);
+
+    let info =
+        vk::DescriptorSetLayoutCreateInfo::default().bindings(std::slice::from_ref(&binding));
+
+    Ok(unsafe { device.create_descriptor_set_layout(&info, None)? })
+}
+
+/// A non-owning descriptor set handle allocated from a [`DescriptorAllocator`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DescriptorSet {
+    raw: vk::DescriptorSet,
+}
+
+impl DescriptorSet {
+    /// Creates a null descriptor set handle.
+    pub fn null() -> Self {
+        Self {
+            raw: vk::DescriptorSet::null(),
+        }
+    }
+
+    /// Returns the raw Vulkan descriptor set handle.
+    pub fn raw(self) -> vk::DescriptorSet {
+        self.raw
+    }
+}
+
+/// Descriptor count to reserve per descriptor set in each pool page.
+#[derive(Clone, Copy, Debug)]
+pub struct DescriptorPoolSize {
+    ty: vk::DescriptorType,
+    descriptors_per_set: u32,
+}
+
+impl DescriptorPoolSize {
+    /// Creates a descriptor pool size rule.
+    pub const fn new(ty: vk::DescriptorType, descriptors_per_set: u32) -> Self {
+        Self {
+            ty,
+            descriptors_per_set,
+        }
+    }
+}
+
+struct DescriptorPoolPage {
+    raw: vk::DescriptorPool,
+}
+
+/// Growable descriptor pool allocator.
+///
+/// Vulkan descriptor pools are fixed-size, so this allocator creates more pool
+/// pages when existing pages can no longer satisfy an allocation.
+pub struct DescriptorAllocator {
+    device: RenderDevice,
+    pool_sizes: Vec<DescriptorPoolSize>,
+    flags: vk::DescriptorPoolCreateFlags,
+    pools: Vec<DescriptorPoolPage>,
+    next_max_sets: u32,
+}
+
+impl DescriptorAllocator {
+    /// Creates a growable descriptor allocator.
+    pub fn new(
+        device: &RenderDevice,
+        pool_sizes: &[DescriptorPoolSize],
+        initial_max_sets: u32,
+    ) -> Result<Self> {
+        let initial_max_sets = initial_max_sets.max(1);
+        let mut allocator = Self {
+            device: device.clone(),
+            pool_sizes: pool_sizes.to_vec(),
+            flags: vk::DescriptorPoolCreateFlags::empty(),
+            pools: Vec::new(),
+            next_max_sets: initial_max_sets,
+        };
+        allocator.add_pool(initial_max_sets)?;
+        Ok(allocator)
+    }
+
+    /// Allocates `count` descriptor sets with the same layout.
+    pub fn allocate_many(
+        &mut self,
+        layout: vk::DescriptorSetLayout,
+        count: usize,
+    ) -> Result<Vec<DescriptorSet>> {
+        let layouts = vec![layout; count];
+        self.allocate(&layouts)
+    }
+
+    /// Allocates a fixed-size array of descriptor sets with the same layout.
+    pub fn allocate_array<const N: usize>(
+        &mut self,
+        layout: vk::DescriptorSetLayout,
+    ) -> Result<[DescriptorSet; N]> {
+        let layouts = [layout; N];
+        let sets = self.allocate(&layouts)?;
+        Ok(std::array::from_fn(|i| sets[i]))
+    }
+
+    /// Writes a uniform buffer descriptor into `set`.
+    pub fn write_uniform_buffer(
+        &self,
+        set: DescriptorSet,
+        binding: u32,
+        buffer: vk::Buffer,
+        range: vk::DeviceSize,
+    ) {
+        let buffer_info = vk::DescriptorBufferInfo::default()
+            .buffer(buffer)
+            .range(range)
+            .offset(0);
+        let write = vk::WriteDescriptorSet::default()
+            .dst_set(set.raw)
+            .dst_binding(binding)
+            .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
+            .buffer_info(std::slice::from_ref(&buffer_info));
+
+        unsafe {
+            self.device.device.update_descriptor_sets(&[write], &[]);
+        }
+    }
+
+    /// Writes a combined image sampler descriptor into `set`.
+    pub fn write_combined_image_sampler(
+        &self,
+        set: DescriptorSet,
+        binding: u32,
+        image_view: vk::ImageView,
+        sampler: vk::Sampler,
+    ) {
+        let image_info = vk::DescriptorImageInfo::default()
+            .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
+            .image_view(image_view)
+            .sampler(sampler);
+        let write = vk::WriteDescriptorSet::default()
+            .dst_set(set.raw)
+            .dst_binding(binding)
+            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+            .image_info(std::slice::from_ref(&image_info));
+
+        unsafe {
+            self.device.device.update_descriptor_sets(&[write], &[]);
+        }
+    }
+
+    fn allocate(&mut self, layouts: &[vk::DescriptorSetLayout]) -> Result<Vec<DescriptorSet>> {
+        if layouts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let required_sets = u32::try_from(layouts.len())
+            .map_err(|_| Error::DescriptorSetCountTooLarge(layouts.len()))?;
+
+        for pool in &self.pools {
+            match self.allocate_from_pool(pool.raw, layouts) {
+                Ok(sets) => return Ok(sets), // returns sets when pool is found
+                Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY | vk::Result::ERROR_FRAGMENTED_POOL) => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        // if no pool found, create one
+        let pool = self.add_pool(required_sets)?;
+        Ok(self.allocate_from_pool(pool, layouts)?)
+    }
+
+    fn allocate_from_pool(
+        &self,
+        pool: vk::DescriptorPool,
+        layouts: &[vk::DescriptorSetLayout],
+    ) -> VkResult<Vec<DescriptorSet>> {
+        let alloc_info = vk::DescriptorSetAllocateInfo::default()
+            .descriptor_pool(pool)
+            .set_layouts(layouts);
+
+        unsafe { self.device.device.allocate_descriptor_sets(&alloc_info) }.map(|sets| {
+            sets.into_iter()
+                .map(|raw| DescriptorSet { raw })
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn add_pool(&mut self, required_sets: u32) -> Result<vk::DescriptorPool> {
+        let max_sets = self.next_max_sets.max(required_sets).max(1);
+        self.next_max_sets = max_sets.saturating_mul(2).max(1);
+        let pool = self.create_pool(max_sets)?;
+        self.pools.push(DescriptorPoolPage { raw: pool });
+        Ok(pool)
+    }
+
+    fn create_pool(&self, max_sets: u32) -> Result<vk::DescriptorPool> {
+        let pool_sizes = self
+            .pool_sizes
+            .iter()
+            .map(|size| {
+                vk::DescriptorPoolSize::default()
+                    .ty(size.ty)
+                    .descriptor_count(size.descriptors_per_set.saturating_mul(max_sets).max(1))
+            })
+            .collect::<Vec<_>>();
+
+        let pool_info = vk::DescriptorPoolCreateInfo::default()
+            .flags(self.flags)
+            .pool_sizes(&pool_sizes)
+            .max_sets(max_sets);
+
+        Ok(unsafe {
+            self.device
+                .device
+                .create_descriptor_pool(&pool_info, None)?
+        })
+    }
+}
+
+impl Drop for DescriptorAllocator {
+    fn drop(&mut self) {
+        for pool in self.pools.drain(..) {
+            self.device.destroy(Garbage::DescriptorPool(pool.raw));
+        }
+    }
+}

--- a/crates/dirk_renderer/src/resources/descriptors.rs
+++ b/crates/dirk_renderer/src/resources/descriptors.rs
@@ -1,11 +1,19 @@
 //! Safe descriptor layout and descriptor pool helpers.
 
-use ash::{Device, prelude::VkResult, vk};
+mod allocator;
+mod layout_types;
+mod set;
+pub mod slots;
+mod writer;
 
-use crate::{
-    Error, Result,
-    resources::device::{Garbage, RenderDevice},
-};
+use ash::{Device, vk};
+
+pub use allocator::DescriptorAllocator;
+pub use layout_types::{MaterialLayout, ObjectLayout, SceneLayout, SetLayout};
+pub use set::DescriptorSet;
+pub use writer::DescriptorWriter;
+
+use crate::Result;
 
 /// All descriptor set layouts used by the renderer.
 pub struct DescriptorLayouts {
@@ -21,30 +29,19 @@ impl DescriptorLayouts {
     /// Creates the descriptor set layouts used by the renderer.
     pub fn create(device: &Device) -> Result<Self> {
         Ok(Self {
-            scene: create_layout(
-                device,
-                0,
-                vk::DescriptorType::UNIFORM_BUFFER,
-                vk::ShaderStageFlags::VERTEX,
-            )?,
-            object: create_layout(
-                device,
-                1,
-                vk::DescriptorType::UNIFORM_BUFFER,
-                vk::ShaderStageFlags::VERTEX,
-            )?,
-            material: create_layout(
-                device,
-                2,
-                vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
-                vk::ShaderStageFlags::FRAGMENT,
-            )?,
+            scene: create_layout::<SceneLayout>(device)?,
+            object: create_layout::<ObjectLayout>(device)?,
+            material: create_layout::<MaterialLayout>(device)?,
         })
     }
 
     /// Returns the layouts in pipeline set order.
     pub fn pipeline_layouts(&self) -> [vk::DescriptorSetLayout; 3] {
-        [self.scene, self.object, self.material]
+        let mut layouts = [vk::DescriptorSetLayout::null(); 3];
+        layouts[SceneLayout::SET_INDEX] = self.scene;
+        layouts[ObjectLayout::SET_INDEX] = self.object;
+        layouts[MaterialLayout::SET_INDEX] = self.material;
+        layouts
     }
 
     /// Destroys every descriptor set layout.
@@ -57,235 +54,14 @@ impl DescriptorLayouts {
     }
 }
 
-fn create_layout(
-    device: &Device,
-    binding: u32,
-    descriptor_type: vk::DescriptorType,
-    stage_flags: vk::ShaderStageFlags,
-) -> Result<vk::DescriptorSetLayout> {
+fn create_layout<L: SetLayout>(device: &Device) -> Result<vk::DescriptorSetLayout> {
     let binding = vk::DescriptorSetLayoutBinding::default()
-        .binding(binding)
-        .descriptor_type(descriptor_type)
-        .descriptor_count(1)
-        .stage_flags(stage_flags);
-
+        .binding(L::BINDING)
+        .descriptor_type(L::DESCRIPTOR_TYPE)
+        .descriptor_count(L::DESCRIPTORS_PER_SET)
+        .stage_flags(L::STAGE);
     let info =
         vk::DescriptorSetLayoutCreateInfo::default().bindings(std::slice::from_ref(&binding));
 
     Ok(unsafe { device.create_descriptor_set_layout(&info, None)? })
-}
-
-/// A non-owning descriptor set handle allocated from a [`DescriptorAllocator`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DescriptorSet {
-    raw: vk::DescriptorSet,
-}
-
-impl DescriptorSet {
-    /// Creates a null descriptor set handle.
-    pub fn null() -> Self {
-        Self {
-            raw: vk::DescriptorSet::null(),
-        }
-    }
-
-    /// Returns the raw Vulkan descriptor set handle.
-    pub fn raw(self) -> vk::DescriptorSet {
-        self.raw
-    }
-}
-
-/// Descriptor count to reserve per descriptor set in each pool page.
-#[derive(Clone, Copy, Debug)]
-pub struct DescriptorPoolSize {
-    ty: vk::DescriptorType,
-    descriptors_per_set: u32,
-}
-
-impl DescriptorPoolSize {
-    /// Creates a descriptor pool size rule.
-    pub const fn new(ty: vk::DescriptorType, descriptors_per_set: u32) -> Self {
-        Self {
-            ty,
-            descriptors_per_set,
-        }
-    }
-}
-
-struct DescriptorPoolPage {
-    raw: vk::DescriptorPool,
-}
-
-/// Growable descriptor pool allocator.
-///
-/// Vulkan descriptor pools are fixed-size, so this allocator creates more pool
-/// pages when existing pages can no longer satisfy an allocation.
-pub struct DescriptorAllocator {
-    device: RenderDevice,
-    pool_sizes: Vec<DescriptorPoolSize>,
-    flags: vk::DescriptorPoolCreateFlags,
-    pools: Vec<DescriptorPoolPage>,
-    next_max_sets: u32,
-}
-
-impl DescriptorAllocator {
-    /// Creates a growable descriptor allocator.
-    pub fn new(
-        device: &RenderDevice,
-        pool_sizes: &[DescriptorPoolSize],
-        initial_max_sets: u32,
-    ) -> Result<Self> {
-        let initial_max_sets = initial_max_sets.max(1);
-        let mut allocator = Self {
-            device: device.clone(),
-            pool_sizes: pool_sizes.to_vec(),
-            flags: vk::DescriptorPoolCreateFlags::empty(),
-            pools: Vec::new(),
-            next_max_sets: initial_max_sets,
-        };
-        allocator.add_pool(initial_max_sets)?;
-        Ok(allocator)
-    }
-
-    /// Allocates `count` descriptor sets with the same layout.
-    pub fn allocate_many(
-        &mut self,
-        layout: vk::DescriptorSetLayout,
-        count: usize,
-    ) -> Result<Vec<DescriptorSet>> {
-        let layouts = vec![layout; count];
-        self.allocate(&layouts)
-    }
-
-    /// Allocates a fixed-size array of descriptor sets with the same layout.
-    pub fn allocate_array<const N: usize>(
-        &mut self,
-        layout: vk::DescriptorSetLayout,
-    ) -> Result<[DescriptorSet; N]> {
-        let layouts = [layout; N];
-        let sets = self.allocate(&layouts)?;
-        Ok(std::array::from_fn(|i| sets[i]))
-    }
-
-    /// Writes a uniform buffer descriptor into `set`.
-    pub fn write_uniform_buffer(
-        &self,
-        set: DescriptorSet,
-        binding: u32,
-        buffer: vk::Buffer,
-        range: vk::DeviceSize,
-    ) {
-        let buffer_info = vk::DescriptorBufferInfo::default()
-            .buffer(buffer)
-            .range(range)
-            .offset(0);
-        let write = vk::WriteDescriptorSet::default()
-            .dst_set(set.raw)
-            .dst_binding(binding)
-            .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
-            .buffer_info(std::slice::from_ref(&buffer_info));
-
-        unsafe {
-            self.device.device.update_descriptor_sets(&[write], &[]);
-        }
-    }
-
-    /// Writes a combined image sampler descriptor into `set`.
-    pub fn write_combined_image_sampler(
-        &self,
-        set: DescriptorSet,
-        binding: u32,
-        image_view: vk::ImageView,
-        sampler: vk::Sampler,
-    ) {
-        let image_info = vk::DescriptorImageInfo::default()
-            .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
-            .image_view(image_view)
-            .sampler(sampler);
-        let write = vk::WriteDescriptorSet::default()
-            .dst_set(set.raw)
-            .dst_binding(binding)
-            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-            .image_info(std::slice::from_ref(&image_info));
-
-        unsafe {
-            self.device.device.update_descriptor_sets(&[write], &[]);
-        }
-    }
-
-    fn allocate(&mut self, layouts: &[vk::DescriptorSetLayout]) -> Result<Vec<DescriptorSet>> {
-        if layouts.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let required_sets = u32::try_from(layouts.len())
-            .map_err(|_| Error::DescriptorSetCountTooLarge(layouts.len()))?;
-
-        for pool in &self.pools {
-            match self.allocate_from_pool(pool.raw, layouts) {
-                Ok(sets) => return Ok(sets), // returns sets when pool is found
-                Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY | vk::Result::ERROR_FRAGMENTED_POOL) => {}
-                Err(error) => return Err(error.into()),
-            }
-        }
-
-        // if no pool found, create one
-        let pool = self.add_pool(required_sets)?;
-        Ok(self.allocate_from_pool(pool, layouts)?)
-    }
-
-    fn allocate_from_pool(
-        &self,
-        pool: vk::DescriptorPool,
-        layouts: &[vk::DescriptorSetLayout],
-    ) -> VkResult<Vec<DescriptorSet>> {
-        let alloc_info = vk::DescriptorSetAllocateInfo::default()
-            .descriptor_pool(pool)
-            .set_layouts(layouts);
-
-        unsafe { self.device.device.allocate_descriptor_sets(&alloc_info) }.map(|sets| {
-            sets.into_iter()
-                .map(|raw| DescriptorSet { raw })
-                .collect::<Vec<_>>()
-        })
-    }
-
-    fn add_pool(&mut self, required_sets: u32) -> Result<vk::DescriptorPool> {
-        let max_sets = self.next_max_sets.max(required_sets).max(1);
-        self.next_max_sets = max_sets.saturating_mul(2).max(1);
-        let pool = self.create_pool(max_sets)?;
-        self.pools.push(DescriptorPoolPage { raw: pool });
-        Ok(pool)
-    }
-
-    fn create_pool(&self, max_sets: u32) -> Result<vk::DescriptorPool> {
-        let pool_sizes = self
-            .pool_sizes
-            .iter()
-            .map(|size| {
-                vk::DescriptorPoolSize::default()
-                    .ty(size.ty)
-                    .descriptor_count(size.descriptors_per_set.saturating_mul(max_sets).max(1))
-            })
-            .collect::<Vec<_>>();
-
-        let pool_info = vk::DescriptorPoolCreateInfo::default()
-            .flags(self.flags)
-            .pool_sizes(&pool_sizes)
-            .max_sets(max_sets);
-
-        Ok(unsafe {
-            self.device
-                .device
-                .create_descriptor_pool(&pool_info, None)?
-        })
-    }
-}
-
-impl Drop for DescriptorAllocator {
-    fn drop(&mut self) {
-        for pool in self.pools.drain(..) {
-            self.device.destroy(Garbage::DescriptorPool(pool.raw));
-        }
-    }
 }

--- a/crates/dirk_renderer/src/resources/descriptors/allocator.rs
+++ b/crates/dirk_renderer/src/resources/descriptors/allocator.rs
@@ -1,0 +1,120 @@
+//! Typed descriptor set allocator.
+
+use std::{marker::PhantomData, mem::MaybeUninit};
+
+use ash::vk;
+
+use crate::{
+    Result,
+    resources::device::{Garbage, RenderDevice},
+};
+
+use super::{layout_types::SetLayout, set::DescriptorSet};
+
+/// Growable descriptor pool allocator for a single layout type.
+pub struct DescriptorAllocator<L: SetLayout> {
+    device: RenderDevice,
+    layout: vk::DescriptorSetLayout,
+    pools: Vec<vk::DescriptorPool>,
+    cursor: usize,
+    next_max_sets: u32,
+    _layout: PhantomData<L>,
+}
+
+impl<L: SetLayout> DescriptorAllocator<L> {
+    /// Creates an allocator with one initial pool page.
+    pub fn new(device: &RenderDevice, initial_max_sets: u32) -> Result<Self> {
+        let initial_max_sets = initial_max_sets.max(1);
+        let mut allocator = Self {
+            device: device.clone(),
+            layout: L::layout(&device.layouts),
+            pools: Vec::new(),
+            cursor: 0,
+            next_max_sets: initial_max_sets,
+            _layout: PhantomData,
+        };
+        allocator.add_page(initial_max_sets)?;
+        Ok(allocator)
+    }
+
+    /// Allocates one descriptor set.
+    pub fn allocate(&mut self) -> Result<DescriptorSet<L>> {
+        if !self.pools.is_empty() {
+            match self.allocate_from(self.cursor) {
+                Ok(set) => return Ok(set),
+                Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY | vk::Result::ERROR_FRAGMENTED_POOL) => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        let page_index = self.add_page(1)?;
+        self.allocate_from(page_index).map_err(Into::into)
+    }
+
+    /// Allocates exactly `N` descriptor sets.
+    pub fn allocate_array<const N: usize>(&mut self) -> Result<[DescriptorSet<L>; N]> {
+        let mut out: [MaybeUninit<DescriptorSet<L>>; N] =
+            std::array::from_fn(|_| MaybeUninit::uninit());
+
+        for i in 0..N {
+            match self.allocate() {
+                Ok(set) => {
+                    out[i].write(set);
+                }
+                Err(error) => {
+                    for initialized in out.iter_mut().take(i) {
+                        // SAFETY: slots before `i` were initialized above.
+                        unsafe { initialized.assume_init_drop() };
+                    }
+                    return Err(error);
+                }
+            }
+        }
+
+        // SAFETY: every slot was initialized by the loop above.
+        Ok(std::array::from_fn(|i| unsafe {
+            out[i].assume_init_read()
+        }))
+    }
+
+    fn allocate_from(&self, page_index: usize) -> ash::prelude::VkResult<DescriptorSet<L>> {
+        let pool = self.pools[page_index];
+        let alloc_info = vk::DescriptorSetAllocateInfo::default()
+            .descriptor_pool(pool)
+            .set_layouts(std::slice::from_ref(&self.layout));
+        let raw_sets = unsafe { self.device.device.allocate_descriptor_sets(&alloc_info)? };
+        Ok(DescriptorSet::new(self.device.clone(), pool, raw_sets[0]))
+    }
+
+    fn add_page(&mut self, required_sets: u32) -> Result<usize> {
+        let max_sets = self.next_max_sets.max(required_sets).max(1);
+        self.next_max_sets = max_sets.saturating_mul(2).max(1);
+
+        let pool_size = vk::DescriptorPoolSize::default()
+            .ty(L::DESCRIPTOR_TYPE)
+            .descriptor_count(L::DESCRIPTORS_PER_SET.saturating_mul(max_sets).max(1));
+
+        let pool_info = vk::DescriptorPoolCreateInfo::default()
+            .flags(vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET)
+            .pool_sizes(std::slice::from_ref(&pool_size))
+            .max_sets(max_sets);
+
+        let pool = unsafe {
+            self.device
+                .device
+                .create_descriptor_pool(&pool_info, None)?
+        };
+        let index = self.pools.len();
+        self.pools.push(pool);
+        self.cursor = index;
+        Ok(index)
+    }
+}
+
+impl<L: SetLayout> Drop for DescriptorAllocator<L> {
+    fn drop(&mut self) {
+        for pool in self.pools.drain(..) {
+            self.device.destroy(Garbage::DescriptorPool(pool));
+        }
+    }
+}

--- a/crates/dirk_renderer/src/resources/descriptors/layout_types.rs
+++ b/crates/dirk_renderer/src/resources/descriptors/layout_types.rs
@@ -1,0 +1,89 @@
+//! Compile-time marker types for descriptor set layouts.
+
+use ash::vk;
+
+use super::{DescriptorLayouts, slots};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Associates a Rust marker type with a specific Vulkan descriptor set layout.
+pub trait SetLayout: sealed::Sealed + Send + Sync + 'static {
+    /// Pipeline set index (`set = N` in GLSL).
+    #[allow(dead_code)]
+    const SET_SLOT: u32;
+    /// Pipeline set index as a Rust array index.
+    const SET_INDEX: usize;
+    /// Binding index within the set (`binding = M` in GLSL).
+    const BINDING: u32;
+    /// Shader stages that access this set.
+    const STAGE: vk::ShaderStageFlags;
+    /// Vulkan descriptor type for the single binding in this set.
+    const DESCRIPTOR_TYPE: vk::DescriptorType;
+    /// Number of descriptors in the single binding.
+    const DESCRIPTORS_PER_SET: u32;
+
+    /// Retrieves the pre-built layout handle from the global layout registry.
+    fn layout(layouts: &DescriptorLayouts) -> vk::DescriptorSetLayout;
+}
+
+/// Layouts whose single binding is a uniform buffer.
+pub trait UniformBufferLayout: SetLayout {}
+
+/// Layouts whose single binding is a combined image sampler.
+pub trait CombinedImageSamplerLayout: SetLayout {}
+
+/// Marker for the per-scene descriptor set.
+pub struct SceneLayout;
+/// Marker for the per-object descriptor set.
+pub struct ObjectLayout;
+/// Marker for the per-material descriptor set.
+pub struct MaterialLayout;
+
+impl sealed::Sealed for SceneLayout {}
+impl sealed::Sealed for ObjectLayout {}
+impl sealed::Sealed for MaterialLayout {}
+
+impl SetLayout for SceneLayout {
+    const SET_SLOT: u32 = slots::SCENE_SET;
+    const SET_INDEX: usize = slots::SCENE_SET_INDEX;
+    const BINDING: u32 = slots::SCENE_BINDING;
+    const STAGE: vk::ShaderStageFlags = slots::SCENE_STAGE;
+    const DESCRIPTOR_TYPE: vk::DescriptorType = vk::DescriptorType::UNIFORM_BUFFER;
+    const DESCRIPTORS_PER_SET: u32 = 1;
+
+    fn layout(layouts: &DescriptorLayouts) -> vk::DescriptorSetLayout {
+        layouts.scene
+    }
+}
+
+impl SetLayout for ObjectLayout {
+    const SET_SLOT: u32 = slots::OBJECT_SET;
+    const SET_INDEX: usize = slots::OBJECT_SET_INDEX;
+    const BINDING: u32 = slots::OBJECT_BINDING;
+    const STAGE: vk::ShaderStageFlags = slots::OBJECT_STAGE;
+    const DESCRIPTOR_TYPE: vk::DescriptorType = vk::DescriptorType::UNIFORM_BUFFER;
+    const DESCRIPTORS_PER_SET: u32 = 1;
+
+    fn layout(layouts: &DescriptorLayouts) -> vk::DescriptorSetLayout {
+        layouts.object
+    }
+}
+
+impl SetLayout for MaterialLayout {
+    const SET_SLOT: u32 = slots::MATERIAL_SET;
+    const SET_INDEX: usize = slots::MATERIAL_SET_INDEX;
+    const BINDING: u32 = slots::MATERIAL_BINDING;
+    const STAGE: vk::ShaderStageFlags = slots::MATERIAL_STAGE;
+    const DESCRIPTOR_TYPE: vk::DescriptorType = vk::DescriptorType::COMBINED_IMAGE_SAMPLER;
+    const DESCRIPTORS_PER_SET: u32 = 1;
+
+    fn layout(layouts: &DescriptorLayouts) -> vk::DescriptorSetLayout {
+        layouts.material
+    }
+}
+
+impl UniformBufferLayout for SceneLayout {}
+impl UniformBufferLayout for ObjectLayout {}
+impl CombinedImageSamplerLayout for MaterialLayout {}

--- a/crates/dirk_renderer/src/resources/descriptors/set.rs
+++ b/crates/dirk_renderer/src/resources/descriptors/set.rs
@@ -1,0 +1,50 @@
+//! Owned descriptor set handle.
+
+use std::marker::PhantomData;
+
+use ash::vk;
+
+use crate::resources::device::{Garbage, RenderDevice};
+
+use super::layout_types::SetLayout;
+
+/// An owned Vulkan descriptor set with deferred RAII cleanup.
+///
+/// The phantom type `L` ensures that descriptor sets allocated for different
+/// layouts cannot be mixed up at the call site.
+pub struct DescriptorSet<L: SetLayout> {
+    device: RenderDevice,
+    pool: vk::DescriptorPool,
+    raw: vk::DescriptorSet,
+    _layout: PhantomData<L>,
+}
+
+impl<L: SetLayout> DescriptorSet<L> {
+    /// Returns the raw Vulkan handle.
+    #[inline]
+    pub fn raw(&self) -> vk::DescriptorSet {
+        self.raw
+    }
+
+    pub(super) fn new(
+        device: RenderDevice,
+        pool: vk::DescriptorPool,
+        raw: vk::DescriptorSet,
+    ) -> Self {
+        Self {
+            device,
+            pool,
+            raw,
+            _layout: PhantomData,
+        }
+    }
+}
+
+impl<L: SetLayout> Drop for DescriptorSet<L> {
+    fn drop(&mut self) {
+        self.device.destroy(Garbage::DescriptorSet {
+            pool: self.pool,
+            set: self.raw,
+        });
+    }
+}

--- a/crates/dirk_renderer/src/resources/descriptors/slots.rs
+++ b/crates/dirk_renderer/src/resources/descriptors/slots.rs
@@ -1,0 +1,33 @@
+//! Single source of truth for descriptor set slot assignments.
+//!
+//! Every number here must match the corresponding `layout(set=N, binding=M)`
+//! annotation in the GLSL shaders.
+
+use ash::vk;
+
+/// Pipeline set slot for the per-scene uniform buffer.
+pub const SCENE_SET: u32 = 0;
+/// Pipeline set slot for the per-scene uniform buffer as an array index.
+pub const SCENE_SET_INDEX: usize = SCENE_SET as usize;
+/// Binding index for scene data within the scene set.
+pub const SCENE_BINDING: u32 = 0;
+/// Shader stages that read the scene set.
+pub const SCENE_STAGE: vk::ShaderStageFlags = vk::ShaderStageFlags::VERTEX;
+
+/// Pipeline set slot for the per-object uniform buffer.
+pub const OBJECT_SET: u32 = 1;
+/// Pipeline set slot for the per-object uniform buffer as an array index.
+pub const OBJECT_SET_INDEX: usize = OBJECT_SET as usize;
+/// Binding index for object data within the object set.
+pub const OBJECT_BINDING: u32 = 1;
+/// Shader stages that read the object set.
+pub const OBJECT_STAGE: vk::ShaderStageFlags = vk::ShaderStageFlags::VERTEX;
+
+/// Pipeline set slot for the per-material combined image sampler.
+pub const MATERIAL_SET: u32 = 2;
+/// Pipeline set slot for the per-material sampler as an array index.
+pub const MATERIAL_SET_INDEX: usize = MATERIAL_SET as usize;
+/// Binding index for material data within the material set.
+pub const MATERIAL_BINDING: u32 = 2;
+/// Shader stages that read the material set.
+pub const MATERIAL_STAGE: vk::ShaderStageFlags = vk::ShaderStageFlags::FRAGMENT;

--- a/crates/dirk_renderer/src/resources/descriptors/writer.rs
+++ b/crates/dirk_renderer/src/resources/descriptors/writer.rs
@@ -1,0 +1,147 @@
+//! Batched descriptor set writes.
+
+use ash::vk;
+
+use super::{
+    layout_types::{CombinedImageSamplerLayout, UniformBufferLayout},
+    set::DescriptorSet,
+};
+
+enum WriteOp {
+    UniformBuffer {
+        set: vk::DescriptorSet,
+        binding: u32,
+        buffer: vk::Buffer,
+        offset: vk::DeviceSize,
+        range: vk::DeviceSize,
+    },
+    CombinedImageSampler {
+        set: vk::DescriptorSet,
+        binding: u32,
+        view: vk::ImageView,
+        sampler: vk::Sampler,
+        image_layout: vk::ImageLayout,
+    },
+}
+
+/// Collects descriptor writes and submits them in one Vulkan call.
+pub struct DescriptorWriter<'dev> {
+    device: &'dev ash::Device,
+    ops: Vec<WriteOp>,
+}
+
+impl<'dev> DescriptorWriter<'dev> {
+    /// Creates an empty writer.
+    pub fn new(device: &'dev ash::Device) -> Self {
+        Self {
+            device,
+            ops: Vec::new(),
+        }
+    }
+
+    /// Adds a uniform-buffer descriptor write.
+    pub fn uniform_buffer<L: UniformBufferLayout>(
+        mut self,
+        set: &DescriptorSet<L>,
+        buffer: vk::Buffer,
+        range: vk::DeviceSize,
+    ) -> Self {
+        self.ops.push(WriteOp::UniformBuffer {
+            set: set.raw(),
+            binding: L::BINDING,
+            buffer,
+            offset: 0,
+            range,
+        });
+        self
+    }
+
+    /// Adds a combined image sampler descriptor write.
+    pub fn combined_image_sampler<L: CombinedImageSamplerLayout>(
+        mut self,
+        set: &DescriptorSet<L>,
+        view: vk::ImageView,
+        sampler: vk::Sampler,
+    ) -> Self {
+        self.ops.push(WriteOp::CombinedImageSampler {
+            set: set.raw(),
+            binding: L::BINDING,
+            view,
+            sampler,
+            image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+        });
+        self
+    }
+
+    /// Submits all pending writes.
+    pub fn flush(self) {
+        if self.ops.is_empty() {
+            return;
+        }
+
+        let mut buffer_infos = Vec::new();
+        let mut image_infos = Vec::new();
+
+        for op in &self.ops {
+            match op {
+                WriteOp::UniformBuffer {
+                    buffer,
+                    offset,
+                    range,
+                    ..
+                } => {
+                    buffer_infos.push(
+                        vk::DescriptorBufferInfo::default()
+                            .buffer(*buffer)
+                            .offset(*offset)
+                            .range(*range),
+                    );
+                }
+                WriteOp::CombinedImageSampler {
+                    view,
+                    sampler,
+                    image_layout,
+                    ..
+                } => {
+                    image_infos.push(
+                        vk::DescriptorImageInfo::default()
+                            .image_layout(*image_layout)
+                            .image_view(*view)
+                            .sampler(*sampler),
+                    );
+                }
+            }
+        }
+
+        let mut buffer_index = 0usize;
+        let mut image_index = 0usize;
+        let writes = self
+            .ops
+            .iter()
+            .map(|op| match op {
+                WriteOp::UniformBuffer { set, binding, .. } => {
+                    let write = vk::WriteDescriptorSet::default()
+                        .dst_set(*set)
+                        .dst_binding(*binding)
+                        .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
+                        .buffer_info(&buffer_infos[buffer_index..=buffer_index]);
+                    buffer_index += 1;
+                    write
+                }
+                WriteOp::CombinedImageSampler { set, binding, .. } => {
+                    let write = vk::WriteDescriptorSet::default()
+                        .dst_set(*set)
+                        .dst_binding(*binding)
+                        .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+                        .image_info(&image_infos[image_index..=image_index]);
+                    image_index += 1;
+                    write
+                }
+            })
+            .collect::<Vec<_>>();
+
+        unsafe {
+            self.device.update_descriptor_sets(&writes, &[]);
+        }
+    }
+}

--- a/crates/dirk_renderer/src/resources/device.rs
+++ b/crates/dirk_renderer/src/resources/device.rs
@@ -90,44 +90,7 @@ impl RenderDevice {
         let swapchain_loader = swapchain::Device::new(&instance, &device);
 
         // LAYOUTS
-        let layouts = DescriptorLayouts {
-            scene: {
-                let binding = vk::DescriptorSetLayoutBinding::default()
-                    .binding(0)
-                    .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
-                    .descriptor_count(1)
-                    .stage_flags(vk::ShaderStageFlags::VERTEX);
-
-                let info = vk::DescriptorSetLayoutCreateInfo::default()
-                    .bindings(std::slice::from_ref(&binding));
-
-                unsafe { device.create_descriptor_set_layout(&info, None)? }
-            },
-            object: {
-                let binding = vk::DescriptorSetLayoutBinding::default()
-                    .binding(1)
-                    .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
-                    .descriptor_count(1)
-                    .stage_flags(vk::ShaderStageFlags::VERTEX);
-
-                let info = vk::DescriptorSetLayoutCreateInfo::default()
-                    .bindings(std::slice::from_ref(&binding));
-
-                unsafe { device.create_descriptor_set_layout(&info, None)? }
-            },
-            material: {
-                let binding = vk::DescriptorSetLayoutBinding::default()
-                    .binding(2)
-                    .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-                    .descriptor_count(1)
-                    .stage_flags(vk::ShaderStageFlags::FRAGMENT);
-
-                let info = vk::DescriptorSetLayoutCreateInfo::default()
-                    .bindings(std::slice::from_ref(&binding));
-
-                unsafe { device.create_descriptor_set_layout(&info, None)? }
-            },
-        };
+        let layouts = DescriptorLayouts::create(&device)?;
 
         // QUEUES
         let queues = Queues::new(&instance, &device, &properties.queue_family_indices);

--- a/crates/dirk_renderer/src/resources/device.rs
+++ b/crates/dirk_renderer/src/resources/device.rs
@@ -198,6 +198,10 @@ pub enum Garbage {
     Sampler(vk::Sampler),
     Pipeline(vk::Pipeline),
     PipelineLayout(vk::PipelineLayout),
+    DescriptorSet {
+        pool: vk::DescriptorPool,
+        set: vk::DescriptorSet,
+    },
     DescriptorPool(vk::DescriptorPool),
     Semaphore(vk::Semaphore),
 
@@ -271,6 +275,9 @@ impl Garbage {
                 Self::Sampler(s) => device.destroy_sampler(s, None),
                 Self::Pipeline(p) => device.destroy_pipeline(p, None),
                 Self::PipelineLayout(l) => device.destroy_pipeline_layout(l, None),
+                Self::DescriptorSet { pool, set } => {
+                    let _ = device.free_descriptor_sets(pool, &[set]);
+                }
                 Self::DescriptorPool(pool) => device.destroy_descriptor_pool(pool, None),
                 Self::Semaphore(semaphore) => device.destroy_semaphore(semaphore, None),
                 Self::Surface(surface) => {

--- a/crates/dirk_renderer/src/utils.rs
+++ b/crates/dirk_renderer/src/utils.rs
@@ -73,32 +73,6 @@ impl Drop for Frame {
     }
 }
 
-/// This struct is owned by [Renderer] and stores
-/// all the different descriptor set layouts used by
-/// the renderer.
-/// Every field should be a descriptor set layout with a
-/// propper comment explain what the layout is and where
-/// it is used.
-pub struct DescriptorLayouts {
-    // TODO: much better comments for descriptor set layouts
-    /// Per scene layout. Holds view & proj matrices for rendering.
-    pub scene: vk::DescriptorSetLayout,
-    /// Per object layout. For model matrix.
-    pub object: vk::DescriptorSetLayout,
-    /// Per material layout. For texture descriptor.
-    pub material: vk::DescriptorSetLayout,
-}
-
-impl DescriptorLayouts {
-    pub fn destroy(&self, device: &Device) {
-        unsafe {
-            device.destroy_descriptor_set_layout(self.scene, None);
-            device.destroy_descriptor_set_layout(self.object, None);
-            device.destroy_descriptor_set_layout(self.material, None);
-        }
-    }
-}
-
 pub struct RendererProperties {
     pub msaa_samples: vk::SampleCountFlags,
     #[allow(unused)]


### PR DESCRIPTION
## Summary
Refactors renderer descriptor management to use typed, owned descriptor sets with deferred cleanup instead of copied raw handles.

## What changed
- split renderer descriptor helpers into dedicated modules for slot constants, layout marker types, owned sets, allocators, and batched writers
- replaced the old untyped descriptor allocator with `DescriptorAllocator<L>` and `OwnedSet<L>` so scene, object, and material sets are layout-typed and freed through the renderer deletion queue
- added deferred `DescriptorSet` cleanup in the render device and updated scene/model drop ordering to ensure set frees are enqueued before pool destruction
- migrated `SceneManager`, `Scene`, `SceneProxy`, and `ModelRegistry` to the new typed descriptor APIs
- batched descriptor writes through `DescriptorWriter` instead of issuing one Vulkan update call per write
- cleaned up model unload so meshes, materials, textures, and material descriptor sets are removed together
- converted glTF material texture assumptions into renderer errors and made model loading roll back partial GPU/resource insertion on failure

## Validation
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy -p dirk_renderer --all-targets --all-features`