### PR TITLE
add DefaultPlugins plugin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,24 @@ pub use dirk_utils as utils;
 pub use dirk_world as world;
 
 pub mod demo;
+
+/// Registers all the engine's default plugins.
+pub struct DefaultPlugins;
+
+impl dirk_engine::EnginePlugin for DefaultPlugins {
+    fn name(&self) -> &'static str {
+        "default_plugins"
+    }
+
+    fn build(&self, builder: &mut dirk_engine::EngineBuilder) -> anyhow::Result<()> {
+        #[cfg(feature = "editor")]
+        builder.with_plugin(editor::EditorPlugin)?;
+        builder.with_plugin(assets::AssetsPlugin)?;
+        builder.with_plugin(platform::PlatformPlugin)?;
+        builder.with_plugin(player::PlayerPlugin)?;
+        builder.with_plugin(world::WorldPlugin)?;
+        builder.with_plugin(renderer::RendererPlugin)?;
+        builder.with_plugin(demo::DemoPlugin)?;
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,16 +5,7 @@ use tracing::error;
 
 fn run() -> anyhow::Result<()> {
     let mut builder = dirk_engine::Engine::builder();
-
-    #[cfg(feature = "editor")]
-    builder.with_plugin(dirkengine::editor::EditorPlugin)?;
-    builder.with_plugin(dirkengine::assets::AssetsPlugin)?;
-    builder.with_plugin(dirkengine::platform::PlatformPlugin)?;
-    builder.with_plugin(dirkengine::player::PlayerPlugin)?;
-    builder.with_plugin(dirkengine::world::WorldPlugin)?;
-    builder.with_plugin(dirkengine::renderer::RendererPlugin)?;
-    builder.with_plugin(dirkengine::demo::DemoPlugin)?;
-
+    builder.with_plugin(dirkengine::DefaultPlugins)?;
     let engine = builder.build().context("build new engine")?;
 
     engine.run().context("run new engine")?;


### PR DESCRIPTION
Add a `DefaultPlugin` plugin that just registers all the main engine plugins (editor, renderer, assets, platform, ...).