### PR TITLE
feat: configurable editor styles and default theme

### DIFF
--- a/crates/dirk_editor/src/lib.rs
+++ b/crates/dirk_editor/src/lib.rs
@@ -10,6 +10,7 @@ use dirk_engine::editor::{
 };
 
 mod settings;
+pub mod style;
 mod universe;
 
 #[cfg(test)]
@@ -42,6 +43,7 @@ impl dirk_engine::editor::EditorSubsystem for BuiltinEditorSubsystem {
         context: &mut dirk_engine::editor::EditorStartContext<'_>,
     ) -> anyhow::Result<()> {
         let services = context.editor;
+        services.add_style(style::default_editor_style());
         services.add_menu(MainMenu);
 
         settings::register_capabilities(services);

--- a/crates/dirk_editor/src/style.rs
+++ b/crates/dirk_editor/src/style.rs
@@ -46,24 +46,24 @@ pub struct EditorPalette {
 impl Default for EditorPalette {
     fn default() -> Self {
         Self {
-            background: color(0x15, 0x17, 0x1a),
-            panel: color(0x1b, 0x1e, 0x22),
-            panel_alt: color(0x20, 0x24, 0x2a),
-            surface: color(0x24, 0x28, 0x2e),
-            surface_high: color(0x2b, 0x30, 0x37),
-            control: color(0x30, 0x36, 0x40),
-            control_hovered: color(0x3a, 0x42, 0x4d),
-            control_active: color(0x24, 0x6f, 0xa8),
-            stroke_subtle: color(0x34, 0x3a, 0x43),
-            stroke_strong: color(0x58, 0x61, 0x6d),
-            text: color(0xd8, 0xdd, 0xe4),
-            text_muted: color(0x99, 0xa2, 0xad),
-            text_bright: color(0xf1, 0xf4, 0xf8),
-            accent: color(0x2f, 0x8c, 0xcf),
-            accent_hovered: color(0x49, 0xa7, 0xec),
-            selection: color(0x1f, 0x5f, 0x8f),
-            warn: color(0xe6, 0xa2, 0x3c),
-            error: color(0xf5, 0x6c, 0x6c),
+            background: color(0x0d, 0x0f, 0x11),
+            panel: color(0x16, 0x18, 0x1b),
+            panel_alt: color(0x1d, 0x20, 0x24),
+            surface: color(0x20, 0x23, 0x27),
+            surface_high: color(0x28, 0x2c, 0x32),
+            control: color(0x25, 0x28, 0x2d),
+            control_hovered: color(0x30, 0x35, 0x3c),
+            control_active: color(0x2f, 0x56, 0x68),
+            stroke_subtle: color(0x2c, 0x30, 0x35),
+            stroke_strong: color(0x4a, 0x51, 0x5b),
+            text: color(0xd0, 0xd5, 0xdc),
+            text_muted: color(0x8c, 0x94, 0x9d),
+            text_bright: color(0xf0, 0xf3, 0xf6),
+            accent: color(0x58, 0x8a, 0xa8),
+            accent_hovered: color(0x7a, 0xa7, 0xc0),
+            selection: color(0x2b, 0x59, 0x73),
+            warn: color(0xd8, 0x9a, 0x3a),
+            error: color(0xe0, 0x62, 0x5c),
         }
     }
 }
@@ -79,100 +79,7 @@ impl From<EditorPalette> for EditorStyle {
         Self::new(move |ctx| {
             ctx.set_theme(egui::Theme::Dark);
 
-            let mut style = egui::Style::default();
-
-            style.spacing.item_spacing = egui::vec2(6.0, 4.0);
-            style.spacing.window_margin = egui::Margin::symmetric(10, 8);
-            style.spacing.menu_margin = egui::Margin::symmetric(8, 6);
-            style.spacing.button_padding = egui::vec2(8.0, 3.0);
-            style.spacing.interact_size = egui::vec2(28.0, 22.0);
-            style.spacing.slider_width = 120.0;
-            style.spacing.combo_width = 140.0;
-            style.spacing.text_edit_width = 260.0;
-
-            style.text_styles.insert(
-                egui::TextStyle::Small,
-                egui::FontId::new(10.0, egui::FontFamily::Proportional),
-            );
-            style.text_styles.insert(
-                egui::TextStyle::Body,
-                egui::FontId::new(13.0, egui::FontFamily::Proportional),
-            );
-            style.text_styles.insert(
-                egui::TextStyle::Button,
-                egui::FontId::new(13.0, egui::FontFamily::Proportional),
-            );
-            style.text_styles.insert(
-                egui::TextStyle::Monospace,
-                egui::FontId::new(13.0, egui::FontFamily::Monospace),
-            );
-            style.text_styles.insert(
-                egui::TextStyle::Heading,
-                egui::FontId::new(18.0, egui::FontFamily::Proportional),
-            );
-
-            let mut visuals = egui::Visuals::dark();
-            visuals.window_fill = palette.surface;
-            visuals.panel_fill = palette.background;
-            visuals.window_stroke = egui::Stroke::new(1.0, palette.stroke_subtle);
-            visuals.window_corner_radius = egui::CornerRadius::same(4);
-            visuals.menu_corner_radius = egui::CornerRadius::same(4);
-            visuals.window_shadow = egui::Shadow {
-                offset: [0, 8],
-                blur: 18,
-                spread: 0,
-                color: egui::Color32::from_black_alpha(120),
-            };
-            visuals.popup_shadow = egui::Shadow {
-                offset: [0, 6],
-                blur: 14,
-                spread: 0,
-                color: egui::Color32::from_black_alpha(110),
-            };
-            visuals.selection.bg_fill = palette.selection;
-            visuals.selection.stroke = egui::Stroke::new(1.0, palette.text_bright);
-            visuals.hyperlink_color = palette.accent_hovered;
-            visuals.warn_fg_color = palette.warn;
-            visuals.error_fg_color = palette.error;
-            visuals.weak_text_color = Some(palette.text_muted);
-            visuals.striped = true;
-            visuals.slider_trailing_fill = true;
-            visuals.button_frame = true;
-            visuals.indent_has_left_vline = true;
-            visuals.handle_shape = egui::style::HandleShape::Rect { aspect_ratio: 0.6 };
-
-            visuals.widgets.noninteractive = widget_visuals(
-                palette.panel,
-                palette.surface,
-                palette.stroke_subtle,
-                palette.text_muted,
-            );
-            visuals.widgets.inactive = widget_visuals(
-                palette.control,
-                palette.control,
-                palette.stroke_subtle,
-                palette.text,
-            );
-            visuals.widgets.hovered = widget_visuals(
-                palette.control_hovered,
-                palette.control_hovered,
-                palette.stroke_strong,
-                palette.text_bright,
-            );
-            visuals.widgets.active = widget_visuals(
-                palette.accent,
-                palette.accent,
-                palette.accent_hovered,
-                palette.text_bright,
-            );
-            visuals.widgets.open = widget_visuals(
-                palette.surface_high,
-                palette.surface_high,
-                palette.accent,
-                palette.text_bright,
-            );
-
-            style.visuals = visuals;
+            let style = editor_egui_style(palette);
 
             ctx.set_style_of(egui::Theme::Dark, style.clone());
             ctx.set_style_of(egui::Theme::Light, style);
@@ -186,6 +93,133 @@ impl From<&EditorPalette> for EditorStyle {
     }
 }
 
+fn editor_egui_style(palette: EditorPalette) -> egui::Style {
+    let mut style = egui::Style::default();
+    apply_compact_spacing(&mut style.spacing);
+    apply_compact_text_styles(&mut style.text_styles);
+    style.visuals = editor_visuals(palette);
+    style
+}
+
+fn apply_compact_spacing(spacing: &mut egui::style::Spacing) {
+    spacing.item_spacing = egui::vec2(4.0, 2.0);
+    spacing.window_margin = egui::Margin::symmetric(6, 5);
+    spacing.menu_margin = egui::Margin::symmetric(5, 3);
+    spacing.button_padding = egui::vec2(5.0, 2.0);
+    spacing.indent = 12.0;
+    spacing.interact_size = egui::vec2(22.0, 18.0);
+    spacing.slider_width = 96.0;
+    spacing.slider_rail_height = 4.0;
+    spacing.combo_width = 118.0;
+    spacing.text_edit_width = 220.0;
+    spacing.icon_width = 14.0;
+    spacing.icon_width_inner = 8.0;
+    spacing.icon_spacing = 4.0;
+    spacing.menu_spacing = 2.0;
+    spacing.scroll.bar_width = 8.0;
+    spacing.scroll.handle_min_length = 24.0;
+    spacing.scroll.bar_inner_margin = 2.0;
+    spacing.scroll.bar_outer_margin = 1.0;
+}
+
+fn apply_compact_text_styles(
+    text_styles: &mut std::collections::BTreeMap<egui::TextStyle, egui::FontId>,
+) {
+    text_styles.insert(
+        egui::TextStyle::Small,
+        egui::FontId::new(9.0, egui::FontFamily::Proportional),
+    );
+    text_styles.insert(
+        egui::TextStyle::Body,
+        egui::FontId::new(12.0, egui::FontFamily::Proportional),
+    );
+    text_styles.insert(
+        egui::TextStyle::Button,
+        egui::FontId::new(12.0, egui::FontFamily::Proportional),
+    );
+    text_styles.insert(
+        egui::TextStyle::Monospace,
+        egui::FontId::new(12.0, egui::FontFamily::Monospace),
+    );
+    text_styles.insert(
+        egui::TextStyle::Heading,
+        egui::FontId::new(15.0, egui::FontFamily::Proportional),
+    );
+}
+
+fn editor_visuals(palette: EditorPalette) -> egui::Visuals {
+    let mut visuals = egui::Visuals::dark();
+    visuals.override_text_color = Some(palette.text);
+    visuals.window_fill = palette.surface;
+    visuals.panel_fill = palette.background;
+    visuals.window_stroke = egui::Stroke::new(1.0, palette.stroke_subtle);
+    visuals.window_corner_radius = egui::CornerRadius::same(2);
+    visuals.menu_corner_radius = egui::CornerRadius::same(2);
+    visuals.window_shadow = egui::Shadow {
+        offset: [0, 3],
+        blur: 8,
+        spread: 0,
+        color: egui::Color32::from_black_alpha(95),
+    };
+    visuals.popup_shadow = egui::Shadow {
+        offset: [0, 2],
+        blur: 6,
+        spread: 0,
+        color: egui::Color32::from_black_alpha(90),
+    };
+    visuals.faint_bg_color = palette.panel_alt;
+    visuals.extreme_bg_color = palette.background;
+    visuals.text_edit_bg_color = Some(palette.panel);
+    visuals.code_bg_color = palette.panel_alt;
+    visuals.selection.bg_fill = palette.selection;
+    visuals.selection.stroke = egui::Stroke::new(1.0, palette.text_bright);
+    visuals.hyperlink_color = palette.accent_hovered;
+    visuals.warn_fg_color = palette.warn;
+    visuals.error_fg_color = palette.error;
+    visuals.weak_text_color = Some(palette.text_muted);
+    visuals.striped = true;
+    visuals.slider_trailing_fill = true;
+    visuals.button_frame = true;
+    visuals.collapsing_header_frame = false;
+    visuals.indent_has_left_vline = true;
+    visuals.handle_shape = egui::style::HandleShape::Rect { aspect_ratio: 0.6 };
+    apply_widget_visuals(&mut visuals.widgets, palette);
+    visuals
+}
+
+fn apply_widget_visuals(widgets: &mut egui::style::Widgets, palette: EditorPalette) {
+    widgets.noninteractive = widget_visuals(
+        palette.panel,
+        palette.surface,
+        palette.stroke_subtle,
+        palette.text_muted,
+    );
+    widgets.inactive = widget_visuals(
+        palette.control,
+        palette.control,
+        palette.stroke_subtle,
+        palette.text,
+    );
+    widgets.hovered = widget_visuals(
+        palette.control_hovered,
+        palette.control_hovered,
+        palette.stroke_strong,
+        palette.text_bright,
+    );
+    widgets.active = widget_visuals(
+        palette.control_active,
+        palette.control_active,
+        palette.accent,
+        palette.text_bright,
+    );
+    widgets.open = widget_visuals(
+        palette.surface_high,
+        palette.surface_high,
+        palette.accent,
+        palette.text_bright,
+    );
+}
+
 fn widget_visuals(
     bg_fill: egui::Color32,
     weak_bg_fill: egui::Color32,
@@ -196,7 +230,7 @@ fn widget_visuals(
         bg_fill,
         weak_bg_fill,
         bg_stroke: egui::Stroke::new(1.0, bg_stroke),
-        corner_radius: egui::CornerRadius::same(3),
+        corner_radius: egui::CornerRadius::same(2),
         fg_stroke: egui::Stroke::new(1.0, fg_stroke),
         expansion: 0.0,
     }

--- a/crates/dirk_editor/src/style.rs
+++ b/crates/dirk_editor/src/style.rs
@@ -1,0 +1,207 @@
+//! Default editor theme and palette.
+
+use dirk_engine::editor::EditorStyle;
+
+/// Color palette for the default Dirk editor theme.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EditorPalette {
+    /// Main editor background.
+    pub background: egui::Color32,
+    /// Primary panel fill.
+    pub panel: egui::Color32,
+    /// Alternate panel fill.
+    pub panel_alt: egui::Color32,
+    /// Floating surface fill.
+    pub surface: egui::Color32,
+    /// Emphasized floating surface fill.
+    pub surface_high: egui::Color32,
+    /// Default interactive control fill.
+    pub control: egui::Color32,
+    /// Hovered interactive control fill.
+    pub control_hovered: egui::Color32,
+    /// Active control fill for specialized controls.
+    pub control_active: egui::Color32,
+    /// Low-contrast border color.
+    pub stroke_subtle: egui::Color32,
+    /// High-contrast border color.
+    pub stroke_strong: egui::Color32,
+    /// Default text color.
+    pub text: egui::Color32,
+    /// Muted text color.
+    pub text_muted: egui::Color32,
+    /// Bright text color.
+    pub text_bright: egui::Color32,
+    /// Primary accent color.
+    pub accent: egui::Color32,
+    /// Hovered accent color.
+    pub accent_hovered: egui::Color32,
+    /// Selection fill color.
+    pub selection: egui::Color32,
+    /// Warning text color.
+    pub warn: egui::Color32,
+    /// Error text color.
+    pub error: egui::Color32,
+}
+
+impl Default for EditorPalette {
+    fn default() -> Self {
+        Self {
+            background: color(0x15, 0x17, 0x1a),
+            panel: color(0x1b, 0x1e, 0x22),
+            panel_alt: color(0x20, 0x24, 0x2a),
+            surface: color(0x24, 0x28, 0x2e),
+            surface_high: color(0x2b, 0x30, 0x37),
+            control: color(0x30, 0x36, 0x40),
+            control_hovered: color(0x3a, 0x42, 0x4d),
+            control_active: color(0x24, 0x6f, 0xa8),
+            stroke_subtle: color(0x34, 0x3a, 0x43),
+            stroke_strong: color(0x58, 0x61, 0x6d),
+            text: color(0xd8, 0xdd, 0xe4),
+            text_muted: color(0x99, 0xa2, 0xad),
+            text_bright: color(0xf1, 0xf4, 0xf8),
+            accent: color(0x2f, 0x8c, 0xcf),
+            accent_hovered: color(0x49, 0xa7, 0xec),
+            selection: color(0x1f, 0x5f, 0x8f),
+            warn: color(0xe6, 0xa2, 0x3c),
+            error: color(0xf5, 0x6c, 0x6c),
+        }
+    }
+}
+
+/// Returns the default compact dark editor style.
+#[must_use]
+pub fn default_editor_style() -> EditorStyle {
+    EditorPalette::default().into()
+}
+
+impl From<EditorPalette> for EditorStyle {
+    fn from(palette: EditorPalette) -> Self {
+        Self::new(move |ctx| {
+            ctx.set_theme(egui::Theme::Dark);
+
+            let mut style = egui::Style::default();
+
+            style.spacing.item_spacing = egui::vec2(6.0, 4.0);
+            style.spacing.window_margin = egui::Margin::symmetric(10, 8);
+            style.spacing.menu_margin = egui::Margin::symmetric(8, 6);
+            style.spacing.button_padding = egui::vec2(8.0, 3.0);
+            style.spacing.interact_size = egui::vec2(28.0, 22.0);
+            style.spacing.slider_width = 120.0;
+            style.spacing.combo_width = 140.0;
+            style.spacing.text_edit_width = 260.0;
+
+            style.text_styles.insert(
+                egui::TextStyle::Small,
+                egui::FontId::new(10.0, egui::FontFamily::Proportional),
+            );
+            style.text_styles.insert(
+                egui::TextStyle::Body,
+                egui::FontId::new(13.0, egui::FontFamily::Proportional),
+            );
+            style.text_styles.insert(
+                egui::TextStyle::Button,
+                egui::FontId::new(13.0, egui::FontFamily::Proportional),
+            );
+            style.text_styles.insert(
+                egui::TextStyle::Monospace,
+                egui::FontId::new(13.0, egui::FontFamily::Monospace),
+            );
+            style.text_styles.insert(
+                egui::TextStyle::Heading,
+                egui::FontId::new(18.0, egui::FontFamily::Proportional),
+            );
+
+            let mut visuals = egui::Visuals::dark();
+            visuals.window_fill = palette.surface;
+            visuals.panel_fill = palette.background;
+            visuals.window_stroke = egui::Stroke::new(1.0, palette.stroke_subtle);
+            visuals.window_corner_radius = egui::CornerRadius::same(4);
+            visuals.menu_corner_radius = egui::CornerRadius::same(4);
+            visuals.window_shadow = egui::Shadow {
+                offset: [0, 8],
+                blur: 18,
+                spread: 0,
+                color: egui::Color32::from_black_alpha(120),
+            };
+            visuals.popup_shadow = egui::Shadow {
+                offset: [0, 6],
+                blur: 14,
+                spread: 0,
+                color: egui::Color32::from_black_alpha(110),
+            };
+            visuals.selection.bg_fill = palette.selection;
+            visuals.selection.stroke = egui::Stroke::new(1.0, palette.text_bright);
+            visuals.hyperlink_color = palette.accent_hovered;
+            visuals.warn_fg_color = palette.warn;
+            visuals.error_fg_color = palette.error;
+            visuals.weak_text_color = Some(palette.text_muted);
+            visuals.striped = true;
+            visuals.slider_trailing_fill = true;
+            visuals.button_frame = true;
+            visuals.indent_has_left_vline = true;
+            visuals.handle_shape = egui::style::HandleShape::Rect { aspect_ratio: 0.6 };
+
+            visuals.widgets.noninteractive = widget_visuals(
+                palette.panel,
+                palette.surface,
+                palette.stroke_subtle,
+                palette.text_muted,
+            );
+            visuals.widgets.inactive = widget_visuals(
+                palette.control,
+                palette.control,
+                palette.stroke_subtle,
+                palette.text,
+            );
+            visuals.widgets.hovered = widget_visuals(
+                palette.control_hovered,
+                palette.control_hovered,
+                palette.stroke_strong,
+                palette.text_bright,
+            );
+            visuals.widgets.active = widget_visuals(
+                palette.accent,
+                palette.accent,
+                palette.accent_hovered,
+                palette.text_bright,
+            );
+            visuals.widgets.open = widget_visuals(
+                palette.surface_high,
+                palette.surface_high,
+                palette.accent,
+                palette.text_bright,
+            );
+
+            style.visuals = visuals;
+
+            ctx.set_style_of(egui::Theme::Dark, style.clone());
+            ctx.set_style_of(egui::Theme::Light, style);
+        })
+    }
+}
+
+impl From<&EditorPalette> for EditorStyle {
+    fn from(palette: &EditorPalette) -> Self {
+        Self::from(*palette)
+    }
+}
+
+fn widget_visuals(
+    bg_fill: egui::Color32,
+    weak_bg_fill: egui::Color32,
+    bg_stroke: egui::Color32,
+    fg_stroke: egui::Color32,
+) -> egui::style::WidgetVisuals {
+    egui::style::WidgetVisuals {
+        bg_fill,
+        weak_bg_fill,
+        bg_stroke: egui::Stroke::new(1.0, bg_stroke),
+        corner_radius: egui::CornerRadius::same(3),
+        fg_stroke: egui::Stroke::new(1.0, fg_stroke),
+        expansion: 0.0,
+    }
+}
+
+fn color(r: u8, g: u8, b: u8) -> egui::Color32 {
+    egui::Color32::from_rgb(r, g, b)
+}

--- a/crates/dirk_editor/src/tests.rs
+++ b/crates/dirk_editor/src/tests.rs
@@ -1,6 +1,17 @@
 use std::sync::{Arc, OnceLock};
 
+use dirk_engine::editor::EditorStyle;
 use dirk_engine::editor::EditorSubsystem as _;
+
+fn begin_egui_pass(ctx: &egui::Context) {
+    ctx.begin_pass(egui::RawInput {
+        screen_rect: Some(egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(800.0, 600.0),
+        )),
+        ..egui::RawInput::default()
+    });
+}
 
 fn test_handle() -> dirk_engine::EngineHandle {
     static HANDLE: OnceLock<dirk_engine::EngineHandle> = OnceLock::new();
@@ -32,6 +43,41 @@ fn test_handle() -> dirk_engine::EngineHandle {
 }
 
 #[test]
+fn default_editor_style_applies_dark_editor_visuals() {
+    let ctx = egui::Context::default();
+    begin_egui_pass(&ctx);
+
+    crate::default_editor_style().apply(&ctx);
+
+    let palette = crate::EditorPalette::default();
+    let style = ctx.style();
+    assert_eq!(ctx.theme(), egui::Theme::Dark);
+    assert_eq!(style.visuals.window_fill, palette.surface);
+    assert_eq!(style.visuals.panel_fill, palette.background);
+    assert_eq!(style.visuals.selection.bg_fill, palette.selection);
+    assert_eq!(style.visuals.widgets.active.bg_fill, palette.accent);
+
+    let _ = ctx.end_pass();
+}
+
+#[test]
+fn editor_palette_converts_to_editor_style() {
+    let ctx = egui::Context::default();
+    begin_egui_pass(&ctx);
+
+    let palette = crate::theme::EditorPalette {
+        surface: egui::Color32::from_rgb(0x32, 0x10, 0x44),
+        ..crate::theme::EditorPalette::default()
+    };
+    let style: EditorStyle = palette.into();
+    style.apply(&ctx);
+
+    assert_eq!(ctx.style().visuals.window_fill, palette.surface);
+
+    let _ = ctx.end_pass();
+}
+
+#[test]
 fn builtin_editor_subsystem_registers_expected_default_capabilities() -> anyhow::Result<()> {
     let services = crate::EditorServices::new();
     let handle = test_handle();
@@ -50,6 +96,21 @@ fn builtin_editor_subsystem_registers_expected_default_capabilities() -> anyhow:
         services.window_titles(),
         vec!["Settings", "Engine", "Worlds", "Entities", "Entity Details",]
     );
+
+    let ctx = egui::Context::default();
+    begin_egui_pass(&ctx);
+
+    let frame = dirk_engine::editor::EditorRenderContext::new(0.016, &handle, &universe);
+    services.render_ui(&ctx, &frame)?;
+
+    let palette = crate::EditorPalette::default();
+    let style = ctx.style();
+    assert_eq!(style.visuals.window_fill, palette.surface);
+    assert_eq!(style.visuals.panel_fill, palette.background);
+    assert_eq!(style.visuals.selection.bg_fill, palette.selection);
+    assert_eq!(style.visuals.widgets.active.bg_fill, palette.accent);
+
+    let _ = ctx.end_pass();
 
     Ok(())
 }

--- a/crates/dirk_editor/src/tests.rs
+++ b/crates/dirk_editor/src/tests.rs
@@ -3,6 +3,9 @@ use std::sync::{Arc, OnceLock};
 use dirk_engine::editor::EditorStyle;
 use dirk_engine::editor::EditorSubsystem as _;
 
+use crate::style::EditorPalette;
+use crate::style::default_editor_style;
+
 fn begin_egui_pass(ctx: &egui::Context) {
     ctx.begin_pass(egui::RawInput {
         screen_rect: Some(egui::Rect::from_min_size(
@@ -47,15 +50,20 @@ fn default_editor_style_applies_dark_editor_visuals() {
     let ctx = egui::Context::default();
     begin_egui_pass(&ctx);
 
-    crate::default_editor_style().apply(&ctx);
+    default_editor_style().apply(&ctx);
 
-    let palette = crate::EditorPalette::default();
+    let palette = EditorPalette::default();
     let style = ctx.style();
     assert_eq!(ctx.theme(), egui::Theme::Dark);
     assert_eq!(style.visuals.window_fill, palette.surface);
     assert_eq!(style.visuals.panel_fill, palette.background);
     assert_eq!(style.visuals.selection.bg_fill, palette.selection);
-    assert_eq!(style.visuals.widgets.active.bg_fill, palette.accent);
+    assert_eq!(style.visuals.widgets.active.bg_fill, palette.control_active);
+    assert_eq!(style.spacing.interact_size, egui::vec2(22.0, 18.0));
+    assert_eq!(
+        style.visuals.window_corner_radius,
+        egui::CornerRadius::same(2)
+    );
 
     let _ = ctx.end_pass();
 }
@@ -65,9 +73,9 @@ fn editor_palette_converts_to_editor_style() {
     let ctx = egui::Context::default();
     begin_egui_pass(&ctx);
 
-    let palette = crate::theme::EditorPalette {
+    let palette = EditorPalette {
         surface: egui::Color32::from_rgb(0x32, 0x10, 0x44),
-        ..crate::theme::EditorPalette::default()
+        ..EditorPalette::default()
     };
     let style: EditorStyle = palette.into();
     style.apply(&ctx);
@@ -103,12 +111,13 @@ fn builtin_editor_subsystem_registers_expected_default_capabilities() -> anyhow:
     let frame = dirk_engine::editor::EditorRenderContext::new(0.016, &handle, &universe);
     services.render_ui(&ctx, &frame)?;
 
-    let palette = crate::EditorPalette::default();
+    let palette = EditorPalette::default();
     let style = ctx.style();
     assert_eq!(style.visuals.window_fill, palette.surface);
     assert_eq!(style.visuals.panel_fill, palette.background);
     assert_eq!(style.visuals.selection.bg_fill, palette.selection);
-    assert_eq!(style.visuals.widgets.active.bg_fill, palette.accent);
+    assert_eq!(style.visuals.widgets.active.bg_fill, palette.control_active);
+    assert_eq!(style.spacing.window_margin, egui::Margin::symmetric(6, 5));
 
     let _ = ctx.end_pass();
 

--- a/crates/dirk_engine/src/editor.rs
+++ b/crates/dirk_engine/src/editor.rs
@@ -302,6 +302,29 @@ pub trait EditorMenu: Send + 'static {
     ) -> anyhow::Result<()>;
 }
 
+/// Generic editor style hook.
+#[derive(Clone)]
+pub struct EditorStyle {
+    apply: Arc<dyn Fn(&egui::Context) + Send + Sync + 'static>,
+}
+
+impl EditorStyle {
+    /// Creates a style hook from a callback.
+    pub fn new<F>(apply: F) -> Self
+    where
+        F: Fn(&egui::Context) + Send + Sync + 'static,
+    {
+        Self {
+            apply: Arc::new(apply),
+        }
+    }
+
+    /// Applies this style hook to an egui context.
+    pub fn apply(&self, ctx: &egui::Context) {
+        (self.apply)(ctx);
+    }
+}
+
 /// Shared state with editor services.
 ///
 /// Services are extensions of the editor. Notably, windows & menus.
@@ -378,6 +401,21 @@ impl EditorServices {
             + 'static,
     {
         self.add_menu(FnEditorMenu { descriptor, ui })
+    }
+
+    /// Replaces the style stack with one style hook.
+    pub fn set_style(&self, style: impl Into<EditorStyle>) {
+        self.state.lock().styles = vec![style.into()];
+    }
+
+    /// Adds a style hook to the style stack.
+    pub fn add_style(&self, style: impl Into<EditorStyle>) {
+        self.state.lock().styles.push(style.into());
+    }
+
+    /// Clears the configured editor style hooks.
+    pub fn clear_style(&self) {
+        self.state.lock().styles.clear();
     }
 
     /// Returns whether a registered window is currently open.
@@ -457,6 +495,11 @@ impl EditorServices {
         ctx: &egui::Context,
         context: &EditorRenderContext<'_>,
     ) -> anyhow::Result<()> {
+        let styles = self.state.lock().styles.clone();
+        for style in styles {
+            style.apply(ctx);
+        }
+
         self.state.lock().render(ctx, context)
     }
 }
@@ -471,6 +514,7 @@ struct EditorServicesState {
     windows: Vec<RegisteredWindow>,
     window_states: HashMap<EditorWindowId, WindowState>,
     menus: Vec<RegisteredMenu>,
+    styles: Vec<EditorStyle>,
 }
 
 impl EditorServicesState {
@@ -479,6 +523,7 @@ impl EditorServicesState {
             windows: Vec::new(),
             window_states: HashMap::new(),
             menus: Vec::new(),
+            styles: Vec::new(),
         }
     }
 

--- a/crates/dirk_engine/src/tests.rs
+++ b/crates/dirk_engine/src/tests.rs
@@ -478,7 +478,7 @@ mod editor_tests {
 
     use super::*;
     use crate::editor::{
-        EditorMenuDescriptor, EditorRenderContext, EditorServices, EditorSubsystem,
+        EditorMenuDescriptor, EditorRenderContext, EditorServices, EditorStyle, EditorSubsystem,
         EditorTickContext, EditorWindowDescriptor, EditorWindowInfo,
     };
 
@@ -726,6 +726,100 @@ mod editor_tests {
         render_services(&services, &universe)?;
 
         assert_eq!(*calls.lock(), vec!["first", "second", "third"]);
+        Ok(())
+    }
+
+    #[test]
+    fn editor_style_is_applied_before_registered_capabilities_render() -> anyhow::Result<()> {
+        let services = EditorServices::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed_window_fill = Arc::new(Mutex::new(None));
+        let styled_window_fill = egui::Color32::from_rgb(0x4a, 0x12, 0x7f);
+
+        {
+            let calls = Arc::clone(&calls);
+            services.set_style(EditorStyle::new(move |ctx| {
+                calls.fetch_add(1, Ordering::Relaxed);
+                ctx.style_mut(|style| {
+                    style.visuals.window_fill = styled_window_fill;
+                });
+            }));
+        }
+        {
+            let observed_window_fill = Arc::clone(&observed_window_fill);
+            services.add_window_fn(descriptor("styled", true), move |ui, _context| {
+                *observed_window_fill.lock() = Some(ui.visuals().window_fill);
+                Ok(())
+            });
+        }
+
+        let universe = Universe::builder().build();
+        render_services(&services, &universe)?;
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(*observed_window_fill.lock(), Some(styled_window_fill));
+        Ok(())
+    }
+
+    #[test]
+    fn editor_styles_stack_in_registration_order() -> anyhow::Result<()> {
+        let services = EditorServices::new();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let observed_window_fill = Arc::new(Mutex::new(None));
+        let first_window_fill = egui::Color32::from_rgb(0x10, 0x20, 0x30);
+        let second_window_fill = egui::Color32::from_rgb(0x40, 0x50, 0x60);
+
+        {
+            let calls = Arc::clone(&calls);
+            services.add_style(EditorStyle::new(move |ctx| {
+                calls.lock().push("first");
+                ctx.style_mut(|style| {
+                    style.visuals.window_fill = first_window_fill;
+                });
+            }));
+        }
+        {
+            let calls = Arc::clone(&calls);
+            services.add_style(EditorStyle::new(move |ctx| {
+                calls.lock().push("second");
+                ctx.style_mut(|style| {
+                    style.visuals.window_fill = second_window_fill;
+                });
+            }));
+        }
+        {
+            let observed_window_fill = Arc::clone(&observed_window_fill);
+            services.add_window_fn(descriptor("stacked", true), move |ui, _context| {
+                *observed_window_fill.lock() = Some(ui.visuals().window_fill);
+                Ok(())
+            });
+        }
+
+        let universe = Universe::builder().build();
+        render_services(&services, &universe)?;
+
+        assert_eq!(*calls.lock(), vec!["first", "second"]);
+        assert_eq!(*observed_window_fill.lock(), Some(second_window_fill));
+        Ok(())
+    }
+
+    #[test]
+    fn editor_style_can_be_cleared() -> anyhow::Result<()> {
+        let services = EditorServices::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        {
+            let calls = Arc::clone(&calls);
+            services.set_style(EditorStyle::new(move |_ctx| {
+                calls.fetch_add(1, Ordering::Relaxed);
+            }));
+        }
+        services.clear_style();
+
+        let universe = Universe::builder().build();
+        render_services(&services, &universe)?;
+
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Add an `EditorStyle` hook to `dirk_engine` so editor services can register, stack, replace, and clear style callbacks.
- Introduce a default dark `EditorPalette` and `default_editor_style()` in `dirk_editor` and apply it from the built-in editor subsystem.
- Expand tests to verify style application order, clearing behavior, and the default palette integration.