### PR TITLE
feat: enhanced cli entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +357,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +425,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -637,6 +733,7 @@ name = "dirkengine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "dirk_assets",
  "dirk_build",
  "dirk_editor",
@@ -994,6 +1091,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1235,12 @@ name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -1524,6 +1633,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -2185,6 +2300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,6 +2662,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ thiserror.workspace = true
 tracing.workspace = true
 glam.workspace = true
 piquel-log.workspace = true
+clap = { workspace = true, optional = true }
 
 dirk_threads.workspace = true
 dirk_utils.workspace = true
@@ -45,13 +46,17 @@ all-features = true
 rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 
 [features]
-default = ["editor"]
+default = ["editor", "cli"]
 
 editor = [
     "dirk_engine/editor",
     "dirk_renderer/editor",
     "dep:dirk_editor",
 ]
+
+# Enhances the CLI of the engine.
+# When this feature is disabled, the engine just runs with DefaultPlugins
+cli = ["dep:clap"]
 
 # WORKSPACE CONFIGURATION
 
@@ -84,6 +89,7 @@ parking_lot = "0.12"
 tempfile = "3"
 slotmap = "1"
 signal-hook = "0.4"
+clap = { version = "4", features = ["derive"] }
 
 thiserror = "2"
 anyhow = "1"

--- a/crates/dirk_engine/src/builder.rs
+++ b/crates/dirk_engine/src/builder.rs
@@ -64,7 +64,7 @@ impl EngineBuilder {
             engine_name: "DirkEngine".to_owned(),
             engine_version: package_version,
             worker_name: "dirk-workers".to_owned(),
-            log_level: piquel_log::LogLevel::Debug,
+            log_level: piquel_log::LogLevel::Info,
             plugins: HashSet::new(),
             plugins_in_progress: HashSet::new(),
             subsystem_factories: HashMap::new(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,16 @@
 //! engine CLI.
 
 use anyhow::Context;
+use clap::Parser;
 
-use crate::DefaultPlugins;
+#[derive(Parser, Debug)]
+#[command(name = "dirkengine")]
+#[command(about = "DirkEngine CLI")]
+struct Cli {
+    /// Enable debug logging.
+    #[arg(long = "no-demo")]
+    no_demo: bool,
+}
 
 /// Runs the enhanced [`clap`] CLI.
 ///
@@ -11,8 +19,22 @@ use crate::DefaultPlugins;
 ///
 /// Returns any error that occurs while running the engine.
 pub fn run() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
     let mut builder = dirk_engine::Engine::builder();
-    builder.with_plugin(DefaultPlugins)?;
+
+    #[cfg(feature = "editor")]
+    builder.with_plugin(dirk_editor::EditorPlugin)?;
+    builder.with_plugin(dirk_assets::AssetsPlugin)?;
+    builder.with_plugin(dirk_platform::PlatformPlugin)?;
+    builder.with_plugin(dirk_player::PlayerPlugin)?;
+    builder.with_plugin(dirk_world::WorldPlugin)?;
+    builder.with_plugin(dirk_renderer::RendererPlugin)?;
+
+    if !cli.no_demo {
+        builder.with_plugin(crate::demo::DemoPlugin)?;
+    }
+
     let engine = builder.build().context("build new engine")?;
 
     engine.run().context("run new engine")?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,20 @@
 //! This crate contains the CLI entrypoint & management for the enhanced clap
 //! engine CLI.
 
+use anyhow::Context;
+
+use crate::DefaultPlugins;
+
 /// Runs the enhanced [`clap`] CLI.
+///
+/// # Errors
+///
+/// Returns any error that occurs while running the engine.
 pub fn run() -> anyhow::Result<()> {
+    let mut builder = dirk_engine::Engine::builder();
+    builder.with_plugin(DefaultPlugins)?;
+    let engine = builder.build().context("build new engine")?;
+
+    engine.run().context("run new engine")?;
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,7 @@
+//! This crate contains the CLI entrypoint & management for the enhanced clap
+//! engine CLI.
+
+/// Runs the enhanced [`clap`] CLI.
+pub fn run() -> anyhow::Result<()> {
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,15 +2,15 @@
 //! engine CLI.
 
 use anyhow::Context;
-use clap::Parser;
+use clap::{ArgAction, Parser};
 
 #[derive(Parser, Debug)]
 #[command(name = "dirkengine")]
 #[command(about = "DirkEngine CLI")]
 struct Cli {
-    /// Enable debug logging.
-    #[arg(short = 'v', long = "verbose", global = true)]
-    verbose: bool,
+    /// Increase logging verbosity. Use -v for debug and -vv for trace.
+    #[arg(short = 'v', long = "verbose", global = true, action = ArgAction::Count)]
+    verbose: u8,
 
     /// Disable the demo world.
     #[arg(long = "no-demo", global = true)]
@@ -27,8 +27,14 @@ pub fn run() -> anyhow::Result<()> {
 
     let mut builder = dirk_engine::Engine::builder();
 
-    if cli.verbose {
-        builder.with_log_level(piquel_log::LogLevel::Trace);
+    match cli.verbose {
+        0 => {}
+        1 => {
+            builder.with_log_level(piquel_log::LogLevel::Debug);
+        }
+        _ => {
+            builder.with_log_level(piquel_log::LogLevel::Trace);
+        }
     }
 
     #[cfg(feature = "editor")]
@@ -47,4 +53,17 @@ pub fn run() -> anyhow::Result<()> {
 
     engine.run().context("run new engine")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verbosity_counts_repeated_flags() {
+        assert_eq!(Cli::parse_from(["dirkengine"]).verbose, 0);
+        assert_eq!(Cli::parse_from(["dirkengine", "-v"]).verbose, 1);
+        assert_eq!(Cli::parse_from(["dirkengine", "-vv"]).verbose, 2);
+        assert_eq!(Cli::parse_from(["dirkengine", "-v", "-v"]).verbose, 2);
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,11 @@ use clap::Parser;
 #[command(about = "DirkEngine CLI")]
 struct Cli {
     /// Enable debug logging.
-    #[arg(long = "no-demo")]
+    #[arg(short = 'v', long = "verbose", global = true)]
+    verbose: bool,
+
+    /// Disable the demo world.
+    #[arg(long = "no-demo", global = true)]
     no_demo: bool,
 }
 
@@ -22,6 +26,10 @@ pub fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     let mut builder = dirk_engine::Engine::builder();
+
+    if cli.verbose {
+        builder.with_log_level(piquel_log::LogLevel::Trace);
+    }
 
     #[cfg(feature = "editor")]
     builder.with_plugin(dirk_editor::EditorPlugin)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,24 @@ pub use dirk_utils as utils;
 pub use dirk_world as world;
 
 pub mod demo;
+
+/// Registers all the engine's default plugins.
+pub struct DefaultPlugins;
+
+impl dirk_engine::EnginePlugin for DefaultPlugins {
+    fn name(&self) -> &'static str {
+        "default_plugins"
+    }
+
+    fn build(&self, builder: &mut dirk_engine::EngineBuilder) -> anyhow::Result<()> {
+        #[cfg(feature = "editor")]
+        builder.with_plugin(editor::EditorPlugin)?;
+        builder.with_plugin(assets::AssetsPlugin)?;
+        builder.with_plugin(platform::PlatformPlugin)?;
+        builder.with_plugin(player::PlayerPlugin)?;
+        builder.with_plugin(world::WorldPlugin)?;
+        builder.with_plugin(renderer::RendererPlugin)?;
+        builder.with_plugin(demo::DemoPlugin)?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@ impl dirk_engine::EnginePlugin for DefaultPlugins {
         builder.with_plugin(player::PlayerPlugin)?;
         builder.with_plugin(world::WorldPlugin)?;
         builder.with_plugin(renderer::RendererPlugin)?;
-        builder.with_plugin(demo::DemoPlugin)?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,9 @@ pub use dirk_world as world;
 
 pub mod demo;
 
+#[cfg(feature = "cli")]
+pub mod cli;
+
 /// Registers all the engine's default plugins.
 pub struct DefaultPlugins;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,16 +5,7 @@ use tracing::error;
 
 fn run() -> anyhow::Result<()> {
     let mut builder = dirk_engine::Engine::builder();
-
-    #[cfg(feature = "editor")]
-    builder.with_plugin(dirkengine::editor::EditorPlugin)?;
-    builder.with_plugin(dirkengine::assets::AssetsPlugin)?;
-    builder.with_plugin(dirkengine::platform::PlatformPlugin)?;
-    builder.with_plugin(dirkengine::player::PlayerPlugin)?;
-    builder.with_plugin(dirkengine::world::WorldPlugin)?;
-    builder.with_plugin(dirkengine::renderer::RendererPlugin)?;
-    builder.with_plugin(dirkengine::demo::DemoPlugin)?;
-
+    builder.with_plugin(dirkengine::DefaultPlugins)?;
     let engine = builder.build().context("build new engine")?;
 
     engine.run().context("run new engine")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,15 @@
 //! Entrypoint for exercising the new plugin/subsystem engine runtime.
 
-use anyhow::Context;
-use tracing::error;
+#[cfg(feature = "cli")]
+use dirkengine::cli::run;
 
+#[cfg(not(feature = "cli"))]
 fn run() -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    println!(
+        "you are running the base cli. to run the advanced cli, enable the \"cli\" cargo feature"
+    );
     let mut builder = dirk_engine::Engine::builder();
     builder.with_plugin(dirkengine::DefaultPlugins)?;
     let engine = builder.build().context("build new engine")?;
@@ -16,7 +22,7 @@ fn main() {
     match run() {
         Ok(()) => {}
         Err(err) => {
-            error!("{err:#}");
+            tracing::error!("{err:#}");
             panic!("Error: {err:#}");
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn run() -> anyhow::Result<()> {
     );
     let mut builder = dirk_engine::Engine::builder();
     builder.with_plugin(dirkengine::DefaultPlugins)?;
-    builder.with_plugin(demo::DemoPlugin)?;
+    builder.with_plugin(dirkengine::demo::DemoPlugin)?;
     let engine = builder.build().context("build new engine")?;
 
     engine.run().context("run new engine")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ fn run() -> anyhow::Result<()> {
     );
     let mut builder = dirk_engine::Engine::builder();
     builder.with_plugin(dirkengine::DefaultPlugins)?;
+    builder.with_plugin(demo::DemoPlugin)?;
     let engine = builder.build().context("build new engine")?;
 
     engine.run().context("run new engine")?;


### PR DESCRIPTION
## Summary

- Add an optional `cli` feature, enabled by default, backed by `clap` and exposed as `dirkengine::cli`.
- Route the default binary through the enhanced CLI when the feature is enabled, while keeping a base entrypoint for `--no-default-features` builds.
- Add `--no-demo` so the demo world can be skipped from the binary entrypoint.
- Move the demo plugin out of `DefaultPlugins` so callers can opt into it explicitly.
- Set the engine default log level to `Info`; `-v` now enables `Debug` and `-vv` enables `Trace`.
- Add parser coverage for repeated verbosity flags.