### PR TITLE
wrap Vulkan fences in RAII helper

### DIFF
--- a/crates/dirk_renderer/src/init.rs
+++ b/crates/dirk_renderer/src/init.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 use crate::{
     DEVICE_EXTENSIONS, Error, MAX_FRAMES_IN_FLIGHT, Renderer, Result, physical_device,
-    resources::{command_pool::CommandPool, device::RenderDevice},
+    resources::{command_pool::CommandPool, device::RenderDevice, sync::Fence},
     utils::{Frame, RendererProperties},
 };
 
@@ -221,14 +221,8 @@ impl Renderer {
                 &render_device.properties.queue_family_indices,
                 vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER,
             )?;
-            let fence = unsafe {
-                device.create_fence(
-                    &vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED),
-                    None,
-                )?
-            };
+            let fence = Fence::signaled(device)?;
             Ok(Frame {
-                device: device.clone(),
                 command_pool,
                 fence,
             })

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -520,16 +520,8 @@ impl Renderer {
         let frame_index = self.current_frame();
         let frame = &self.frames[frame_index];
 
-        unsafe {
-            self.render_device.device.wait_for_fences(
-                std::slice::from_ref(&frame.fence),
-                true,
-                u64::MAX,
-            )?;
-            self.render_device
-                .device
-                .reset_fences(std::slice::from_ref(&frame.fence))?;
-        }
+        frame.fence.wait(u64::MAX)?;
+        frame.fence.reset()?;
         self.render_device.flush_deletions();
         #[cfg(feature = "editor")]
         self.egui.free_textures_for_frame(frame_index)?;
@@ -660,7 +652,7 @@ impl Renderer {
         self.render_device.queues.submit(
             QueueType::Graphics,
             std::slice::from_ref(&submit_info),
-            frame.fence,
+            Some(&frame.fence),
         )?;
 
         render_image.present()?;

--- a/crates/dirk_renderer/src/resources.rs
+++ b/crates/dirk_renderer/src/resources.rs
@@ -7,3 +7,4 @@ pub mod device;
 pub mod image;
 pub mod queues;
 pub mod swapchain;
+pub mod sync;

--- a/crates/dirk_renderer/src/resources/command_pool.rs
+++ b/crates/dirk_renderer/src/resources/command_pool.rs
@@ -5,7 +5,10 @@ use ash::{Device, prelude::VkResult, vk};
 use crate::{
     Result,
     physical_device::QueueFamilyIndices,
-    resources::queues::{QueueType, Queues},
+    resources::{
+        queues::{QueueType, Queues},
+        sync::Fence,
+    },
 };
 
 #[derive(Debug)]
@@ -325,7 +328,7 @@ impl CommandBuffer {
         &self,
         queues: &Queues,
         submit_info: vk::SubmitInfo,
-        fence: vk::Fence,
+        fence: Option<&Fence>,
     ) -> VkResult<()> {
         queues.submit(self.queue_type, std::slice::from_ref(&submit_info), fence)
     }
@@ -334,32 +337,19 @@ impl CommandBuffer {
         unsafe {
             self.device.end_command_buffer(self.buff)?;
         };
-        let fence = unsafe {
-            self.device
-                .create_fence(&vk::FenceCreateInfo::default(), None)?
-        };
+        let fence = Fence::unsignaled(&self.device)?;
 
-        let submit_result = self.submit(queues, info, fence);
+        let submit_result = self.submit(queues, info, Some(&fence));
         if submit_result.is_ok() {
-            let wait_result = unsafe {
-                self.device
-                    .wait_for_fences(std::slice::from_ref(&fence), true, u64::MAX)
-            };
+            let wait_result = fence.wait(u64::MAX);
             if wait_result.is_ok() {
                 unsafe {
                     self.device
                         .free_command_buffers(self.pool, std::slice::from_ref(&self.buff));
                 }
             }
-            unsafe {
-                self.device.destroy_fence(fence, None);
-            }
             wait_result
         } else {
-            // TODO: RAII Fence wrapper to avoid having to do this weird deletion.
-            unsafe {
-                self.device.destroy_fence(fence, None);
-            }
             submit_result
         }
     }

--- a/crates/dirk_renderer/src/resources/queues.rs
+++ b/crates/dirk_renderer/src/resources/queues.rs
@@ -2,7 +2,7 @@
 
 use ash::{Device, Instance, khr::swapchain, prelude::VkResult, vk};
 
-use crate::physical_device::QueueFamilyIndices;
+use crate::{physical_device::QueueFamilyIndices, resources::sync::Fence};
 
 /// The type of queue you would like to submit to.
 #[derive(Copy, Clone)]
@@ -37,13 +37,14 @@ impl Queues {
         &self,
         queue_type: QueueType,
         submits: &[vk::SubmitInfo],
-        fence: vk::Fence,
+        fence: Option<&Fence>,
     ) -> VkResult<()> {
         let queue = match queue_type {
             QueueType::Compute => self.compute,
             QueueType::Graphics => self.graphics,
             QueueType::Transfer => self.transfer,
         };
+        let fence = fence.map_or_else(Fence::null_handle, Fence::raw);
         unsafe { self.device.queue_submit(queue, submits, fence) }
     }
 

--- a/crates/dirk_renderer/src/resources/swapchain.rs
+++ b/crates/dirk_renderer/src/resources/swapchain.rs
@@ -4,7 +4,10 @@ use ash::vk;
 
 use crate::{
     Error, Result,
-    resources::device::{Garbage, RenderDevice},
+    resources::{
+        device::{Garbage, RenderDevice},
+        sync::Fence,
+    },
 };
 
 /// An acquired image from a [`Swapchain`].
@@ -98,7 +101,7 @@ impl Swapchain {
                 self.raw,
                 u64::MAX,
                 image_available_semaphore,
-                vk::Fence::null(),
+                Fence::null_handle(),
             )?
         };
 

--- a/crates/dirk_renderer/src/resources/sync.rs
+++ b/crates/dirk_renderer/src/resources/sync.rs
@@ -1,0 +1,63 @@
+//! Synchronization resource wrappers.
+
+use ash::{Device, prelude::VkResult, vk};
+
+/// RAII wrapper for a Vulkan fence.
+pub struct Fence {
+    device: Device,
+    raw: vk::Fence,
+}
+
+impl Fence {
+    /// Creates a fence with the supplied creation flags.
+    pub fn create(device: &Device, flags: vk::FenceCreateFlags) -> VkResult<Self> {
+        let info = vk::FenceCreateInfo::default().flags(flags);
+        let raw = unsafe { device.create_fence(&info, None)? };
+
+        Ok(Self {
+            device: device.clone(),
+            raw,
+        })
+    }
+
+    /// Creates an unsignaled fence.
+    pub fn unsignaled(device: &Device) -> VkResult<Self> {
+        Self::create(device, vk::FenceCreateFlags::empty())
+    }
+
+    /// Creates a signaled fence.
+    pub fn signaled(device: &Device) -> VkResult<Self> {
+        Self::create(device, vk::FenceCreateFlags::SIGNALED)
+    }
+
+    /// Returns the raw Vulkan fence handle.
+    pub fn raw(&self) -> vk::Fence {
+        self.raw
+    }
+
+    /// Returns the raw null fence handle for Vulkan calls that take an optional fence.
+    pub(crate) fn null_handle() -> vk::Fence {
+        vk::Fence::null()
+    }
+
+    /// Waits for this fence to become signaled.
+    pub fn wait(&self, timeout: u64) -> VkResult<()> {
+        unsafe {
+            self.device
+                .wait_for_fences(std::slice::from_ref(&self.raw), true, timeout)
+        }
+    }
+
+    /// Resets this fence to the unsignaled state.
+    pub fn reset(&self) -> VkResult<()> {
+        unsafe { self.device.reset_fences(std::slice::from_ref(&self.raw)) }
+    }
+}
+
+impl Drop for Fence {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_fence(self.raw, None);
+        }
+    }
+}

--- a/crates/dirk_renderer/src/utils.rs
+++ b/crates/dirk_renderer/src/utils.rs
@@ -1,8 +1,11 @@
-use ash::{Device, vk};
+use ash::vk;
 
 use crate::{
     physical_device,
-    resources::command_pool::{CommandPool, Graphics},
+    resources::{
+        command_pool::{CommandPool, Graphics},
+        sync::Fence,
+    },
     shaders::metadata::VertexInput,
 };
 
@@ -44,11 +47,10 @@ pub fn make_version(version: dirk_utils::Version) -> u32 {
 }
 
 pub struct Frame {
-    pub device: Device,
     /// Command pool to allocate command buffers on every frame
     pub command_pool: CommandPool<Graphics>,
     /// Main synchronization fence
-    pub fence: vk::Fence,
+    pub fence: Fence,
     // TODO: have one primary command buffer that is allocated once and
     // secondary command for each scene. Should be allocated every time
     // there is a change in scene count. If not reallocated, reset.
@@ -57,9 +59,6 @@ pub struct Frame {
 impl Drop for Frame {
     fn drop(&mut self) {
         self.command_pool.destroy();
-        unsafe {
-            self.device.destroy_fence(self.fence, None);
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Introduce a `Fence` wrapper in `dirk_renderer` that owns a Vulkan fence and destroys it on drop.
- Update frame lifecycle and queue submission code to use the new wrapper for signaled and unsignaled fences.
- Simplify fence wait/reset handling by exposing methods on the wrapper instead of calling raw Vulkan functions at each site.
- Remove manual fence destruction from `Frame` and command buffer cleanup paths.
