### PR TITLE
route platform input to egui

### DIFF
--- a/crates/dirk_platform/src/event.rs
+++ b/crates/dirk_platform/src/event.rs
@@ -1,4 +1,10 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
+
 use dirk_events::Event;
+use parking_lot::Mutex;
 use winit::{
     event::{ButtonSource, MouseScrollDelta},
     keyboard::{Key, ModifiersState, PhysicalKey},
@@ -86,6 +92,79 @@ impl From<MouseScrollDelta> for ScrollDelta {
             MouseScrollDelta::PixelDelta(px) => Self::Pixels { x: px.x, y: px.y },
         }
     }
+}
+
+/// Input events routed to UI integrations.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub enum UiInputEvent {
+    WindowFocused {
+        id: WindowId,
+        focused: bool,
+    },
+    ModifiersChanged {
+        id: WindowId,
+        modifiers: ModifiersState,
+    },
+    Key {
+        id: WindowId,
+        key: Key,
+        physical_key: PhysicalKey,
+        pressed: bool,
+        repeat: bool,
+        modifiers: ModifiersState,
+        text: Option<String>,
+    },
+    PointerMoved {
+        id: WindowId,
+        position: glam::DVec2,
+    },
+    PointerGone {
+        id: WindowId,
+    },
+    PointerButton {
+        id: WindowId,
+        button: ButtonSource,
+        position: glam::DVec2,
+        pressed: bool,
+        modifiers: ModifiersState,
+    },
+    MouseWheel {
+        id: WindowId,
+        delta: ScrollDelta,
+        modifiers: ModifiersState,
+    },
+    Ime {
+        id: WindowId,
+        event: UiImeEvent,
+    },
+}
+
+impl UiInputEvent {
+    /// Returns the window that received this UI input event.
+    #[must_use]
+    pub fn id(&self) -> WindowId {
+        match self {
+            Self::WindowFocused { id, .. }
+            | Self::ModifiersChanged { id, .. }
+            | Self::Key { id, .. }
+            | Self::PointerMoved { id, .. }
+            | Self::PointerGone { id }
+            | Self::PointerButton { id, .. }
+            | Self::MouseWheel { id, .. }
+            | Self::Ime { id, .. } => *id,
+        }
+    }
+}
+
+/// Input method event routed to UI integrations.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub enum UiImeEvent {
+    Enabled,
+    Preedit(String),
+    Commit(String),
+    Disabled,
 }
 
 /// Input events produced by platform windows.
@@ -181,5 +260,99 @@ impl InputEvent {
             | Self::MouseButtonReleased { id, .. }
             | Self::MouseWheelScrolled { id, .. } => id,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window_id(raw: usize) -> WindowId {
+        WindowId::from_raw(raw)
+    }
+
+    #[test]
+    fn router_blocks_pointer_press_when_pointer_capture_is_active() {
+        let router = InputRouter::default();
+        router.set_capture(
+            window_id(1),
+            InputCapture {
+                pointer: true,
+                keyboard: false,
+            },
+        );
+
+        assert!(!router.should_dispatch_pointer_button(window_id(1), true));
+    }
+
+    #[test]
+    fn router_allows_pointer_release_when_pointer_capture_is_active() {
+        let router = InputRouter::default();
+        router.set_capture(
+            window_id(1),
+            InputCapture {
+                pointer: true,
+                keyboard: false,
+            },
+        );
+
+        assert!(router.should_dispatch_pointer_button(window_id(1), false));
+    }
+
+    #[test]
+    fn router_blocks_key_press_when_keyboard_capture_is_active() {
+        let router = InputRouter::default();
+        router.set_capture(
+            window_id(1),
+            InputCapture {
+                pointer: false,
+                keyboard: true,
+            },
+        );
+
+        assert!(!router.should_dispatch_key(window_id(1), true));
+    }
+
+    #[test]
+    fn router_allows_key_release_when_keyboard_capture_is_active() {
+        let router = InputRouter::default();
+        router.set_capture(
+            window_id(1),
+            InputCapture {
+                pointer: false,
+                keyboard: true,
+            },
+        );
+
+        assert!(router.should_dispatch_key(window_id(1), false));
+    }
+
+    #[test]
+    fn router_drains_ui_events_in_fifo_order() {
+        let router = InputRouter::default();
+        router.push_ui_event(UiInputEvent::PointerGone { id: window_id(1) });
+        router.push_ui_event(UiInputEvent::PointerGone { id: window_id(2) });
+
+        let events = router.drain_ui_events();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].id(), window_id(1));
+        assert_eq!(events[1].id(), window_id(2));
+        assert!(router.drain_ui_events().is_empty());
+    }
+
+    #[test]
+    fn router_capture_is_scoped_by_window_id() {
+        let router = InputRouter::default();
+        router.set_capture(
+            window_id(1),
+            InputCapture {
+                pointer: true,
+                keyboard: false,
+            },
+        );
+
+        assert!(router.captures_pointer(window_id(1)));
+        assert!(!router.captures_pointer(window_id(2)));
     }
 }

--- a/crates/dirk_platform/src/event.rs
+++ b/crates/dirk_platform/src/event.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::{HashMap, VecDeque},
-    sync::Arc,
-};
-
 use dirk_events::Event;
-use parking_lot::Mutex;
 use winit::{
     event::{ButtonSource, MouseScrollDelta},
     keyboard::{Key, ModifiersState, PhysicalKey},
@@ -265,6 +259,8 @@ impl InputEvent {
 
 #[cfg(test)]
 mod tests {
+    use crate::{InputCapture, InputRouter};
+
     use super::*;
 
     fn window_id(raw: usize) -> WindowId {

--- a/crates/dirk_platform/src/handler.rs
+++ b/crates/dirk_platform/src/handler.rs
@@ -8,7 +8,7 @@ use winit::{
 };
 
 use crate::{
-    InputEvent, PlatformWindows, Window,
+    InputEvent, InputRouter, PlatformWindows, UiImeEvent, UiInputEvent, Window,
     event::{PlatformEvent, WindowEvent as PlatformWindowEvent},
 };
 
@@ -26,10 +26,15 @@ pub struct PlatformHandler {
     window_dispatcher: dirk_events::Dispatcher<PlatformWindowEvent>,
     /// Dispatch [`InputEvent`]
     input_dispatch: dirk_events::Dispatcher<InputEvent>,
+    input_router: InputRouter,
 }
 
 impl PlatformHandler {
-    pub fn new(events: &dirk_events::EventManager, windows: PlatformWindows) -> Self {
+    pub fn new(
+        events: &dirk_events::EventManager,
+        windows: PlatformWindows,
+        input_router: InputRouter,
+    ) -> Self {
         Self {
             can_create_surfaces: false,
             windows,
@@ -37,6 +42,7 @@ impl PlatformHandler {
             platform_dispatcher: events.register(),
             window_dispatcher: events.register(),
             input_dispatch: events.register(),
+            input_router,
         }
     }
     fn create_window(&mut self, event_loop: &dyn ActiveEventLoop) -> anyhow::Result<WindowId> {
@@ -87,6 +93,11 @@ impl PlatformHandler {
                     .dispatch(PlatformWindowEvent::ThemeChanged { id, theme: *theme });
             }
             WindowEvent::Focused(focused) => {
+                self.input_router
+                    .push_ui_event(UiInputEvent::WindowFocused {
+                        id,
+                        focused: *focused,
+                    });
                 self.window_dispatcher
                     .dispatch(PlatformWindowEvent::FocusChanged {
                         id,
@@ -111,6 +122,11 @@ impl PlatformHandler {
             WindowEvent::ModifiersChanged(new_modifiers) => {
                 self.modifiers = new_modifiers.state();
                 trace!("Modifiers changed to {:?}", self.modifiers);
+                self.input_router
+                    .push_ui_event(UiInputEvent::ModifiersChanged {
+                        id,
+                        modifiers: self.modifiers,
+                    });
                 self.input_dispatch.dispatch(InputEvent::ModifiersChanged {
                     id,
                     modifiers: self.modifiers,
@@ -121,66 +137,140 @@ impl PlatformHandler {
                 is_synthetic: false,
                 ..
             } => self.dispatch_keyboard_input(id, event),
-            WindowEvent::PointerMoved { position, .. } => {
-                trace!("Pointer moved to {position:?}");
-                self.input_dispatch.dispatch(InputEvent::PointerMoved {
-                    id,
-                    position: glam::dvec2(position.x, position.y),
-                });
+            WindowEvent::PointerMoved { position, .. } => self.dispatch_pointer_moved(id, position),
+            WindowEvent::PointerEntered { position, .. } => {
+                self.dispatch_pointer_entered(id, position);
             }
-            WindowEvent::PointerEntered { .. } => {
-                trace!("Pointer entered Window={id:?}");
-                self.input_dispatch
-                    .dispatch(InputEvent::PointerEntered { id });
-            }
-            WindowEvent::PointerLeft { .. } => {
-                trace!("Pointer left Window={id:?}");
-                self.input_dispatch.dispatch(InputEvent::PointerLeft { id });
-            }
+            WindowEvent::PointerLeft { .. } => self.dispatch_pointer_left(id),
             WindowEvent::PointerButton {
                 button,
                 state,
                 position,
                 ..
-            } => {
-                trace!("Pointer button {button:?} {state:?} at {position:?}");
-                let position = glam::dvec2(position.x, position.y);
-                let event = match state {
-                    ElementState::Pressed => InputEvent::MouseButtonPressed {
-                        id,
-                        button: button.clone(),
-                        position,
-                    },
-                    ElementState::Released => InputEvent::MouseButtonReleased {
-                        id,
-                        button: button.clone(),
-                        position,
-                    },
-                };
-                self.input_dispatch.dispatch(event);
-            }
-            WindowEvent::MouseWheel { delta, .. } => {
-                trace!("Mouse wheel {delta:?}");
-                self.input_dispatch
-                    .dispatch(InputEvent::MouseWheelScrolled {
-                        id,
-                        delta: (*delta).into(),
-                    });
-            }
+            } => self.dispatch_pointer_button(id, button, *state, position),
+            WindowEvent::MouseWheel { delta, .. } => self.dispatch_mouse_wheel(id, delta),
+            WindowEvent::Ime(event) => self.dispatch_ime(id, event),
             _ => return false,
         }
 
         true
     }
 
+    fn dispatch_pointer_moved(&self, id: WindowId, position: &winit::dpi::PhysicalPosition<f64>) {
+        trace!("Pointer moved to {position:?}");
+        let position = glam::dvec2(position.x, position.y);
+        self.input_router
+            .push_ui_event(UiInputEvent::PointerMoved { id, position });
+        if !self.input_router.captures_pointer(id) {
+            self.input_dispatch
+                .dispatch(InputEvent::PointerMoved { id, position });
+        }
+    }
+
+    fn dispatch_pointer_entered(&self, id: WindowId, position: &winit::dpi::PhysicalPosition<f64>) {
+        trace!("Pointer entered Window={id:?}");
+        self.input_router.push_ui_event(UiInputEvent::PointerMoved {
+            id,
+            position: glam::dvec2(position.x, position.y),
+        });
+        self.input_dispatch
+            .dispatch(InputEvent::PointerEntered { id });
+    }
+
+    fn dispatch_pointer_left(&self, id: WindowId) {
+        trace!("Pointer left Window={id:?}");
+        self.input_router
+            .push_ui_event(UiInputEvent::PointerGone { id });
+        self.input_dispatch.dispatch(InputEvent::PointerLeft { id });
+    }
+
+    fn dispatch_pointer_button(
+        &self,
+        id: WindowId,
+        button: &winit::event::ButtonSource,
+        state: ElementState,
+        position: &winit::dpi::PhysicalPosition<f64>,
+    ) {
+        trace!("Pointer button {button:?} {state:?} at {position:?}");
+        let position = glam::dvec2(position.x, position.y);
+        let pressed = state == ElementState::Pressed;
+        self.input_router
+            .push_ui_event(UiInputEvent::PointerButton {
+                id,
+                button: button.clone(),
+                position,
+                pressed,
+                modifiers: self.modifiers,
+            });
+        if !self
+            .input_router
+            .should_dispatch_pointer_button(id, pressed)
+        {
+            return;
+        }
+
+        let event = match state {
+            ElementState::Pressed => InputEvent::MouseButtonPressed {
+                id,
+                button: button.clone(),
+                position,
+            },
+            ElementState::Released => InputEvent::MouseButtonReleased {
+                id,
+                button: button.clone(),
+                position,
+            },
+        };
+        self.input_dispatch.dispatch(event);
+    }
+
+    fn dispatch_mouse_wheel(&self, id: WindowId, delta: &winit::event::MouseScrollDelta) {
+        trace!("Mouse wheel {delta:?}");
+        let delta: crate::ScrollDelta = (*delta).into();
+        self.input_router.push_ui_event(UiInputEvent::MouseWheel {
+            id,
+            delta: delta.clone(),
+            modifiers: self.modifiers,
+        });
+        if !self.input_router.captures_pointer(id) {
+            self.input_dispatch
+                .dispatch(InputEvent::MouseWheelScrolled { id, delta });
+        }
+    }
+
+    fn dispatch_ime(&self, id: WindowId, event: &winit::event::Ime) {
+        let event = match event {
+            winit::event::Ime::Enabled => UiImeEvent::Enabled,
+            winit::event::Ime::Preedit(text, _) => UiImeEvent::Preedit(text.clone()),
+            winit::event::Ime::Commit(text) => UiImeEvent::Commit(text.clone()),
+            winit::event::Ime::Disabled => UiImeEvent::Disabled,
+            winit::event::Ime::DeleteSurrounding { .. } => return,
+        };
+        self.input_router
+            .push_ui_event(UiInputEvent::Ime { id, event });
+    }
+
     fn dispatch_keyboard_input(&self, id: WindowId, event: &winit::event::KeyEvent) {
         let modifiers = self.modifiers;
+        let pressed = event.state == ElementState::Pressed;
+        self.input_router.push_ui_event(UiInputEvent::Key {
+            id,
+            key: event.logical_key.clone(),
+            physical_key: event.physical_key,
+            pressed,
+            repeat: event.repeat,
+            modifiers,
+            text: event.text.as_ref().map(ToString::to_string),
+        });
         match event.state {
             ElementState::Pressed => {
                 trace!(
                     "Key pressed: {:?} (repeat={})",
                     event.logical_key, event.repeat
                 );
+                if !self.input_router.should_dispatch_key(id, pressed) {
+                    return;
+                }
                 self.input_dispatch.dispatch(InputEvent::KeyPressed {
                     id,
                     key: event.logical_key.clone(),

--- a/crates/dirk_platform/src/lib.rs
+++ b/crates/dirk_platform/src/lib.rs
@@ -14,14 +14,16 @@ mod handler;
 mod router;
 mod window;
 
-pub use errors::Error;
-pub use event::*;
-pub use router::InputRouter;
-pub use window::{MainWindow, PlatformWindows, Window, Windows};
 pub use winit::{
     event::{ButtonSource, MouseButton},
     keyboard::{Key, KeyCode, ModifiersState, NamedKey, PhysicalKey},
     window::{Theme, WindowId},
+};
+pub use {
+    errors::Error,
+    event::*,
+    router::{InputCapture, InputRouter},
+    window::{MainWindow, PlatformWindows, Window, Windows},
 };
 
 use errors::Result;

--- a/crates/dirk_platform/src/lib.rs
+++ b/crates/dirk_platform/src/lib.rs
@@ -11,14 +11,17 @@ use winit::event_loop::{
 mod errors;
 mod event;
 mod handler;
+mod router;
 mod window;
+
 pub use errors::Error;
 pub use event::*;
+pub use router::InputRouter;
 pub use window::{MainWindow, PlatformWindows, Window, Windows};
 pub use winit::{
     event::{ButtonSource, MouseButton},
-    keyboard::{KeyCode, PhysicalKey},
-    window::WindowId,
+    keyboard::{Key, KeyCode, ModifiersState, NamedKey, PhysicalKey},
+    window::{Theme, WindowId},
 };
 
 use errors::Result;
@@ -36,6 +39,7 @@ impl dirk_engine::EnginePlugin for PlatformPlugin {
         builder.add_subsystem(|ctx| {
             let platform = Platform::init(ctx.events())?;
             ctx.add_resource(platform.platform_windows())?;
+            ctx.add_resource(platform.input_router())?;
             Ok(platform)
         });
         Ok(())
@@ -50,6 +54,7 @@ struct Platform {
     handler: PlatformHandler,
     event_loop: EventLoop,
     windows: PlatformWindows,
+    input_router: InputRouter,
 
     window_consumer: dirk_events::Consumer<WindowEvent>,
 }
@@ -64,10 +69,12 @@ impl Platform {
     /// to start it.
     fn init(events: &dirk_events::EventManager) -> Result<Self> {
         let windows = PlatformWindows::default();
+        let input_router = InputRouter::default();
         let mut platform = Self {
-            handler: PlatformHandler::new(events, windows.clone()),
+            handler: PlatformHandler::new(events, windows.clone(), input_router.clone()),
             event_loop: EventLoop::new()?,
             windows,
+            input_router,
             window_consumer: events.subscribe(),
         };
 
@@ -92,6 +99,12 @@ impl Platform {
     #[must_use]
     pub fn platform_windows(&self) -> PlatformWindows {
         self.windows.clone()
+    }
+
+    /// Returns the shared platform input router.
+    #[must_use]
+    pub fn input_router(&self) -> InputRouter {
+        self.input_router.clone()
     }
 }
 

--- a/crates/dirk_platform/src/router.rs
+++ b/crates/dirk_platform/src/router.rs
@@ -1,0 +1,71 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
+
+use parking_lot::Mutex;
+use winit::window::WindowId;
+
+use crate::UiInputEvent;
+
+/// Whether a UI layer is currently capturing input for a window.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct InputCapture {
+    /// Pointer input should not be routed to gameplay.
+    pub pointer: bool,
+    /// Keyboard input should not be routed to gameplay.
+    pub keyboard: bool,
+}
+
+#[derive(Default)]
+struct InputRouterState {
+    ui_events: VecDeque<UiInputEvent>,
+    captures: HashMap<WindowId, InputCapture>,
+}
+
+/// Shared router between platform input and UI integrations.
+#[derive(Clone, Default)]
+pub struct InputRouter {
+    state: Arc<Mutex<InputRouterState>>,
+}
+
+impl InputRouter {
+    /// Drains all UI input events currently pending in FIFO order.
+    #[must_use]
+    pub fn drain_ui_events(&self) -> Vec<UiInputEvent> {
+        self.state.lock().ui_events.drain(..).collect()
+    }
+
+    /// Sets the current input capture state for one window.
+    pub fn set_capture(&self, id: WindowId, capture: InputCapture) {
+        self.state.lock().captures.insert(id, capture);
+    }
+
+    pub(crate) fn push_ui_event(&self, event: UiInputEvent) {
+        self.state.lock().ui_events.push_back(event);
+    }
+
+    pub(crate) fn captures_pointer(&self, id: WindowId) -> bool {
+        self.state
+            .lock()
+            .captures
+            .get(&id)
+            .is_some_and(|capture| capture.pointer)
+    }
+
+    pub(crate) fn captures_keyboard(&self, id: WindowId) -> bool {
+        self.state
+            .lock()
+            .captures
+            .get(&id)
+            .is_some_and(|capture| capture.keyboard)
+    }
+
+    pub(crate) fn should_dispatch_pointer_button(&self, id: WindowId, pressed: bool) -> bool {
+        !pressed || !self.captures_pointer(id)
+    }
+
+    pub(crate) fn should_dispatch_key(&self, id: WindowId, pressed: bool) -> bool {
+        !pressed || !self.captures_keyboard(id)
+    }
+}

--- a/crates/dirk_platform/src/window.rs
+++ b/crates/dirk_platform/src/window.rs
@@ -149,6 +149,25 @@ impl Window {
     pub fn size(&self) -> PhysicalSize<u32> {
         self.raw.surface_size()
     }
+
+    /// Returns the native scale factor for this window.
+    #[must_use]
+    pub fn scale_factor(&self) -> f64 {
+        self.raw.scale_factor()
+    }
+
+    /// Returns whether this window is focused.
+    #[must_use]
+    pub fn focused(&self) -> bool {
+        self.focused
+    }
+
+    /// Returns the current window theme.
+    #[must_use]
+    pub fn theme(&self) -> Theme {
+        self.theme
+    }
+
     /// Handles [`WindowEvent`]. These should first be proccessed
     /// and accepted by the window.
     pub fn handle_event(&mut self, event: &WindowEvent) {

--- a/crates/dirk_renderer/src/egui_integration.rs
+++ b/crates/dirk_renderer/src/egui_integration.rs
@@ -1,7 +1,14 @@
 use std::time::Instant;
 
 use ash::vk;
-use egui::{ClippedPrimitive, Context, TextureId, TexturesDelta};
+use dirk_platform::{
+    ButtonSource, InputCapture, Key, KeyCode, ModifiersState, MouseButton, NamedKey, PhysicalKey,
+    ScrollDelta, Theme, UiImeEvent, UiInputEvent, WindowId,
+};
+use egui::{
+    ClippedPrimitive, Context, MouseWheelUnit, Pos2, TextureId, TexturesDelta, Vec2, ViewportId,
+    ViewportInfo,
+};
 use egui_ash_renderer::{DynamicRendering, Options};
 
 use crate::{
@@ -15,6 +22,15 @@ pub struct EguiState {
     start_time: Instant,
     pending: Option<EguiPaintData>,
     textures_to_free: [Vec<TextureId>; MAX_FRAMES_IN_FLIGHT],
+}
+
+pub struct EguiFrameInput {
+    pub window_id: WindowId,
+    pub extent: vk::Extent2D,
+    pub native_pixels_per_point: f32,
+    pub focused: bool,
+    pub theme: Option<Theme>,
+    pub events: Vec<UiInputEvent>,
 }
 
 impl EguiState {
@@ -43,21 +59,47 @@ impl EguiState {
     }
 
     #[allow(clippy::cast_precision_loss)]
-    pub fn begin_frame(&self, extent: vk::Extent2D) -> Context {
+    pub fn begin_frame(&mut self, input: &EguiFrameInput) -> Context {
+        let native_pixels_per_point = input.native_pixels_per_point.max(f32::EPSILON);
         let screen_rect = egui::Rect::from_min_size(
             egui::Pos2::ZERO,
-            egui::vec2(extent.width as f32, extent.height as f32),
+            egui::vec2(
+                input.extent.width as f32 / native_pixels_per_point,
+                input.extent.height as f32 / native_pixels_per_point,
+            ),
         );
-
-        self.ctx.begin_pass(egui::RawInput {
+        let events = translate_events(
+            input.window_id,
+            native_pixels_per_point,
+            input.events.as_slice(),
+        );
+        let system_theme = input.theme.map(|theme| match theme {
+            Theme::Dark => egui::Theme::Dark,
+            Theme::Light => egui::Theme::Light,
+        });
+        let mut raw_input = egui::RawInput {
             screen_rect: Some(screen_rect),
             time: Some(self.start_time.elapsed().as_secs_f64()),
+            focused: input.focused,
+            system_theme,
+            events,
             ..egui::RawInput::default()
-        });
+        };
+        raw_input.viewports.insert(
+            ViewportId::ROOT,
+            ViewportInfo {
+                native_pixels_per_point: Some(native_pixels_per_point),
+                inner_rect: Some(screen_rect),
+                focused: Some(input.focused),
+                ..ViewportInfo::default()
+            },
+        );
+
+        self.ctx.begin_pass(raw_input);
         self.ctx.clone()
     }
 
-    pub fn end_frame(&mut self) {
+    pub fn end_frame(&mut self) -> InputCapture {
         let output = self.ctx.end_pass();
         let primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
         self.pending = Some(EguiPaintData {
@@ -65,6 +107,10 @@ impl EguiState {
             primitives,
             pixels_per_point: output.pixels_per_point,
         });
+        InputCapture {
+            pointer: self.ctx.wants_pointer_input(),
+            keyboard: self.ctx.wants_keyboard_input(),
+        }
     }
 
     pub fn free_textures_for_frame(&mut self, frame: usize) -> Result<()> {
@@ -106,4 +152,441 @@ struct EguiPaintData {
     textures_delta: TexturesDelta,
     primitives: Vec<ClippedPrimitive>,
     pixels_per_point: f32,
+}
+
+fn translate_events(
+    window_id: WindowId,
+    native_pixels_per_point: f32,
+    events: &[UiInputEvent],
+) -> Vec<egui::Event> {
+    let mut translated = Vec::new();
+    for event in events {
+        if event.id() != window_id {
+            continue;
+        }
+        append_translated_event(&mut translated, native_pixels_per_point, event);
+    }
+    translated
+}
+
+#[allow(clippy::too_many_lines)]
+fn append_translated_event(
+    out: &mut Vec<egui::Event>,
+    native_pixels_per_point: f32,
+    event: &UiInputEvent,
+) {
+    match event {
+        UiInputEvent::WindowFocused { focused, .. } => {
+            out.push(egui::Event::WindowFocused(*focused));
+        }
+        UiInputEvent::ModifiersChanged { .. } => {}
+        UiInputEvent::Key {
+            key,
+            physical_key,
+            pressed,
+            repeat,
+            modifiers,
+            text,
+            ..
+        } => {
+            let modifiers = modifiers_to_egui(*modifiers);
+            if let Some(key) = key_to_egui(key) {
+                out.push(egui::Event::Key {
+                    key,
+                    physical_key: physical_key_to_egui(*physical_key),
+                    pressed: *pressed,
+                    repeat: *repeat,
+                    modifiers,
+                });
+            }
+            if *pressed
+                && !modifiers.command
+                && !modifiers.ctrl
+                && let Some(text) = text
+                && should_emit_text_event(text)
+            {
+                out.push(egui::Event::Text(text.clone()));
+            }
+        }
+        UiInputEvent::PointerMoved { position, .. } => {
+            out.push(egui::Event::PointerMoved(position_to_egui(
+                *position,
+                native_pixels_per_point,
+            )));
+        }
+        UiInputEvent::PointerGone { .. } => {
+            out.push(egui::Event::PointerGone);
+        }
+        UiInputEvent::PointerButton {
+            button,
+            position,
+            pressed,
+            modifiers,
+            ..
+        } => {
+            if let Some(button) = button_to_egui(button.clone()) {
+                out.push(egui::Event::PointerButton {
+                    pos: position_to_egui(*position, native_pixels_per_point),
+                    button,
+                    pressed: *pressed,
+                    modifiers: modifiers_to_egui(*modifiers),
+                });
+            }
+        }
+        UiInputEvent::MouseWheel {
+            delta, modifiers, ..
+        } => {
+            let (unit, delta) = scroll_to_egui(delta);
+            out.push(egui::Event::MouseWheel {
+                unit,
+                delta,
+                modifiers: modifiers_to_egui(*modifiers),
+            });
+        }
+        UiInputEvent::Ime { event, .. } => {
+            out.push(egui::Event::Ime(match event {
+                UiImeEvent::Enabled => egui::ImeEvent::Enabled,
+                UiImeEvent::Preedit(text) => egui::ImeEvent::Preedit(text.clone()),
+                UiImeEvent::Commit(text) => egui::ImeEvent::Commit(text.clone()),
+                UiImeEvent::Disabled => egui::ImeEvent::Disabled,
+            }));
+        }
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn position_to_egui(position: glam::DVec2, native_pixels_per_point: f32) -> Pos2 {
+    let scale = f64::from(native_pixels_per_point.max(f32::EPSILON));
+    Pos2::new((position.x / scale) as f32, (position.y / scale) as f32)
+}
+
+fn modifiers_to_egui(modifiers: ModifiersState) -> egui::Modifiers {
+    let ctrl = modifiers.control_key();
+    let mac_cmd = cfg!(target_os = "macos") && modifiers.meta_key();
+    egui::Modifiers {
+        alt: modifiers.alt_key(),
+        ctrl,
+        shift: modifiers.shift_key(),
+        mac_cmd,
+        command: if cfg!(target_os = "macos") {
+            modifiers.meta_key()
+        } else {
+            ctrl
+        },
+    }
+}
+
+fn key_to_egui(key: &Key) -> Option<egui::Key> {
+    match key {
+        Key::Character(text) => text.chars().next().and_then(char_to_egui_key),
+        Key::Named(named) => named_key_to_egui(*named),
+        Key::Unidentified(_) | Key::Dead(_) => None,
+    }
+}
+
+fn named_key_to_egui(key: NamedKey) -> Option<egui::Key> {
+    Some(match key {
+        NamedKey::ArrowDown => egui::Key::ArrowDown,
+        NamedKey::ArrowLeft => egui::Key::ArrowLeft,
+        NamedKey::ArrowRight => egui::Key::ArrowRight,
+        NamedKey::ArrowUp => egui::Key::ArrowUp,
+        NamedKey::Escape => egui::Key::Escape,
+        NamedKey::Tab => egui::Key::Tab,
+        NamedKey::Backspace => egui::Key::Backspace,
+        NamedKey::Enter => egui::Key::Enter,
+        NamedKey::Insert => egui::Key::Insert,
+        NamedKey::Delete => egui::Key::Delete,
+        NamedKey::Home => egui::Key::Home,
+        NamedKey::End => egui::Key::End,
+        NamedKey::PageUp => egui::Key::PageUp,
+        NamedKey::PageDown => egui::Key::PageDown,
+        NamedKey::Copy => egui::Key::Copy,
+        NamedKey::Cut => egui::Key::Cut,
+        NamedKey::Paste => egui::Key::Paste,
+        NamedKey::F1 => egui::Key::F1,
+        NamedKey::F2 => egui::Key::F2,
+        NamedKey::F3 => egui::Key::F3,
+        NamedKey::F4 => egui::Key::F4,
+        NamedKey::F5 => egui::Key::F5,
+        NamedKey::F6 => egui::Key::F6,
+        NamedKey::F7 => egui::Key::F7,
+        NamedKey::F8 => egui::Key::F8,
+        NamedKey::F9 => egui::Key::F9,
+        NamedKey::F10 => egui::Key::F10,
+        NamedKey::F11 => egui::Key::F11,
+        NamedKey::F12 => egui::Key::F12,
+        NamedKey::F13 => egui::Key::F13,
+        NamedKey::F14 => egui::Key::F14,
+        NamedKey::F15 => egui::Key::F15,
+        NamedKey::F16 => egui::Key::F16,
+        NamedKey::F17 => egui::Key::F17,
+        NamedKey::F18 => egui::Key::F18,
+        NamedKey::F19 => egui::Key::F19,
+        NamedKey::BrowserBack => egui::Key::BrowserBack,
+        _ => return None,
+    })
+}
+
+fn physical_key_to_egui(key: PhysicalKey) -> Option<egui::Key> {
+    match key {
+        PhysicalKey::Code(code) => key_code_to_egui(code),
+        PhysicalKey::Unidentified(_) => None,
+    }
+}
+
+fn key_code_to_egui(code: KeyCode) -> Option<egui::Key> {
+    Some(match code {
+        KeyCode::ArrowDown => egui::Key::ArrowDown,
+        KeyCode::ArrowLeft => egui::Key::ArrowLeft,
+        KeyCode::ArrowRight => egui::Key::ArrowRight,
+        KeyCode::ArrowUp => egui::Key::ArrowUp,
+        KeyCode::Escape => egui::Key::Escape,
+        KeyCode::Tab => egui::Key::Tab,
+        KeyCode::Backspace => egui::Key::Backspace,
+        KeyCode::Enter => egui::Key::Enter,
+        KeyCode::Space => egui::Key::Space,
+        KeyCode::Insert => egui::Key::Insert,
+        KeyCode::Delete => egui::Key::Delete,
+        KeyCode::Home => egui::Key::Home,
+        KeyCode::End => egui::Key::End,
+        KeyCode::PageUp => egui::Key::PageUp,
+        KeyCode::PageDown => egui::Key::PageDown,
+        KeyCode::KeyA => egui::Key::A,
+        KeyCode::KeyB => egui::Key::B,
+        KeyCode::KeyC => egui::Key::C,
+        KeyCode::KeyD => egui::Key::D,
+        KeyCode::KeyE => egui::Key::E,
+        KeyCode::KeyF => egui::Key::F,
+        KeyCode::KeyG => egui::Key::G,
+        KeyCode::KeyH => egui::Key::H,
+        KeyCode::KeyI => egui::Key::I,
+        KeyCode::KeyJ => egui::Key::J,
+        KeyCode::KeyK => egui::Key::K,
+        KeyCode::KeyL => egui::Key::L,
+        KeyCode::KeyM => egui::Key::M,
+        KeyCode::KeyN => egui::Key::N,
+        KeyCode::KeyO => egui::Key::O,
+        KeyCode::KeyP => egui::Key::P,
+        KeyCode::KeyQ => egui::Key::Q,
+        KeyCode::KeyR => egui::Key::R,
+        KeyCode::KeyS => egui::Key::S,
+        KeyCode::KeyT => egui::Key::T,
+        KeyCode::KeyU => egui::Key::U,
+        KeyCode::KeyV => egui::Key::V,
+        KeyCode::KeyW => egui::Key::W,
+        KeyCode::KeyX => egui::Key::X,
+        KeyCode::KeyY => egui::Key::Y,
+        KeyCode::KeyZ => egui::Key::Z,
+        KeyCode::Digit0 | KeyCode::Numpad0 => egui::Key::Num0,
+        KeyCode::Digit1 | KeyCode::Numpad1 => egui::Key::Num1,
+        KeyCode::Digit2 | KeyCode::Numpad2 => egui::Key::Num2,
+        KeyCode::Digit3 | KeyCode::Numpad3 => egui::Key::Num3,
+        KeyCode::Digit4 | KeyCode::Numpad4 => egui::Key::Num4,
+        KeyCode::Digit5 | KeyCode::Numpad5 => egui::Key::Num5,
+        KeyCode::Digit6 | KeyCode::Numpad6 => egui::Key::Num6,
+        KeyCode::Digit7 | KeyCode::Numpad7 => egui::Key::Num7,
+        KeyCode::Digit8 | KeyCode::Numpad8 => egui::Key::Num8,
+        KeyCode::Digit9 | KeyCode::Numpad9 => egui::Key::Num9,
+        KeyCode::F1 => egui::Key::F1,
+        KeyCode::F2 => egui::Key::F2,
+        KeyCode::F3 => egui::Key::F3,
+        KeyCode::F4 => egui::Key::F4,
+        KeyCode::F5 => egui::Key::F5,
+        KeyCode::F6 => egui::Key::F6,
+        KeyCode::F7 => egui::Key::F7,
+        KeyCode::F8 => egui::Key::F8,
+        KeyCode::F9 => egui::Key::F9,
+        KeyCode::F10 => egui::Key::F10,
+        KeyCode::F11 => egui::Key::F11,
+        KeyCode::F12 => egui::Key::F12,
+        KeyCode::F13 => egui::Key::F13,
+        KeyCode::F14 => egui::Key::F14,
+        KeyCode::F15 => egui::Key::F15,
+        KeyCode::F16 => egui::Key::F16,
+        KeyCode::F17 => egui::Key::F17,
+        KeyCode::F18 => egui::Key::F18,
+        KeyCode::F19 => egui::Key::F19,
+        KeyCode::BrowserBack => egui::Key::BrowserBack,
+        _ => return None,
+    })
+}
+
+fn char_to_egui_key(character: char) -> Option<egui::Key> {
+    Some(match character.to_ascii_lowercase() {
+        'a' => egui::Key::A,
+        'b' => egui::Key::B,
+        'c' => egui::Key::C,
+        'd' => egui::Key::D,
+        'e' => egui::Key::E,
+        'f' => egui::Key::F,
+        'g' => egui::Key::G,
+        'h' => egui::Key::H,
+        'i' => egui::Key::I,
+        'j' => egui::Key::J,
+        'k' => egui::Key::K,
+        'l' => egui::Key::L,
+        'm' => egui::Key::M,
+        'n' => egui::Key::N,
+        'o' => egui::Key::O,
+        'p' => egui::Key::P,
+        'q' => egui::Key::Q,
+        'r' => egui::Key::R,
+        's' => egui::Key::S,
+        't' => egui::Key::T,
+        'u' => egui::Key::U,
+        'v' => egui::Key::V,
+        'w' => egui::Key::W,
+        'x' => egui::Key::X,
+        'y' => egui::Key::Y,
+        'z' => egui::Key::Z,
+        '0' => egui::Key::Num0,
+        '1' => egui::Key::Num1,
+        '2' => egui::Key::Num2,
+        '3' => egui::Key::Num3,
+        '4' => egui::Key::Num4,
+        '5' => egui::Key::Num5,
+        '6' => egui::Key::Num6,
+        '7' => egui::Key::Num7,
+        '8' => egui::Key::Num8,
+        '9' => egui::Key::Num9,
+        ' ' => egui::Key::Space,
+        ':' => egui::Key::Colon,
+        ',' => egui::Key::Comma,
+        '\\' => egui::Key::Backslash,
+        '/' => egui::Key::Slash,
+        '|' => egui::Key::Pipe,
+        '?' => egui::Key::Questionmark,
+        '!' => egui::Key::Exclamationmark,
+        '[' => egui::Key::OpenBracket,
+        ']' => egui::Key::CloseBracket,
+        '{' => egui::Key::OpenCurlyBracket,
+        '}' => egui::Key::CloseCurlyBracket,
+        '`' => egui::Key::Backtick,
+        '-' => egui::Key::Minus,
+        '.' => egui::Key::Period,
+        '+' => egui::Key::Plus,
+        '=' => egui::Key::Equals,
+        ';' => egui::Key::Semicolon,
+        '\'' => egui::Key::Quote,
+        _ => return None,
+    })
+}
+
+fn button_to_egui(button: ButtonSource) -> Option<egui::PointerButton> {
+    Some(match button.mouse_button()? {
+        MouseButton::Left => egui::PointerButton::Primary,
+        MouseButton::Right => egui::PointerButton::Secondary,
+        MouseButton::Middle => egui::PointerButton::Middle,
+        MouseButton::Back => egui::PointerButton::Extra1,
+        MouseButton::Forward => egui::PointerButton::Extra2,
+        _ => return None,
+    })
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn scroll_to_egui(delta: &ScrollDelta) -> (MouseWheelUnit, Vec2) {
+    match *delta {
+        ScrollDelta::Lines { x, y } => (MouseWheelUnit::Line, Vec2::new(x, y)),
+        ScrollDelta::Pixels { x, y } => (MouseWheelUnit::Point, Vec2::new(x as f32, y as f32)),
+    }
+}
+
+fn should_emit_text_event(text: &str) -> bool {
+    !text.is_empty() && !text.chars().any(char::is_control)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window_id(raw: usize) -> WindowId {
+        WindowId::from_raw(raw)
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn modifiers_map_ctrl_to_command_on_non_macos() {
+        let modifiers = modifiers_to_egui(ModifiersState::CONTROL);
+
+        assert!(modifiers.ctrl);
+        assert!(modifiers.command);
+        assert!(!modifiers.mac_cmd);
+    }
+
+    #[test]
+    fn key_characters_map_to_egui_letters_and_digits() {
+        assert_eq!(key_to_egui(&Key::Character("a".into())), Some(egui::Key::A));
+        assert_eq!(
+            key_to_egui(&Key::Character("7".into())),
+            Some(egui::Key::Num7)
+        );
+    }
+
+    #[test]
+    fn named_keys_map_to_navigation_keys() {
+        assert_eq!(
+            key_to_egui(&Key::Named(NamedKey::ArrowLeft)),
+            Some(egui::Key::ArrowLeft)
+        );
+        assert_eq!(
+            key_to_egui(&Key::Named(NamedKey::PageDown)),
+            Some(egui::Key::PageDown)
+        );
+    }
+
+    #[test]
+    fn pointer_positions_are_scaled_from_physical_pixels_to_points() {
+        let events = translate_events(
+            window_id(1),
+            2.0,
+            &[UiInputEvent::PointerMoved {
+                id: window_id(1),
+                position: glam::dvec2(20.0, 10.0),
+            }],
+        );
+
+        assert_eq!(
+            events,
+            vec![egui::Event::PointerMoved(Pos2::new(10.0, 5.0))]
+        );
+    }
+
+    #[test]
+    fn wheel_line_delta_maps_to_line_unit() {
+        let (unit, delta) = scroll_to_egui(&ScrollDelta::Lines { x: 1.0, y: -2.0 });
+
+        assert_eq!(unit, MouseWheelUnit::Line);
+        assert_eq!(delta, Vec2::new(1.0, -2.0));
+    }
+
+    #[test]
+    fn wheel_pixel_delta_maps_to_point_unit() {
+        let (unit, delta) = scroll_to_egui(&ScrollDelta::Pixels { x: 3.0, y: -4.0 });
+
+        assert_eq!(unit, MouseWheelUnit::Point);
+        assert_eq!(delta, Vec2::new(3.0, -4.0));
+    }
+
+    #[test]
+    fn text_events_are_not_emitted_for_command_shortcuts() {
+        let events = translate_events(
+            window_id(1),
+            1.0,
+            &[UiInputEvent::Key {
+                id: window_id(1),
+                key: Key::Character("c".into()),
+                physical_key: PhysicalKey::Code(KeyCode::KeyC),
+                pressed: true,
+                repeat: false,
+                modifiers: ModifiersState::CONTROL,
+                text: Some("c".to_owned()),
+            }],
+        );
+
+        assert!(
+            events
+                .iter()
+                .all(|event| !matches!(event, egui::Event::Text(_)))
+        );
+    }
 }

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -39,7 +39,7 @@ pub use errors::{Error, Result};
 #[cfg(feature = "editor")]
 mod egui_integration;
 #[cfg(feature = "editor")]
-use egui_integration::EguiState;
+use egui_integration::{EguiFrameInput, EguiState};
 
 mod window;
 use window::Window;
@@ -86,6 +86,8 @@ impl dirk_engine::EnginePlugin for RendererPlugin {
 
         builder.add_subsystem(|ctx| {
             let platform_windows = ctx.resource::<dirk_platform::PlatformWindows>()?;
+            #[cfg(feature = "editor")]
+            let input_router = ctx.resource::<dirk_platform::InputRouter>()?;
 
             let create_info = RendererCreateInfo::from_engine_metadata(ctx.handle().metadata())?;
 
@@ -95,6 +97,8 @@ impl dirk_engine::EnginePlugin for RendererPlugin {
                 &main_window,
                 ctx.events(),
                 platform_windows.clone(),
+                #[cfg(feature = "editor")]
+                input_router,
             )?;
 
             ctx.extend_universe(renderer.universe_builder());
@@ -157,6 +161,10 @@ struct Renderer {
     /// Immediate-mode UI rendering state.
     #[cfg(feature = "editor")]
     egui: EguiState,
+    #[cfg(feature = "editor")]
+    egui_window: Option<WindowId>,
+    #[cfg(feature = "editor")]
+    input_router: dirk_platform::InputRouter,
     /// Maps each live [`PlayerId`] to its proxy.
     players: HashMap<PlayerId, PlayerProxy>,
 
@@ -195,9 +203,6 @@ impl dirk_engine::Subsystem for Renderer {
             self.render_ui(delta_time, &ctx);
         }
 
-        #[cfg(not(feature = "editor"))]
-        self.begin_frame();
-
         self.end_frame().context("rendering")?;
 
         Ok(())
@@ -226,6 +231,7 @@ impl Renderer {
         window: &dirk_platform::Window,
         event_manager: &dirk_events::EventManager,
         platform_windows: PlatformWindows,
+        #[cfg(feature = "editor")] input_router: dirk_platform::InputRouter,
     ) -> Result<Self> {
         info!("Intializing Vulkan...");
 
@@ -309,6 +315,10 @@ impl Renderer {
             models,
             #[cfg(feature = "editor")]
             egui,
+            #[cfg(feature = "editor")]
+            egui_window: None,
+            #[cfg(feature = "editor")]
+            input_router,
 
             frames,
             current_frame,
@@ -327,21 +337,16 @@ impl Renderer {
     /// Returns an [`egui::Context`] for rendering.
     #[cfg(feature = "editor")]
     pub fn begin_frame(&mut self) -> egui::Context {
-        self.egui.begin_frame(self.primary_extent())
+        let input = self.egui_frame_input();
+        self.egui_window = Some(input.window_id);
+        self.egui.begin_frame(&input)
     }
-
-    /// Begins a frame.
-    #[cfg(not(feature = "editor"))]
-    #[allow(clippy::unused_self)]
-    pub fn begin_frame(&mut self) {}
 
     // TODO: shouldn't be necessary
     #[cfg(feature = "editor")]
     fn primary_extent(&self) -> vk::Extent2D {
-        self.players
-            .values()
-            .find_map(|player| self.windows.get(&player.window))
-            .or_else(|| self.windows.values().next())
+        self.primary_window_id()
+            .and_then(|id| self.windows.get(&id))
             .map_or(
                 vk::Extent2D {
                     width: 1,
@@ -349,6 +354,53 @@ impl Renderer {
                 },
                 Window::extent,
             )
+    }
+
+    #[cfg(feature = "editor")]
+    fn primary_window_id(&self) -> Option<WindowId> {
+        self.players
+            .values()
+            .find_map(|player| {
+                self.windows
+                    .contains_key(&player.window)
+                    .then_some(player.window)
+            })
+            .or_else(|| self.windows.keys().next().copied())
+    }
+
+    #[cfg(feature = "editor")]
+    #[allow(clippy::cast_possible_truncation)]
+    fn egui_frame_input(&mut self) -> EguiFrameInput {
+        let window_id = self
+            .primary_window_id()
+            .unwrap_or_else(|| WindowId::from_raw(0));
+        let extent = self.primary_extent();
+        let events = self
+            .input_router
+            .drain_ui_events()
+            .into_iter()
+            .filter(|event| event.id() == window_id)
+            .collect();
+
+        let (native_pixels_per_point, focused, theme) = {
+            let windows = self.platform_windows.windows();
+            windows.get(&window_id).map_or((1.0, true, None), |window| {
+                (
+                    window.scale_factor() as f32,
+                    window.focused(),
+                    Some(window.theme()),
+                )
+            })
+        };
+
+        EguiFrameInput {
+            window_id,
+            extent,
+            native_pixels_per_point,
+            focused,
+            theme,
+            events,
+        }
     }
 
     /// Returns a [`UniverseBuilder`] that is populated with [`Renderer`] systems.
@@ -458,7 +510,12 @@ impl Renderer {
     /// Vulkan errors can occur during rendering
     fn end_frame(&mut self) -> Result<()> {
         #[cfg(feature = "editor")]
-        self.egui.end_frame();
+        {
+            let capture = self.egui.end_frame();
+            if let Some(window_id) = self.egui_window {
+                self.input_router.set_capture(window_id, capture);
+            }
+        }
 
         let frame_index = self.current_frame();
         let frame = &self.frames[frame_index];


### PR DESCRIPTION
## Summary
- Added a shared platform `InputRouter` and new UI input event types so egui can consume routed input separately from gameplay input.
- Forwarded focus, modifiers, pointer, wheel, key, and IME events into the router while suppressing gameplay dispatch when egui captures that input.
- Updated egui frame setup to use window scale factor, focus, theme, and translated routed events.
- Exposed additional window state needed by the renderer and UI integration.