### PR TITLE
feat: player & world allocator

### DIFF
--- a/crates/dirk_universe/src/allocator.rs
+++ b/crates/dirk_universe/src/allocator.rs
@@ -1,0 +1,43 @@
+//! Allocates stable handles for worlds and entities.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, AtomicU64, Ordering},
+};
+
+use crate::{Entity, WorldId};
+
+/// Shared allocator for [`WorldId`] and [`Entity`] handles.
+///
+/// Cloning this type is cheap. Every clone points at the same counters, so
+/// handles allocated from any clone stay unique within that allocator.
+#[derive(Clone, Debug, Default)]
+pub struct Allocator {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    next_world: AtomicU32,
+    next_entity: AtomicU64,
+}
+
+impl Allocator {
+    /// Creates a new empty allocator.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocates a new [`WorldId`].
+    #[must_use]
+    pub fn allocate_world(&self) -> WorldId {
+        WorldId::new(self.inner.next_world.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Allocates a new [`Entity`].
+    #[must_use]
+    pub fn allocate_entity(&self) -> Entity {
+        Entity::new(self.inner.next_entity.fetch_add(1, Ordering::Relaxed))
+    }
+}

--- a/crates/dirk_universe/src/command_buffer.rs
+++ b/crates/dirk_universe/src/command_buffer.rs
@@ -1,20 +1,20 @@
 use std::any::TypeId;
 
 use crate::{
-    Entity, EntityBuilder, WorldBuilder, WorldId,
+    Allocator, Entity, EntityBuilder, WorldBuilder, WorldId,
     components::{AnyComponent, Component},
 };
 
 /// A buffer to record edits to the [`Universe`].
-#[derive(Default)]
 pub struct CommandBuffer {
     commands: Vec<Command>,
+    alloc: Allocator,
 }
 
 pub(crate) enum Command {
-    CreateWorld(WorldBuilder),
+    CreateWorld(WorldId, String),
     DestroyWorld(WorldId),
-    Spawn(WorldId, EntityBuilder),
+    Spawn(Entity, EntityBuilder, WorldId),
     Despawn(Entity),
     Send(Entity, WorldId),
     SetComponent(Entity, Box<dyn AnyComponent>),
@@ -24,9 +24,13 @@ pub(crate) enum Command {
 impl CommandBuffer {
     /// Creates a new empty command buffer
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub(crate) fn new(alloc: Allocator) -> Self {
+        Self {
+            commands: Vec::new(),
+            alloc,
+        }
     }
+
     pub(crate) fn commands(self) -> Vec<Command> {
         self.commands
     }
@@ -40,9 +44,16 @@ impl CommandBuffer {
     // WORLD MANAGEMENT
 
     /// Will create a new empty world & return its ID.
-    pub fn create_world(&mut self, builder: WorldBuilder) {
-        self.commands.push(Command::CreateWorld(builder));
+    pub fn create_world(&mut self, builder: WorldBuilder) -> WorldId {
+        let id = self.alloc.allocate_world();
+        self.commands.push(Command::CreateWorld(id, builder.name));
+
+        for entity in builder.entities {
+            self.spawn(id, entity);
+        }
+        id
     }
+
     /// Will destroy the world & call all its destruction systems.
     pub fn destroy_world(&mut self, world: WorldId) {
         self.commands.push(Command::DestroyWorld(world));
@@ -54,9 +65,12 @@ impl CommandBuffer {
     /// Returns the handle of the new [`Entity`].
     ///
     /// If None, then the [`World`] does not exist.
-    pub fn spawn(&mut self, world: WorldId, builder: EntityBuilder) {
-        self.commands.push(Command::Spawn(world, builder));
+    pub fn spawn(&mut self, world: WorldId, builder: EntityBuilder) -> Entity {
+        let entity = self.alloc.allocate_entity();
+        self.commands.push(Command::Spawn(entity, builder, world));
+        entity
     }
+
     /// Will despawn the provided [`Entity`].
     ///
     /// Calls [`ComponentSystem::removed`] for every component still attached

--- a/crates/dirk_universe/src/command_buffer.rs
+++ b/crates/dirk_universe/src/command_buffer.rs
@@ -64,7 +64,8 @@ impl CommandBuffer {
     /// Will spawn a new [`Entity`] using the provided [`EntityBuilder`].
     /// Returns the handle of the new [`Entity`].
     ///
-    /// If None, then the [`World`] does not exist.
+    /// If the [`World`] does not exist when this command is applied, the
+    /// returned handle will not become alive.
     pub fn spawn(&mut self, world: WorldId, builder: EntityBuilder) -> Entity {
         let entity = self.alloc.allocate_entity();
         self.commands.push(Command::Spawn(entity, builder, world));

--- a/crates/dirk_universe/src/entity.rs
+++ b/crates/dirk_universe/src/entity.rs
@@ -15,6 +15,11 @@ use crate::components::{AnyComponent, Component};
 pub struct Entity(u64);
 
 impl Entity {
+    #[must_use]
+    pub(crate) fn new(id: u64) -> Self {
+        Self(id)
+    }
+
     /// Returns an empty [`EntityBuilder`].
     #[must_use]
     pub fn builder() -> EntityBuilder {

--- a/crates/dirk_universe/src/lib.rs
+++ b/crates/dirk_universe/src/lib.rs
@@ -28,6 +28,8 @@ pub use entity::{Entity, EntityBuilder};
 mod world;
 pub use world::{World, WorldBuilder, WorldId};
 
+mod allocator;
+
 /// Read-only information about one component attached to an entity.
 pub struct ComponentInfo<'a> {
     /// Component [`TypeId`].

--- a/crates/dirk_universe/src/lib.rs
+++ b/crates/dirk_universe/src/lib.rs
@@ -169,6 +169,12 @@ impl Universe {
                         warn!("cannot add entity {entity:?} as it already exists");
                         continue;
                     }
+                    let Some(world_ref) = self.worlds.get_mut(&world) else {
+                        warn!(
+                            "cannot add entity {entity:?} to world {world:?} as the world does not exist"
+                        );
+                        continue;
+                    };
 
                     self.entities.insert(entity, world);
 
@@ -180,13 +186,7 @@ impl Universe {
                         added_components.insert((entity, type_id));
                     });
 
-                    if let Some(world) = self.worlds.get_mut(&world) {
-                        world.alive.insert(entity);
-                    } else {
-                        warn!(
-                            "cannot add entity {entity:?} to world {world:?} as the world does not exit"
-                        );
-                    }
+                    world_ref.alive.insert(entity);
                 }
                 Command::Despawn(entity) => {
                     if !self.is_alive(entity) {

--- a/crates/dirk_universe/src/lib.rs
+++ b/crates/dirk_universe/src/lib.rs
@@ -29,6 +29,7 @@ mod world;
 pub use world::{World, WorldBuilder, WorldId};
 
 mod allocator;
+use allocator::Allocator;
 
 /// Read-only information about one component attached to an entity.
 pub struct ComponentInfo<'a> {
@@ -43,10 +44,9 @@ pub struct ComponentInfo<'a> {
 /// This struct is the manager for all the worlds.
 pub struct Universe {
     worlds: HashMap<WorldId, World>,
-    next_world_id: WorldId,
-
     entities: HashMap<Entity, WorldId>,
-    next_entity_id: Entity,
+
+    allocator: Allocator,
 
     // this field starts with `universe`
     #[allow(clippy::struct_field_names)]
@@ -72,9 +72,8 @@ impl Universe {
     fn build(builder: UniverseBuilder) -> Self {
         let mut universe = Self {
             worlds: HashMap::new(),
-            next_world_id: WorldId::default(),
             entities: HashMap::new(),
-            next_entity_id: Entity::default(),
+            allocator: Allocator::new(),
             universe_systems: builder.universe_systems,
             ticking_systems: builder.ticking_systems,
             entity_systems: builder.entity_systems,
@@ -83,12 +82,18 @@ impl Universe {
             buffers: Vec::new(),
         };
 
-        let mut cmd = CommandBuffer::new();
+        let mut cmd = universe.command_buffer();
         for builder in builder.worlds {
             cmd.create_world(builder);
         }
         universe.submit_buffer(cmd);
         universe
+    }
+
+    /// Creates a new empty command buffer for this universe.
+    #[must_use]
+    pub fn command_buffer(&self) -> CommandBuffer {
+        CommandBuffer::new(self.allocator.clone())
     }
 
     /// Ticks every the entire [`Universe`].
@@ -99,7 +104,7 @@ impl Universe {
     /// was just created is not found in the [`Universe`].
     /// No panic should be caused by user error.
     pub fn tick(&mut self, delta_time: f64) {
-        let mut cmd = CommandBuffer::new();
+        let mut cmd = self.command_buffer();
 
         let buffers = std::mem::take(&mut self.buffers);
 
@@ -136,23 +141,13 @@ impl Universe {
 
         for command in commands {
             match command {
-                Command::CreateWorld(builder) => {
-                    let id = self.next_world_id;
-                    self.next_world_id += 1;
-
-                    let world = World::new(id, builder.name);
-                    self.worlds.insert(id, world);
-
-                    for builder in builder.entities {
-                        let entity = self.add_entity(id).expect("just created world");
-                        spawned_entities.insert(entity);
-
-                        builder.components.into_values().for_each(|component| {
-                            let type_id = component.component_type_id();
-                            self.components.insert_any(entity, component);
-                            added_components.insert((entity, type_id));
-                        });
+                Command::CreateWorld(id, name) => {
+                    if self.worlds.contains_key(&id) {
+                        warn!("cannot create world {id} as it already exists");
+                        continue;
                     }
+                    let world = World::new(id, name);
+                    self.worlds.insert(id, world);
 
                     created_worlds.insert(id);
                 }
@@ -169,11 +164,14 @@ impl Universe {
                     }
                     destroyed_worlds.insert(world.id());
                 }
-                Command::Spawn(world, builder) => {
-                    let Some(entity) = self.add_entity(world) else {
-                        warn!("cannot add entity to world {world} as it does not exist");
+                Command::Spawn(entity, builder, world) => {
+                    if self.is_alive(entity) {
+                        warn!("cannot add entity {entity:?} as it already exists");
                         continue;
-                    };
+                    }
+
+                    self.entities.insert(entity, world);
+
                     spawned_entities.insert(entity);
 
                     builder.components.into_values().for_each(|component| {
@@ -181,6 +179,14 @@ impl Universe {
                         self.components.insert_any(entity, component);
                         added_components.insert((entity, type_id));
                     });
+
+                    if let Some(world) = self.worlds.get_mut(&world) {
+                        world.alive.insert(entity);
+                    } else {
+                        warn!(
+                            "cannot add entity {entity:?} to world {world:?} as the world does not exit"
+                        );
+                    }
                 }
                 Command::Despawn(entity) => {
                     if !self.is_alive(entity) {
@@ -347,19 +353,6 @@ impl Universe {
         }
     }
 
-    /// Just adds an [`Entity`] to the `world` & returns its ID.
-    /// Returns `None` if the `world` does not exist.
-    fn add_entity(&mut self, world: WorldId) -> Option<Entity> {
-        let world = self.worlds.get_mut(&world)?;
-
-        let entity = self.next_entity_id;
-        self.next_entity_id += 1;
-        self.entities.insert(entity, world.id());
-
-        world.alive.insert(entity);
-        Some(entity)
-    }
-
     // COMMAND BUFFERS
 
     /// Will submit a buffer for execution.
@@ -443,41 +436,6 @@ impl Universe {
     #[must_use]
     pub fn component<C: Component>(&self, entity: Entity) -> Option<&C> {
         self.components.get(entity)
-    }
-
-    /// Will create a new [`World`] & return it [`WorldId`].
-    ///
-    /// The world creation runs immediately unlike when directly
-    /// submitting a [`CommandBuffer`].
-    pub fn create_world(&mut self, builder: WorldBuilder) -> Option<WorldId> {
-        let next_id = self.next_world_id;
-        let mut cmd = CommandBuffer::new();
-        self.run_commands(&mut cmd, vec![Command::CreateWorld(builder)]);
-        self.submit_buffer(cmd);
-        let new_next = self.next_world_id;
-
-        if next_id == new_next {
-            None
-        } else {
-            Some(next_id)
-        }
-    }
-
-    /// Will spawn a new [`Entity`] & return its ID.
-    ///
-    /// The spawning runs immediately unlike when directly submitting a [`CommandBuffer`].
-    pub fn spawn_entity(&mut self, world: WorldId, builder: EntityBuilder) -> Option<Entity> {
-        let next_id = self.next_entity_id;
-        let mut cmd = CommandBuffer::new();
-        self.run_commands(&mut cmd, vec![Command::Spawn(world, builder)]);
-        self.submit_buffer(cmd);
-        let new_next = self.next_entity_id;
-
-        if next_id == new_next {
-            None
-        } else {
-            Some(next_id)
-        }
     }
 }
 

--- a/crates/dirk_universe/src/lib.rs
+++ b/crates/dirk_universe/src/lib.rs
@@ -5,28 +5,27 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
 };
-
-use crate::{
-    command_buffer::Command,
-    components::{AnyComponent, Component, Components},
-    systems::{
-        ComponentSystem, ComponentSystemStorage, EntitySystem, EntitySystemStorage, TickingSystem,
-        TickingSystemStorage, UniverseSystem, UniverseSystemStorage,
-    },
-};
+use tracing::warn;
 
 pub mod components;
+use components::{AnyComponent, Component, Components};
+
 pub mod query;
+
 pub mod systems;
+use systems::{
+    ComponentSystem, ComponentSystemStorage, EntitySystem, EntitySystemStorage, TickingSystem,
+    TickingSystemStorage, UniverseSystem, UniverseSystemStorage,
+};
 
 mod command_buffer;
+use command_buffer::Command;
 pub use command_buffer::CommandBuffer;
 
 mod entity;
 pub use entity::{Entity, EntityBuilder};
 
 mod world;
-use tracing::warn;
 pub use world::{World, WorldBuilder, WorldId};
 
 /// Read-only information about one component attached to an entity.

--- a/crates/dirk_universe/src/tests.rs
+++ b/crates/dirk_universe/src/tests.rs
@@ -11,6 +11,17 @@ struct Health(u32);
 struct Mana(u32);
 
 #[test]
+fn allocator_clones_share_world_and_entity_sequences() {
+    let allocator = crate::Allocator::new();
+    let clone = allocator.clone();
+
+    assert_eq!(allocator.allocate_world().raw(), 0);
+    assert_eq!(clone.allocate_world().raw(), 1);
+    assert_eq!(allocator.allocate_entity().raw(), 0);
+    assert_eq!(clone.allocate_entity().raw(), 1);
+}
+
+#[test]
 fn builder_creates_worlds_and_initial_entities() {
     let mut universe = Universe::builder()
         .with_world(World::builder("alpha").with_entity(Entity::builder()))

--- a/crates/dirk_universe/src/tests.rs
+++ b/crates/dirk_universe/src/tests.rs
@@ -2,13 +2,21 @@
 
 use std::any::TypeId;
 
-use crate::{CommandBuffer, Entity, Universe, World, components::Component, query::Query};
+use crate::{Entity, EntityBuilder, Universe, World, WorldId, components::Component, query::Query};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Component)]
 struct Health(u32);
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Component)]
 struct Mana(u32);
+
+fn spawn_entity(universe: &mut Universe, world: WorldId, builder: EntityBuilder) -> Entity {
+    let mut command_buffer = universe.command_buffer();
+    let entity = command_buffer.spawn(world, builder);
+    universe.submit_buffer(command_buffer);
+    universe.tick(0.0);
+    entity
+}
 
 #[test]
 fn allocator_clones_share_world_and_entity_sequences() {
@@ -43,14 +51,14 @@ fn builder_creates_worlds_and_initial_entities() {
 }
 
 #[test]
-fn spawn_entity_in_missing_world_returns_none() {
+fn spawn_entity_in_missing_world_is_ignored() {
     let mut universe = Universe::builder().build();
     universe.tick(0.0);
     let missing = crate::WorldId::default() + 99;
 
-    let spawned = universe.spawn_entity(missing, Entity::builder());
+    let spawned = spawn_entity(&mut universe, missing, Entity::builder());
 
-    assert!(spawned.is_none());
+    assert!(!universe.is_alive(spawned));
     assert_eq!(universe.alive_count(), 0);
 }
 
@@ -65,17 +73,18 @@ fn query_filters_by_components_and_world_membership() {
     let world_a = crate::WorldId::default();
     let world_b = world_a + 1;
 
-    let e1 = universe
-        .spawn_entity(world_a, Entity::builder().with_component(Health(10)))
-        .expect("world exists");
-    let e2 = universe
-        .spawn_entity(
-            world_b,
-            Entity::builder()
-                .with_component(Health(20))
-                .with_component(Mana(5)),
-        )
-        .expect("world exists");
+    let e1 = spawn_entity(
+        &mut universe,
+        world_a,
+        Entity::builder().with_component(Health(10)),
+    );
+    let e2 = spawn_entity(
+        &mut universe,
+        world_b,
+        Entity::builder()
+            .with_component(Health(20))
+            .with_component(Mana(5)),
+    );
 
     let q = Query::empty()
         .with_component::<Health>()
@@ -93,9 +102,11 @@ fn component_getter_returns_expected_values() {
     universe.tick(0.0);
     let world = crate::WorldId::default();
 
-    let e = universe
-        .spawn_entity(world, Entity::builder().with_component(Health(123)))
-        .expect("world exists");
+    let e = spawn_entity(
+        &mut universe,
+        world,
+        Entity::builder().with_component(Health(123)),
+    );
 
     assert_eq!(universe.component::<Health>(e).map(|h| h.0), Some(123));
     assert_eq!(universe.component::<Mana>(e).map(|m| m.0), None);
@@ -131,12 +142,8 @@ fn entities_returns_live_entity_world_pairs() {
 
     let first_world = crate::WorldId::default();
     let second_world = first_world + 1;
-    let first = universe
-        .spawn_entity(first_world, Entity::builder())
-        .expect("world exists");
-    let second = universe
-        .spawn_entity(second_world, Entity::builder())
-        .expect("world exists");
+    let first = spawn_entity(&mut universe, first_world, Entity::builder());
+    let second = spawn_entity(&mut universe, second_world, Entity::builder());
 
     let mut entities: Vec<_> = universe
         .entities()
@@ -163,12 +170,8 @@ fn entities_in_world_filters_correctly() {
 
     let first_world = crate::WorldId::default();
     let second_world = first_world + 1;
-    let first = universe
-        .spawn_entity(first_world, Entity::builder())
-        .expect("world exists");
-    let _second = universe
-        .spawn_entity(second_world, Entity::builder())
-        .expect("world exists");
+    let first = spawn_entity(&mut universe, first_world, Entity::builder());
+    let _second = spawn_entity(&mut universe, second_world, Entity::builder());
 
     let entities: Vec<_> = universe
         .entities_in_world(first_world)
@@ -183,9 +186,11 @@ fn component_infos_exposes_type_name_and_debug_value() {
     let mut universe = Universe::builder().with_world(World::builder("w")).build();
     universe.tick(0.0);
     let world = crate::WorldId::default();
-    let entity = universe
-        .spawn_entity(world, Entity::builder().with_component(Health(77)))
-        .expect("world exists");
+    let entity = spawn_entity(
+        &mut universe,
+        world,
+        Entity::builder().with_component(Health(77)),
+    );
 
     let infos: Vec<_> = universe.component_infos(entity).collect();
 
@@ -205,14 +210,18 @@ fn inspection_helpers_update_after_despawn_and_world_destruction() {
 
     let first_world = crate::WorldId::default();
     let second_world = first_world + 1;
-    let despawned = universe
-        .spawn_entity(first_world, Entity::builder().with_component(Health(10)))
-        .expect("world exists");
-    let destroyed = universe
-        .spawn_entity(second_world, Entity::builder().with_component(Mana(20)))
-        .expect("world exists");
+    let despawned = spawn_entity(
+        &mut universe,
+        first_world,
+        Entity::builder().with_component(Health(10)),
+    );
+    let destroyed = spawn_entity(
+        &mut universe,
+        second_world,
+        Entity::builder().with_component(Mana(20)),
+    );
 
-    let mut command_buffer = CommandBuffer::new();
+    let mut command_buffer = universe.command_buffer();
     command_buffer.despawn(despawned);
     command_buffer.destroy_world(second_world);
     universe.submit_buffer(command_buffer);

--- a/crates/dirk_universe/src/world.rs
+++ b/crates/dirk_universe/src/world.rs
@@ -11,7 +11,12 @@ use crate::{Entity, EntityBuilder};
 pub struct WorldId(u32);
 
 impl WorldId {
-    /// Returns the raw entity ID
+    #[must_use]
+    pub(crate) fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw world ID.
     #[must_use]
     pub fn raw(self) -> u32 {
         self.0

--- a/crates/dirk_universe/tests/integration.rs
+++ b/crates/dirk_universe/tests/integration.rs
@@ -78,3 +78,29 @@ fn buffered_spawns_are_applied_on_tick_and_components_are_readable() {
     );
     assert_eq!(universe.component::<Hidden>(e1).map(|_| true), Some(true));
 }
+
+#[test]
+fn allocator_handles_can_be_used_in_command_buffers() {
+    let mut universe = Universe::builder().build();
+    let allocator = universe.allocator();
+    let world = allocator.allocate_world();
+    let entity = allocator.allocate_entity();
+
+    let mut cmd = dirk_universe::CommandBuffer::new();
+    cmd.create_allocated_world(world, World::builder("allocated"));
+    cmd.spawn_allocated(
+        world,
+        entity,
+        Entity::builder().with_component(Position(4, 8)),
+    );
+    universe.submit_buffer(cmd);
+
+    universe.tick(0.016);
+
+    assert_eq!(universe.world(world).map(World::name), Some("allocated"));
+    assert!(universe.is_in_world(world, entity));
+    assert_eq!(
+        universe.component::<Position>(entity).map(|p| (p.0, p.1)),
+        Some((4, 8))
+    );
+}

--- a/crates/dirk_universe/tests/integration.rs
+++ b/crates/dirk_universe/tests/integration.rs
@@ -1,12 +1,20 @@
 //! Integration tests for the `universe` crate.
 
-use dirk_universe::{Entity, Universe, World, components::Component};
+use dirk_universe::{Entity, EntityBuilder, Universe, World, WorldId, components::Component};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Component)]
 struct Position(i32, i32);
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Component)]
 struct Hidden;
+
+fn spawn_entity(universe: &mut Universe, world: WorldId, builder: EntityBuilder) -> Entity {
+    let mut cmd = universe.command_buffer();
+    let entity = cmd.spawn(world, builder);
+    universe.submit_buffer(cmd);
+    universe.tick(0.0);
+    entity
+}
 
 #[test]
 fn universe_public_api_supports_entity_lifecycle_across_worlds() {
@@ -19,15 +27,17 @@ fn universe_public_api_supports_entity_lifecycle_across_worlds() {
     let overworld = dirk_universe::WorldId::default();
     let dungeon = overworld + 1;
 
-    let entity = universe
-        .spawn_entity(overworld, Entity::builder().with_component(Position(2, 3)))
-        .expect("entity should spawn");
+    let entity = spawn_entity(
+        &mut universe,
+        overworld,
+        Entity::builder().with_component(Position(2, 3)),
+    );
 
     assert!(universe.is_alive(entity));
     assert!(universe.is_in_world(overworld, entity));
     assert_eq!(universe.get_world(entity), Some(overworld));
 
-    let mut cmd = dirk_universe::CommandBuffer::new();
+    let mut cmd = universe.command_buffer();
     cmd.send(entity, dungeon);
     universe.submit_buffer(cmd);
     universe.tick(0.016);
@@ -35,7 +45,7 @@ fn universe_public_api_supports_entity_lifecycle_across_worlds() {
     assert!(universe.is_in_world(dungeon, entity));
     assert_eq!(universe.get_world(entity), Some(dungeon));
 
-    let mut cmd = dirk_universe::CommandBuffer::new();
+    let mut cmd = universe.command_buffer();
     cmd.despawn(entity);
     universe.submit_buffer(cmd);
     universe.tick(0.016);
@@ -49,9 +59,9 @@ fn buffered_spawns_are_applied_on_tick_and_components_are_readable() {
     universe.tick(0.0);
     let world = dirk_universe::WorldId::default();
 
-    let mut cmd = dirk_universe::CommandBuffer::new();
-    cmd.spawn(world, Entity::builder().with_component(Position(1, 1)));
-    cmd.spawn(
+    let mut cmd = universe.command_buffer();
+    let e0 = cmd.spawn(world, Entity::builder().with_component(Position(1, 1)));
+    let e1 = cmd.spawn(
         world,
         Entity::builder()
             .with_component(Position(9, 9))
@@ -62,9 +72,6 @@ fn buffered_spawns_are_applied_on_tick_and_components_are_readable() {
     universe.tick(0.016);
 
     assert_eq!(universe.alive_count(), 2);
-
-    let e0 = Entity::default();
-    let e1 = e0 + 1;
 
     assert_eq!(
         universe.component::<Position>(e0).map(|p| (p.0, p.1)),
@@ -80,27 +87,46 @@ fn buffered_spawns_are_applied_on_tick_and_components_are_readable() {
 }
 
 #[test]
-fn allocator_handles_can_be_used_in_command_buffers() {
+fn public_command_buffers_allocate_unique_handles() {
     let mut universe = Universe::builder().build();
-    let allocator = universe.allocator();
-    let world = allocator.allocate_world();
-    let entity = allocator.allocate_entity();
 
-    let mut cmd = dirk_universe::CommandBuffer::new();
-    cmd.create_allocated_world(world, World::builder("allocated"));
-    cmd.spawn_allocated(
-        world,
-        entity,
+    let mut first_cmd = universe.command_buffer();
+    let first_world = first_cmd.create_world(World::builder("first"));
+    let first_entity = first_cmd.spawn(
+        first_world,
         Entity::builder().with_component(Position(4, 8)),
     );
-    universe.submit_buffer(cmd);
 
+    let mut second_cmd = universe.command_buffer();
+    let second_world = second_cmd.create_world(World::builder("second"));
+    let second_entity = second_cmd.spawn(
+        second_world,
+        Entity::builder().with_component(Position(16, 32)),
+    );
+
+    universe.submit_buffer(first_cmd);
+    universe.submit_buffer(second_cmd);
     universe.tick(0.016);
 
-    assert_eq!(universe.world(world).map(World::name), Some("allocated"));
-    assert!(universe.is_in_world(world, entity));
+    assert_ne!(first_world, second_world);
+    assert_ne!(first_entity, second_entity);
+    assert_eq!(universe.world(first_world).map(World::name), Some("first"));
     assert_eq!(
-        universe.component::<Position>(entity).map(|p| (p.0, p.1)),
+        universe.world(second_world).map(World::name),
+        Some("second")
+    );
+    assert!(universe.is_in_world(first_world, first_entity));
+    assert!(universe.is_in_world(second_world, second_entity));
+    assert_eq!(
+        universe
+            .component::<Position>(first_entity)
+            .map(|p| (p.0, p.1)),
         Some((4, 8))
+    );
+    assert_eq!(
+        universe
+            .component::<Position>(second_entity)
+            .map(|p| (p.0, p.1)),
+        Some((16, 32))
     );
 }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -2,9 +2,8 @@
 
 use std::f32::consts::PI;
 
-use anyhow::Context;
 use dirk_engine::{EngineHandle, EnginePlugin, Subsystem};
-use dirk_universe::{Entity, Universe, World};
+use dirk_universe::{CommandBuffer, Entity, Universe, World};
 
 /// An [`EnginePlugin`] with a basic demo world.
 pub struct DemoPlugin;
@@ -44,10 +43,12 @@ impl Subsystem for Demo {
             return Ok(());
         }
 
-        let world_id = create_test_world(universe).context("create test world")?;
+        let mut cmd = universe.command_buffer();
+
+        let world_id = create_test_world(&mut cmd);
         let player = self.players.new_player();
 
-        universe.spawn_entity(
+        cmd.spawn(
             world_id,
             Entity::builder().with_component(player).with_component(
                 dirk_world::components::Transform {
@@ -58,12 +59,14 @@ impl Subsystem for Demo {
             ),
         );
 
+        universe.submit_buffer(cmd);
+
         self.started = true;
         Ok(())
     }
 }
 
-fn create_test_world(universe: &mut Universe) -> anyhow::Result<dirk_universe::WorldId> {
+fn create_test_world(cmd: &mut CommandBuffer) -> dirk_universe::WorldId {
     use dirk_world::components::{Renderable, Transform};
 
     let duck_model = dirk_assets::AssetHandle::from_raw(
@@ -95,7 +98,5 @@ fn create_test_world(universe: &mut Universe) -> anyhow::Result<dirk_universe::W
         .with_entity(shrek_builder)
         .with_entity(duck_builder);
 
-    universe
-        .create_world(world_builder)
-        .context("world creation returned no id")
+    cmd.create_world(world_builder)
 }


### PR DESCRIPTION
## Summary
- Introduce a shared atomic allocator for `WorldId` and `Entity` handles so buffered commands can reserve unique IDs up front.
- Update `CommandBuffer` and `Universe` to create worlds and spawn entities with preallocated handles, including support for spawning initial entities when a world is created.
- Remove the immediate `Universe::create_world` and `Universe::spawn_entity` APIs in favor of buffered command submission, and update the demo and tests to use the new flow.

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --workspace`
- Added and updated unit/integration coverage for allocator behavior, buffered world/entity creation, and lifecycle handling across worlds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Core Infrastructure

### New Allocator Module (`allocator.rs`)
A new shared atomic allocator has been introduced to manage globally-unique handle allocation for both `WorldId` and `Entity`. The `Allocator` type uses an `Arc<Inner>` wrapper to share state across clones, with atomic counters (`next_world: AtomicU32`, `next_entity: AtomicU64`) for each handle type. The `allocate_world()` and `allocate_entity()` methods use `fetch_add` with relaxed atomic ordering to generate new IDs deterministically and safely in concurrent contexts.

### Entity and World ID Constructors
- **Entity**: Added `pub(crate) fn new(id: u64) -> Self` to construct entity instances from raw ID values
- **WorldId**: Added `pub(crate) fn new(id: u32) -> Self` to construct world instances from raw ID values, replacing documentation that incorrectly referenced entity IDs

## CommandBuffer Architecture

The `CommandBuffer` has been fundamentally refactored to integrate with the allocator and support preallocated handles:

- **Allocator integration**: `CommandBuffer` now owns an `Allocator` instance and is constructed via `new(alloc: Allocator)` instead of using the `Default` trait
- **Return values**: Both `create_world()` and `spawn()` now return allocated IDs (`WorldId` and `Entity` respectively) rather than only enqueueing commands
- **ID preallocaton**: IDs are allocated upfront during command recording, enabling predictable handle assignment
- **Command payload changes**:
  - `CreateWorld` now carries `(WorldId, String)` instead of a `WorldBuilder`
  - `Spawn` now carries `(Entity, EntityBuilder, WorldId)` instead of `(WorldId, EntityBuilder)`
- **Visibility change**: The `commands()` method visibility was reduced from `pub` to `pub(crate)`

## Universe API Refactoring

The `Universe` type has undergone significant API changes to embrace command-driven entity and world creation:

- **Removed immediate-execution APIs**:
  - `pub fn create_world(&mut self, builder: WorldBuilder) -> Option<WorldId>` — eliminated in favor of buffered commands
  - `pub fn spawn_entity(&mut self, world: WorldId, builder: EntityBuilder) -> Option<Entity>` — eliminated in favor of buffered commands
- **Allocator ownership**: `Universe` now owns and manages an `Allocator` instance
- **Internal state refactoring**: Removed internal `next_world_id` and `next_entity_id` fields, replacing them with the allocator
- **Command processing updates**: The `run_commands()` method now:
  - Accepts pre-allocated world and entity IDs from commands
  - No longer allocates IDs internally; allocation responsibility lies entirely with the allocator
  - Includes validation checks for entity aliveness and world existence before spawning
  - Updates both the universe's `entities` map and target world's `alive` set directly
- **Removed helper**: The private `add_entity` helper method was deleted

## Testing Infrastructure

### Unit Tests (`tests.rs`)
Tests have been refactored to use a new `spawn_entity` helper that coordinates command buffer creation, entity spawning, buffer submission, and universe tick. Key changes include:

- Replaced direct `universe.spawn_entity()` calls with the new helper
- Updated assertions for missing-world scenarios: now checks entity aliveness with `!universe.is_alive(entity)` rather than expecting `Option::None`
- Standardized command buffer construction through `universe.command_buffer()` instead of manual `CommandBuffer::new()`
- Preserved all component inspection, query matching, and despawn/world-destruction test coverage

### Integration Tests (`integration.rs`)
Integration tests have been updated to validate the allocator-driven API:

- Updated `universe_public_api_supports_entity_lifecycle_across_worlds` to use the command buffer helper for entity spawning and buffered operations
- Updated `buffered_spawns_are_applied_on_tick_and_components_are_readable` to obtain command buffers via `universe.command_buffer()` and verify component readability post-tick
- Added new test `public_command_buffers_allocate_unique_handles` to verify that separate command buffers allocate distinct world/entity handles, preserve world names, and maintain correct entity-world membership with proper component values

## Application Code

### Demo Application (`demo.rs`)
The demo setup has been converted from immediate universe mutations to buffered command operations:

- Updated `create_test_world` to accept a mutable `CommandBuffer` reference and use `cmd.create_world()` instead of direct `Universe::create_world()` calls
- Modified `Demo::start` to:
  - Allocate a command buffer via `universe.command_buffer()`
  - Create the test world through the buffer
  - Spawn entities through the buffer's `spawn()` method
  - Submit the buffered commands via `universe.submit_buffer(cmd)`
- Removed the `anyhow::Context` import as error handling changed

## Summary of Behavioral Changes

The PR fundamentally shifts the entity and world creation model from synchronous, immediate operations returning `Option` results to an asynchronous, buffered command pattern where:

1. **IDs are preallocated**: Callers receive handles immediately when queuing creation commands
2. **Operations are deferred**: Actual world and entity instantiation occurs during `run_commands()` when the universe is ticked
3. **Allocation is deterministic**: A shared allocator ensures consistent, globally-unique ID assignment across command buffers
4. **Errors are implicit**: The absence of `Option` return types for immediate operations means validation (entity aliveness, world existence) occurs at execution time, not command recording time

<!-- end of auto-generated comment: release notes by coderabbit.ai -->