### PR TITLE
add graceful shutdown on os signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,7 @@ dependencies = [
  "dirk_utils",
  "parking_lot",
  "piquel-log",
+ "signal-hook",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -2103,6 +2104,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ piquel-log = { version = "0.0.5", features = ["log", "file"] }
 parking_lot = "0.12"
 tempfile = "3"
 slotmap = "1"
+signal-hook = "0.4"
 
 thiserror = "2"
 anyhow = "1"

--- a/crates/dirk_engine/Cargo.toml
+++ b/crates/dirk_engine/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 parking_lot.workspace = true
 piquel-log.workspace = true
+signal-hook.workspace = true
 
 dirk_threads.workspace = true
 dirk_events.workspace = true

--- a/crates/dirk_engine/src/builder.rs
+++ b/crates/dirk_engine/src/builder.rs
@@ -15,7 +15,7 @@ use tracing::info;
 
 use crate::{
     Engine, EngineHandle, EngineMetadata, EnginePlugin, EngineResource, EngineState, Result,
-    Subsystem, errors::Error,
+    Subsystem, errors::Error, signal::OperatingSystemSignals,
 };
 
 type SubsystemFactory =
@@ -205,7 +205,10 @@ impl EngineBuilder {
             builder: Universe::builder(),
         };
 
+        let signals = OperatingSystemSignals::install().map_err(Error::SignalHandlerInitFailed)?;
+
         let mut subsystems = Vec::with_capacity(self.subsystem_factories.len());
+
         for type_id in self.subsystem_order {
             if let Some(factory) = self.subsystem_factories.remove(&type_id) {
                 subsystems.push(factory(&mut context).map_err(Error::SubsystemFailedInit)?);
@@ -221,6 +224,7 @@ impl EngineBuilder {
             state,
             handle,
             command_receiver,
+            signals,
             frame_dispatcher: events.register(),
             exiting_dispatcher: events.register(),
             last_tick: Instant::now(),

--- a/crates/dirk_engine/src/errors.rs
+++ b/crates/dirk_engine/src/errors.rs
@@ -76,6 +76,9 @@ pub enum Error {
     /// When an engine subsystem failed to initialize.
     #[error("subsystem failed to initialize: {0}")]
     SubsystemFailedInit(#[source] anyhow::Error),
+    /// When operating system signal handlers failed to initialize.
+    #[error("failed to initialize operating system signal handlers: {0}")]
+    SignalHandlerInitFailed(#[source] anyhow::Error),
     /// An error occurred while starting.
     #[error("engine failed to start: {0}")]
     StartFailed(#[source] anyhow::Error),

--- a/crates/dirk_engine/src/lib.rs
+++ b/crates/dirk_engine/src/lib.rs
@@ -79,10 +79,10 @@ use tracing::error;
 
 pub mod errors;
 pub mod events;
-pub mod signal;
 pub mod subsystem;
 
 mod builder;
+mod signal;
 pub use builder::{EngineBuildContext, EngineBuilder};
 
 use errors::{Error, Result};
@@ -158,6 +158,7 @@ pub struct Engine {
     state: Arc<EngineState>,
     handle: EngineHandle,
     command_receiver: Receiver<EngineCommand>,
+    signals: signal::OperatingSystemSignals,
     frame_dispatcher: dirk_events::Dispatcher<events::BeginFrame>,
     exiting_dispatcher: dirk_events::Dispatcher<events::Exiting>,
     last_tick: Instant,
@@ -241,6 +242,11 @@ impl Engine {
             return Ok(self.status());
         }
 
+        self.process_operating_system_signals();
+        if self.is_exiting() {
+            return Ok(self.status());
+        }
+
         let frame = self.state.increment_frame();
         self.frame_dispatcher.dispatch(events::BeginFrame(frame));
 
@@ -306,6 +312,7 @@ impl Engine {
                 })?;
         }
 
+        self.signals.shutdown();
         self.shutdown = true;
         self.state.set_status(EngineStatus::Exited);
         Ok(())
@@ -329,6 +336,12 @@ impl Engine {
             match command {
                 EngineCommand::RequestExit(error) => self.request_exit(error),
             }
+        }
+    }
+
+    fn process_operating_system_signals(&mut self) {
+        if self.signals.exit_requested() {
+            self.request_exit(None);
         }
     }
 

--- a/crates/dirk_engine/src/lib.rs
+++ b/crates/dirk_engine/src/lib.rs
@@ -79,6 +79,7 @@ use tracing::error;
 
 pub mod errors;
 pub mod events;
+pub mod signal;
 pub mod subsystem;
 
 mod builder;

--- a/crates/dirk_engine/src/signal.rs
+++ b/crates/dirk_engine/src/signal.rs
@@ -4,6 +4,13 @@
 //! inside the OS signal context. `signal-hook` writes notifications into a pipe,
 //! a background thread forwards them to this subsystem, and the subsystem asks
 //! the engine to exit during the normal tick flow.
+//!
+//! This is intentionally scoped to terminal and service-manager workflows. On
+//! Unix-like systems this covers common termination signals such as `SIGINT`,
+//! `SIGTERM`, `SIGHUP`, and `SIGQUIT`. On Windows, `signal-hook` is limited to
+//! CRT signal emulation, so this covers `SIGINT` and `SIGBREAK` only. Console
+//! close, logoff, shutdown events, and normal game-window close events are
+//! handled elsewhere by platform/window integration.
 
 use std::{
     sync::{
@@ -13,37 +20,16 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-use dirk_universe::Universe;
 use signal_hook::{
     iterator::{Handle as SignalIteratorHandle, Signals},
     low_level::{emulate_default_handler, signal_name},
 };
 use tracing::{debug, error, info, warn};
 
-use crate::{EngineBuilder, EngineHandle, EnginePlugin, Subsystem};
-
 #[cfg(windows)]
-use signal_hook::consts::signal::{SIGABRT, SIGBREAK, SIGINT, SIGTERM};
+use signal_hook::consts::signal::{SIGBREAK, SIGINT};
 #[cfg(not(windows))]
-use signal_hook::consts::signal::{SIGABRT, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
-
-/// Registers operating system signal handlers with the engine.
-///
-/// The first handled signal requests graceful engine shutdown. Handled signals
-/// include `SIGINT`, `SIGTERM`, and `SIGABRT`, plus platform-specific console
-/// termination signals where available.
-pub struct OperatingSystemSignalPlugin;
-
-impl EnginePlugin for OperatingSystemSignalPlugin {
-    fn name(&self) -> &'static str {
-        "operating-system-signals"
-    }
-
-    fn build(&self, builder: &mut EngineBuilder) -> anyhow::Result<()> {
-        builder.add_subsystem(|_ctx| OperatingSystemSignalSubsystem::install());
-        Ok(())
-    }
-}
+use signal_hook::consts::signal::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct OperatingSystemSignal {
@@ -118,17 +104,20 @@ impl Drop for SignalListener {
     }
 }
 
-struct OperatingSystemSignalSubsystem {
+pub(crate) struct OperatingSystemSignals {
     receiver: Receiver<OperatingSystemSignal>,
     listener: Option<SignalListener>,
 }
 
-impl OperatingSystemSignalSubsystem {
-    fn install() -> anyhow::Result<Self> {
+impl OperatingSystemSignals {
+    pub(crate) fn install() -> anyhow::Result<Self> {
         let (sender, receiver) = mpsc::channel();
         let listener = SignalListener::install(sender)?;
 
-        info!(signals = ?handled_signals(), "installed operating system signal handlers");
+        info!(
+            signals = ?handled_signal_names(),
+            "installed operating system signal handlers",
+        );
         Ok(Self {
             receiver,
             listener: Some(listener),
@@ -142,67 +131,94 @@ impl OperatingSystemSignalSubsystem {
             listener: None,
         }
     }
-}
 
-impl Subsystem for OperatingSystemSignalSubsystem {
-    fn name(&self) -> &'static str {
-        "operating-system-signals"
+    #[cfg(test)]
+    pub(crate) fn empty_for_tests() -> Self {
+        let (_sender, receiver) = mpsc::channel();
+        Self::from_receiver(receiver)
     }
 
-    fn tick(
-        &mut self,
-        _delta_time: f64,
-        handle: &EngineHandle,
-        _universe: &mut Universe,
-    ) -> anyhow::Result<()> {
-        if let Some(signal) = self.receiver.try_iter().next() {
+    #[cfg(test)]
+    pub(crate) fn with_signal_for_tests(signal: i32) -> anyhow::Result<Self> {
+        let (sender, receiver) = mpsc::channel();
+        sender.send(OperatingSystemSignal::new(signal))?;
+        Ok(Self::from_receiver(receiver))
+    }
+
+    pub(crate) fn exit_requested(&mut self) -> bool {
+        if let Ok(signal) = self.receiver.try_recv() {
             warn!(
                 signal = signal.number,
                 name = signal.name(),
                 "operating system signal received; requesting engine shutdown",
             );
-            handle.exit();
+            return true;
         }
 
-        Ok(())
+        false
     }
 
-    fn shutdown(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    pub(crate) fn shutdown(&mut self) {
         if let Some(mut listener) = self.listener.take() {
             listener.shutdown();
             debug!("shut down operating system signal listener");
         }
-
-        Ok(())
     }
 }
 
 #[cfg(not(windows))]
 fn handled_signals() -> &'static [i32] {
-    &[SIGINT, SIGTERM, SIGABRT, SIGHUP, SIGQUIT]
+    &[SIGINT, SIGTERM, SIGHUP, SIGQUIT]
 }
 
 #[cfg(windows)]
 fn handled_signals() -> &'static [i32] {
-    &[SIGINT, SIGTERM, SIGABRT, SIGBREAK]
+    &[SIGINT, SIGBREAK]
+}
+
+fn handled_signal_names() -> Vec<&'static str> {
+    handled_signals()
+        .iter()
+        .copied()
+        .map(signal_display_name)
+        .collect()
+}
+
+fn signal_display_name(signal: i32) -> &'static str {
+    if let Some(name) = signal_name(signal) {
+        return name;
+    }
+
+    #[cfg(windows)]
+    if signal == SIGBREAK {
+        return "SIGBREAK";
+    }
+
+    "unknown signal"
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::EngineStatus;
 
     #[test]
-    fn received_signal_requests_engine_exit() -> anyhow::Result<()> {
-        let (sender, receiver) = mpsc::channel();
-        sender.send(OperatingSystemSignal::new(SIGINT))?;
+    fn received_signal_requests_exit() -> anyhow::Result<()> {
+        let mut signals = OperatingSystemSignals::with_signal_for_tests(SIGINT)?;
 
-        let mut engine = crate::tests::engine_with_subsystems(vec![Box::new(
-            OperatingSystemSignalSubsystem::from_receiver(receiver),
-        )]);
-
-        assert_eq!(engine.tick()?, EngineStatus::ExitRequested);
-        engine.shutdown()?;
+        assert!(signals.exit_requested());
         Ok(())
+    }
+
+    #[test]
+    fn startup_signal_names_are_human_readable() {
+        let signal_names = handled_signal_names();
+
+        assert!(signal_names.contains(&"SIGINT"));
+        assert!(!signal_names.contains(&"unknown signal"));
+    }
+
+    #[test]
+    fn abort_signal_is_not_handled() {
+        assert!(!handled_signals().contains(&signal_hook::consts::SIGABRT));
     }
 }

--- a/crates/dirk_engine/src/signal.rs
+++ b/crates/dirk_engine/src/signal.rs
@@ -1,0 +1,208 @@
+//! Operating system signal integration.
+//!
+//! The signal handler installed by this module does not touch engine state from
+//! inside the OS signal context. `signal-hook` writes notifications into a pipe,
+//! a background thread forwards them to this subsystem, and the subsystem asks
+//! the engine to exit during the normal tick flow.
+
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver},
+    },
+    thread::{self, JoinHandle},
+};
+
+use dirk_universe::Universe;
+use signal_hook::{
+    iterator::{Handle as SignalIteratorHandle, Signals},
+    low_level::{emulate_default_handler, signal_name},
+};
+use tracing::{debug, error, info, warn};
+
+use crate::{EngineBuilder, EngineHandle, EnginePlugin, Subsystem};
+
+#[cfg(windows)]
+use signal_hook::consts::signal::{SIGABRT, SIGBREAK, SIGINT, SIGTERM};
+#[cfg(not(windows))]
+use signal_hook::consts::signal::{SIGABRT, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
+
+/// Registers operating system signal handlers with the engine.
+///
+/// The first handled signal requests graceful engine shutdown. Handled signals
+/// include `SIGINT`, `SIGTERM`, and `SIGABRT`, plus platform-specific console
+/// termination signals where available.
+pub struct OperatingSystemSignalPlugin;
+
+impl EnginePlugin for OperatingSystemSignalPlugin {
+    fn name(&self) -> &'static str {
+        "operating-system-signals"
+    }
+
+    fn build(&self, builder: &mut EngineBuilder) -> anyhow::Result<()> {
+        builder.add_subsystem(|_ctx| OperatingSystemSignalSubsystem::install());
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OperatingSystemSignal {
+    number: i32,
+}
+
+impl OperatingSystemSignal {
+    fn new(number: i32) -> Self {
+        Self { number }
+    }
+
+    fn name(self) -> &'static str {
+        signal_name(self.number).unwrap_or("unknown signal")
+    }
+}
+
+struct SignalListener {
+    handle: SignalIteratorHandle,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl SignalListener {
+    fn install(sender: mpsc::Sender<OperatingSystemSignal>) -> anyhow::Result<Self> {
+        let mut signals = Signals::new(handled_signals())?;
+        let handle = signals.handle();
+        let shutdown_requested = AtomicBool::new(false);
+        let thread = thread::Builder::new()
+            .name("dirk-os-signals".to_owned())
+            .spawn(move || {
+                for signal in signals.forever() {
+                    if shutdown_requested.swap(true, Ordering::SeqCst) {
+                        warn!(
+                            signal,
+                            name = OperatingSystemSignal::new(signal).name(),
+                            "additional operating system signal received; using default handler",
+                        );
+                        if let Err(err) = emulate_default_handler(signal) {
+                            error!(
+                                signal,
+                                error = %err,
+                                "failed to emulate default signal handler; exiting process",
+                            );
+                        }
+                        std::process::exit(128 + signal);
+                    }
+
+                    if sender.send(OperatingSystemSignal::new(signal)).is_err() {
+                        break;
+                    }
+                }
+            })?;
+
+        Ok(Self {
+            handle,
+            thread: Some(thread),
+        })
+    }
+
+    fn shutdown(&mut self) {
+        self.handle.close();
+        if let Some(thread) = self.thread.take()
+            && thread.join().is_err()
+        {
+            error!("operating system signal listener thread panicked");
+        }
+    }
+}
+
+impl Drop for SignalListener {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+struct OperatingSystemSignalSubsystem {
+    receiver: Receiver<OperatingSystemSignal>,
+    listener: Option<SignalListener>,
+}
+
+impl OperatingSystemSignalSubsystem {
+    fn install() -> anyhow::Result<Self> {
+        let (sender, receiver) = mpsc::channel();
+        let listener = SignalListener::install(sender)?;
+
+        info!(signals = ?handled_signals(), "installed operating system signal handlers");
+        Ok(Self {
+            receiver,
+            listener: Some(listener),
+        })
+    }
+
+    #[cfg(test)]
+    fn from_receiver(receiver: Receiver<OperatingSystemSignal>) -> Self {
+        Self {
+            receiver,
+            listener: None,
+        }
+    }
+}
+
+impl Subsystem for OperatingSystemSignalSubsystem {
+    fn name(&self) -> &'static str {
+        "operating-system-signals"
+    }
+
+    fn tick(
+        &mut self,
+        _delta_time: f64,
+        handle: &EngineHandle,
+        _universe: &mut Universe,
+    ) -> anyhow::Result<()> {
+        if let Some(signal) = self.receiver.try_iter().next() {
+            warn!(
+                signal = signal.number,
+                name = signal.name(),
+                "operating system signal received; requesting engine shutdown",
+            );
+            handle.exit();
+        }
+
+        Ok(())
+    }
+
+    fn shutdown(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+        if let Some(mut listener) = self.listener.take() {
+            listener.shutdown();
+            debug!("shut down operating system signal listener");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn handled_signals() -> &'static [i32] {
+    &[SIGINT, SIGTERM, SIGABRT, SIGHUP, SIGQUIT]
+}
+
+#[cfg(windows)]
+fn handled_signals() -> &'static [i32] {
+    &[SIGINT, SIGTERM, SIGABRT, SIGBREAK]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EngineStatus;
+
+    #[test]
+    fn received_signal_requests_engine_exit() -> anyhow::Result<()> {
+        let (sender, receiver) = mpsc::channel();
+        sender.send(OperatingSystemSignal::new(SIGINT))?;
+
+        let mut engine = crate::tests::engine_with_subsystems(vec![Box::new(
+            OperatingSystemSignalSubsystem::from_receiver(receiver),
+        )]);
+
+        assert_eq!(engine.tick()?, EngineStatus::ExitRequested);
+        engine.shutdown()?;
+        Ok(())
+    }
+}

--- a/crates/dirk_engine/src/tests.rs
+++ b/crates/dirk_engine/src/tests.rs
@@ -200,6 +200,16 @@ fn build_context() -> EngineBuildContext {
 }
 
 pub(crate) fn engine_with_subsystems(subsystems: Vec<Box<dyn Subsystem>>) -> Engine {
+    engine_with_subsystems_and_signals(
+        subsystems,
+        signal::OperatingSystemSignals::empty_for_tests(),
+    )
+}
+
+fn engine_with_subsystems_and_signals(
+    subsystems: Vec<Box<dyn Subsystem>>,
+    signals: signal::OperatingSystemSignals,
+) -> Engine {
     let workers = WorkerPool::new("dirk-engine-test");
     let events = EventManager::new(workers.clone());
     let state = Arc::new(EngineState::new());
@@ -226,11 +236,32 @@ pub(crate) fn engine_with_subsystems(subsystems: Vec<Box<dyn Subsystem>>) -> Eng
         state,
         handle,
         command_receiver,
+        signals,
         frame_dispatcher: events.register(),
         exiting_dispatcher: events.register(),
         last_tick: Instant::now(),
         started: false,
         shutdown: false,
+    }
+}
+
+struct CountingTickSubsystem {
+    ticks: Arc<AtomicUsize>,
+}
+
+impl Subsystem for CountingTickSubsystem {
+    fn name(&self) -> &'static str {
+        "counting-tick"
+    }
+
+    fn tick(
+        &mut self,
+        _delta_time: f64,
+        _handle: &EngineHandle,
+        _universe: &mut Universe,
+    ) -> anyhow::Result<()> {
+        self.ticks.fetch_add(1, Ordering::Relaxed);
+        Ok(())
     }
 }
 
@@ -328,6 +359,27 @@ fn subsystem_shutdown_failure_uses_shutdown_error_variant() {
             ..
         })
     ));
+}
+
+#[test]
+fn operating_system_signals_are_processed_before_subsystem_ticks() -> Result<()> {
+    let ticks = Arc::new(AtomicUsize::new(0));
+    let signals =
+        signal::OperatingSystemSignals::with_signal_for_tests(signal_hook::consts::SIGINT)
+            .map_err(Error::SubsystemFailedInit)?;
+    let mut engine = engine_with_subsystems_and_signals(
+        vec![Box::new(CountingTickSubsystem {
+            ticks: Arc::clone(&ticks),
+        })],
+        signals,
+    );
+
+    let status = engine.tick()?;
+
+    assert_eq!(status, EngineStatus::ExitRequested);
+    assert_eq!(ticks.load(Ordering::Relaxed), 0);
+    engine.shutdown()?;
+    Ok(())
 }
 
 #[test]

--- a/crates/dirk_engine/src/tests.rs
+++ b/crates/dirk_engine/src/tests.rs
@@ -199,7 +199,7 @@ fn build_context() -> EngineBuildContext {
     })
 }
 
-fn engine_with_subsystems(subsystems: Vec<Box<dyn Subsystem>>) -> Engine {
+pub(crate) fn engine_with_subsystems(subsystems: Vec<Box<dyn Subsystem>>) -> Engine {
     let workers = WorkerPool::new("dirk-engine-test");
     let events = EventManager::new(workers.clone());
     let state = Arc::new(EngineState::new());

--- a/crates/dirk_engine/tests/signal_handling.rs
+++ b/crates/dirk_engine/tests/signal_handling.rs
@@ -1,0 +1,117 @@
+#![cfg(unix)]
+//! Subprocess coverage for Unix signal shutdown behavior.
+
+use std::{
+    process::{Child, Command, ExitStatus},
+    thread,
+    time::{Duration, Instant},
+};
+
+use dirk_engine::{Engine, EngineBuilder, EngineHandle, EnginePlugin, Subsystem};
+use dirk_universe::Universe;
+
+const CHILD_ENV: &str = "DIRK_ENGINE_SIGNAL_TEST_CHILD";
+const SIGINT: i32 = 2;
+
+struct BlockingShutdownPlugin;
+
+impl EnginePlugin for BlockingShutdownPlugin {
+    fn name(&self) -> &'static str {
+        "blocking-shutdown"
+    }
+
+    fn build(&self, builder: &mut EngineBuilder) -> anyhow::Result<()> {
+        builder.add_subsystem(|_ctx| Ok(BlockingShutdownSubsystem));
+        Ok(())
+    }
+}
+
+struct BlockingShutdownSubsystem;
+
+impl Subsystem for BlockingShutdownSubsystem {
+    fn name(&self) -> &'static str {
+        "blocking-shutdown"
+    }
+
+    fn shutdown(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+        loop {
+            thread::sleep(Duration::from_secs(1));
+        }
+    }
+}
+
+#[test]
+fn second_sigint_terminates_process_with_default_signal_handler() -> anyhow::Result<()> {
+    let mut child = Command::new(std::env::current_exe()?)
+        .env(CHILD_ENV, "1")
+        .arg("--exact")
+        .arg("signal_test_child_blocks_during_shutdown")
+        .arg("--nocapture")
+        .spawn()?;
+
+    thread::sleep(Duration::from_secs(1));
+    send_signal(&child, "INT")?;
+
+    thread::sleep(Duration::from_millis(500));
+    assert!(
+        child.try_wait()?.is_none(),
+        "child exited after first SIGINT before blocking shutdown"
+    );
+
+    send_signal(&child, "INT")?;
+    let status = wait_for_exit(child, Duration::from_secs(5))?;
+
+    assert!(
+        status_was_sigint(status),
+        "expected child to terminate from SIGINT or exit 130, got {status:?}",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn signal_test_child_blocks_during_shutdown() -> anyhow::Result<()> {
+    if std::env::var_os(CHILD_ENV).is_none() {
+        return Ok(());
+    }
+
+    let mut builder = Engine::builder();
+    builder.with_log_level(piquel_log::LogLevel::Error);
+    builder.with_plugin(BlockingShutdownPlugin)?;
+
+    builder.build()?.run()?;
+    Ok(())
+}
+
+fn send_signal(child: &Child, signal: &str) -> anyhow::Result<()> {
+    let status = Command::new("kill")
+        .arg(format!("-{signal}"))
+        .arg(child.id().to_string())
+        .status()?;
+
+    anyhow::ensure!(status.success(), "kill command failed with {status:?}");
+    Ok(())
+}
+
+fn wait_for_exit(mut child: Child, timeout: Duration) -> anyhow::Result<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("child did not exit within {timeout:?}");
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn status_was_sigint(status: ExitStatus) -> bool {
+    use std::os::unix::process::ExitStatusExt;
+
+    status.signal() == Some(SIGINT) || status.code() == Some(128 + SIGINT)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use tracing::error;
 fn run() -> anyhow::Result<()> {
     let mut builder = dirk_engine::Engine::builder();
 
-    builder.with_plugin(dirk_engine::signal::OperatingSystemSignalPlugin)?;
     builder.with_plugin(dirkengine::assets::AssetsPlugin)?;
     builder.with_plugin(dirkengine::platform::PlatformPlugin)?;
     builder.with_plugin(dirkengine::player::PlayerPlugin)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use tracing::error;
 fn run() -> anyhow::Result<()> {
     let mut builder = dirk_engine::Engine::builder();
 
+    builder.with_plugin(dirk_engine::signal::OperatingSystemSignalPlugin)?;
     builder.with_plugin(dirkengine::assets::AssetsPlugin)?;
     builder.with_plugin(dirkengine::platform::PlatformPlugin)?;
     builder.with_plugin(dirkengine::player::PlayerPlugin)?;


### PR DESCRIPTION
## Summary
- Make operating-system signal handling a core `dirk_engine` runtime feature rather than an application plugin or subsystem.
- Install a private signal listener owned by `Engine`, then poll it directly in `Engine::tick()` before `BeginFrame`, universe ticking, or subsystem ticks.
- Request graceful engine shutdown from normal engine flow on the first handled signal, while keeping the listener alive during subsystem shutdown so a repeated signal can fall back to the default handler.
- Remove `SIGABRT` handling; abort paths may indicate corrupted process state and should not attempt graceful cleanup.
- Tighten platform scope: Unix handles `SIGINT`, `SIGTERM`, `SIGHUP`, and `SIGQUIT`; Windows is limited to `signal-hook`'s CRT `SIGINT`/`SIGBREAK` support. Console close/logoff/shutdown events and normal window close events remain platform/window-layer concerns.

## Notes
- Added a Unix subprocess test for repeated `SIGINT` escalation during a blocked shutdown.
- Full workspace build/test/clippy could not be completed in the current environment because `dirk_renderer` invokes `cargo +nightly-2026-04-11`, which requires rustup's Cargo shim; the available fallback Cargo cannot handle `+toolchain` syntax here.
