### PR TITLE
feat: Move Universe out of Subsystems & introduce UniverseHandle in its stead

### DIFF
--- a/crates/dirk_assets/src/lib.rs
+++ b/crates/dirk_assets/src/lib.rs
@@ -65,12 +65,7 @@ impl Subsystem for AssetsSubsystem {
         "assets"
     }
 
-    fn tick(
-        &mut self,
-        _delta_time: f64,
-        _handle: &EngineHandle,
-        _universe: &mut dirk_universe::Universe,
-    ) -> anyhow::Result<()> {
+    fn tick(&mut self, _delta_time: f64, _handle: &EngineHandle) -> anyhow::Result<()> {
         self.registry.tick();
         Ok(())
     }

--- a/crates/dirk_assets/src/lib.rs
+++ b/crates/dirk_assets/src/lib.rs
@@ -4,6 +4,7 @@
 mod tests;
 
 mod errors;
+use dirk_universe::Universe;
 pub use errors::{Error, Result};
 
 mod events;
@@ -65,7 +66,12 @@ impl Subsystem for AssetsSubsystem {
         "assets"
     }
 
-    fn tick(&mut self, _delta_time: f64, _handle: &EngineHandle) -> anyhow::Result<()> {
+    fn tick(
+        &mut self,
+        _delta_time: f64,
+        _handle: &EngineHandle,
+        _universe: &Universe,
+    ) -> anyhow::Result<()> {
         self.registry.tick();
         Ok(())
     }

--- a/crates/dirk_editor/src/lib.rs
+++ b/crates/dirk_editor/src/lib.rs
@@ -4,10 +4,13 @@
 
 use std::collections::BTreeMap;
 
-use dirk_engine::editor::{
-    EDITOR_CATEGORY, EditorMenu, EditorMenuContext, EditorMenuDescriptor, EditorServices,
-    EditorUiContext, EditorWindow, EditorWindowDescriptor, EditorWindowId, EditorWindowInfo,
-    UNIVERSE_CATEGORY,
+use dirk_engine::{
+    EngineHandle,
+    editor::{
+        EDITOR_CATEGORY, EditorMenu, EditorMenuContext, EditorMenuDescriptor, EditorServices,
+        EditorUiContext, EditorWindow, EditorWindowDescriptor, EditorWindowId, EditorWindowInfo,
+        UNIVERSE_CATEGORY,
+    },
 };
 
 mod settings;
@@ -39,11 +42,7 @@ impl dirk_engine::editor::EditorSubsystem for BuiltinEditorSubsystem {
         "builtin-editor"
     }
 
-    fn start(
-        &mut self,
-        context: &mut dirk_engine::editor::EditorStartContext<'_>,
-    ) -> anyhow::Result<()> {
-        let services = context.editor;
+    fn start(&mut self, _engine: &EngineHandle, services: &EditorServices) -> anyhow::Result<()> {
         services.add_style(style::default_editor_style());
         services.add_menu(MainMenu);
 

--- a/crates/dirk_editor/src/tests.rs
+++ b/crates/dirk_editor/src/tests.rs
@@ -89,13 +89,8 @@ fn builtin_editor_subsystem_registers_expected_default_capabilities() -> anyhow:
     let handle = test_handle();
     let universe = dirk_universe::Universe::builder().build();
     let mut subsystem = crate::BuiltinEditorSubsystem;
-    let mut context = dirk_engine::editor::EditorStartContext {
-        engine: &handle,
-        universe: &universe,
-        editor: &services,
-    };
 
-    subsystem.start(&mut context)?;
+    subsystem.start(&handle, &services)?;
 
     assert_eq!(services.menu_titles(), vec!["Main", "Settings", "Windows"]);
     assert_eq!(
@@ -113,8 +108,8 @@ fn builtin_editor_subsystem_registers_expected_default_capabilities() -> anyhow:
     let ctx = egui::Context::default();
     begin_egui_pass(&ctx);
 
-    let frame = dirk_engine::editor::EditorRenderContext::new(0.016, &handle, &universe);
-    services.render_ui(&ctx, &frame)?;
+    let frame = dirk_engine::editor::EditorRenderContext::new(0.016, &handle);
+    services.render_ui(&ctx, &frame, &universe)?;
 
     let palette = EditorPalette::default();
     let style = ctx.style();

--- a/crates/dirk_editor/src/universe.rs
+++ b/crates/dirk_editor/src/universe.rs
@@ -22,7 +22,9 @@ pub fn register_capabilities(services: &EditorServices) {
                 show_in_list: true,
             },
             move |ui, context| {
-                universe_windows.lock().world_list_ui(ui, context.universe);
+                universe_windows
+                    .lock()
+                    .world_list_ui(ui, context.universe());
                 Ok(())
             },
         );
@@ -39,7 +41,9 @@ pub fn register_capabilities(services: &EditorServices) {
                 show_in_list: true,
             },
             move |ui, context| {
-                let entity_clicked = universe_windows.lock().entity_list_ui(ui, context.universe);
+                let entity_clicked = universe_windows
+                    .lock()
+                    .entity_list_ui(ui, context.universe());
                 if entity_clicked && let Some(entity_details) = *entity_details_window.lock() {
                     context.open_window(entity_details);
                 }
@@ -58,7 +62,7 @@ pub fn register_capabilities(services: &EditorServices) {
         move |ui, context| {
             universe_windows
                 .lock()
-                .entity_details_ui(ui, context.universe);
+                .entity_details_ui(ui, context.universe());
             Ok(())
         },
     );

--- a/crates/dirk_engine/src/builder.rs
+++ b/crates/dirk_engine/src/builder.rs
@@ -250,6 +250,7 @@ impl EngineBuilder {
             handle: handle.clone(),
             builder: Universe::builder(),
         };
+        context.add_resource(context.builder.handle())?;
 
         #[cfg(feature = "editor")]
         let editor_services = {

--- a/crates/dirk_engine/src/editor.rs
+++ b/crates/dirk_engine/src/editor.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use anyhow::Context as _;
+use dirk_universe::Universe;
 use egui_dock::{
     DockArea, DockState, NodeIndex, Split, SurfaceIndex, TabViewer, tab_viewer::OnCloseResponse,
 };
@@ -106,6 +107,8 @@ pub struct EditorUiContext<'a> {
     commands: EditorCommandSender,
     /// Shared engine handle.
     pub handle: &'a EngineHandle,
+    /// The Universe
+    universe: &'a Universe,
 }
 
 impl EditorUiContext<'_> {
@@ -118,6 +121,12 @@ impl EditorUiContext<'_> {
     /// Requests that an editor window be opened.
     pub fn open_window(&self, id: EditorWindowId) {
         self.commands.open_window(id);
+    }
+
+    /// Returns an immutable reference to the [`Universe`].
+    #[must_use]
+    pub fn universe(&self) -> &Universe {
+        self.universe
     }
 
     /// Returns the editor command sender for this UI pass.
@@ -479,13 +488,14 @@ impl EditorServices {
         &self,
         ctx: &egui::Context,
         context: &EditorRenderContext<'_>,
+        universe: &Universe,
     ) -> anyhow::Result<()> {
         let styles = self.state.lock().styles.clone();
         for style in styles {
             style.apply(ctx);
         }
 
-        self.state.lock().render(ctx, context)
+        self.state.lock().render(ctx, context, universe)
     }
 }
 
@@ -520,13 +530,14 @@ impl EditorServicesState {
         &mut self,
         ctx: &egui::Context,
         context: &EditorRenderContext<'_>,
+        universe: &Universe,
     ) -> anyhow::Result<()> {
         let (editor_commands, command_receiver) = mpsc::channel();
         let editor_commands = EditorCommandSender::new(editor_commands);
 
-        self.render_menus(ctx, context, &editor_commands)?;
+        self.render_menus(ctx, context, &editor_commands, universe)?;
         self.apply_commands(command_receiver.try_iter());
-        self.render_windows(ctx, context, &editor_commands)?;
+        self.render_windows(ctx, context, &editor_commands, universe)?;
         self.apply_commands(command_receiver.try_iter());
         Ok(())
     }
@@ -536,6 +547,7 @@ impl EditorServicesState {
         ctx: &egui::Context,
         context: &EditorRenderContext<'_>,
         editor_commands: &EditorCommandSender,
+        universe: &Universe,
     ) -> anyhow::Result<()> {
         if self.menus.is_empty() {
             return Ok(());
@@ -547,6 +559,7 @@ impl EditorServicesState {
             delta_time: context.delta_time(),
             commands: (*editor_commands).clone(),
             handle: context.handle,
+            universe,
         };
 
         let mut result = Ok(());
@@ -573,6 +586,7 @@ impl EditorServicesState {
         ctx: &egui::Context,
         context: &EditorRenderContext<'_>,
         editor_commands: &EditorCommandSender,
+        universe: &Universe,
     ) -> anyhow::Result<()> {
         self.bootstrap_default_dock_layout();
         self.sync_dock_tabs_with_open_windows();
@@ -582,6 +596,7 @@ impl EditorServicesState {
             delta_time: context.delta_time(),
             commands: (*editor_commands).clone(),
             handle: context.handle,
+            universe,
         };
         let mut tab_viewer = EditorDockTabViewer {
             windows: &mut self.windows,

--- a/crates/dirk_engine/src/editor.rs
+++ b/crates/dirk_engine/src/editor.rs
@@ -41,7 +41,7 @@ pub trait EditorSubsystem: Send + 'static {
     /// # Errors
     ///
     /// Returns an error if startup fails.
-    fn start(&mut self, _context: &mut EditorStartContext<'_>) -> anyhow::Result<()> {
+    fn start(&mut self, _engine: &EngineHandle, _editor: &EditorServices) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -50,7 +50,12 @@ pub trait EditorSubsystem: Send + 'static {
     /// # Errors
     ///
     /// Returns an error if ticking fails.
-    fn tick(&mut self, _context: &mut EditorTickContext<'_>) -> anyhow::Result<()> {
+    fn tick(
+        &mut self,
+        _engine: &EngineHandle,
+        _editor: &EditorServices,
+        _delta_time: f64,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -59,7 +64,7 @@ pub trait EditorSubsystem: Send + 'static {
     /// # Errors
     ///
     /// Returns an error if shutdown fails.
-    fn shutdown(&mut self, _context: &mut EditorShutdownContext<'_>) -> anyhow::Result<()> {
+    fn shutdown(&mut self, _engine: &EngineHandle, _editor: &EditorServices) -> anyhow::Result<()> {
         Ok(())
     }
 }
@@ -72,69 +77,19 @@ pub struct EditorBuildContext<'a> {
     pub editor: &'a EditorServices,
 }
 
-/// Context passed to editor subsystem startup.
-pub struct EditorStartContext<'a> {
-    /// Shared engine handle.
-    pub engine: &'a EngineHandle,
-    /// Read-only ECS universe.
-    pub universe: &'a dirk_universe::Universe,
-    /// Shared editor services.
-    pub editor: &'a EditorServices,
-}
-
-/// Context passed to editor subsystem ticks.
-pub struct EditorTickContext<'a> {
-    /// Seconds elapsed since the previous engine tick.
-    delta_time: f64,
-    /// Shared engine handle.
-    pub engine: &'a EngineHandle,
-    /// Read-only ECS universe.
-    pub universe: &'a dirk_universe::Universe,
-    /// Shared editor services.
-    pub editor: &'a EditorServices,
-}
-
-impl EditorTickContext<'_> {
-    /// Returns the seconds elapsed since the previous engine tick.
-    #[must_use]
-    pub fn delta_time(&self) -> f64 {
-        self.delta_time
-    }
-}
-
-/// Context passed to editor subsystem shutdown.
-pub struct EditorShutdownContext<'a> {
-    /// Shared engine handle.
-    pub engine: &'a EngineHandle,
-    /// Read-only ECS universe.
-    pub universe: &'a dirk_universe::Universe,
-    /// Shared editor services.
-    pub editor: &'a EditorServices,
-}
-
 /// Per-frame context passed to editor rendering.
 pub struct EditorRenderContext<'a> {
     /// Seconds elapsed since the previous engine tick.
     delta_time: f64,
     /// Shared engine handle.
     pub handle: &'a EngineHandle,
-    /// Read-only ECS universe.
-    pub universe: &'a dirk_universe::Universe,
 }
 
 impl<'a> EditorRenderContext<'a> {
     /// Creates a context for rendering editor UI.
     #[must_use]
-    pub fn new(
-        delta_time: f64,
-        handle: &'a EngineHandle,
-        universe: &'a dirk_universe::Universe,
-    ) -> Self {
-        Self {
-            delta_time,
-            handle,
-            universe,
-        }
+    pub fn new(delta_time: f64, handle: &'a EngineHandle) -> Self {
+        Self { delta_time, handle }
     }
 
     /// Returns the seconds elapsed since the previous engine tick.
@@ -151,8 +106,6 @@ pub struct EditorUiContext<'a> {
     commands: EditorCommandSender,
     /// Shared engine handle.
     pub handle: &'a EngineHandle,
-    /// Read-only ECS universe.
-    pub universe: &'a dirk_universe::Universe,
 }
 
 impl EditorUiContext<'_> {
@@ -594,7 +547,6 @@ impl EditorServicesState {
             delta_time: context.delta_time(),
             commands: (*editor_commands).clone(),
             handle: context.handle,
-            universe: context.universe,
         };
 
         let mut result = Ok(());
@@ -630,7 +582,6 @@ impl EditorServicesState {
             delta_time: context.delta_time(),
             commands: (*editor_commands).clone(),
             handle: context.handle,
-            universe: context.universe,
         };
         let mut tab_viewer = EditorDockTabViewer {
             windows: &mut self.windows,
@@ -933,61 +884,32 @@ impl EditorRuntime {
         }
     }
 
-    pub(crate) fn start(
-        &mut self,
-        engine: &EngineHandle,
-        universe: &dirk_universe::Universe,
-    ) -> Result<()> {
+    pub(crate) fn start(&mut self, engine: &EngineHandle) -> Result<()> {
         for subsystem in &mut self.subsystems {
             let name = subsystem.name();
-            let mut context = EditorStartContext {
-                engine,
-                universe,
-                editor: &self.services,
-            };
             subsystem
-                .start(&mut context)
+                .start(engine, &self.services)
                 .map_err(|source| Error::EditorSubsystemFailedStart { name, source })?;
         }
         self.services.state.lock().bootstrap_default_dock_layout();
         Ok(())
     }
 
-    pub(crate) fn tick(
-        &mut self,
-        delta_time: f64,
-        engine: &EngineHandle,
-        universe: &dirk_universe::Universe,
-    ) -> crate::Result<()> {
+    pub(crate) fn tick(&mut self, delta_time: f64, engine: &EngineHandle) -> crate::Result<()> {
         for subsystem in &mut self.subsystems {
             let name = subsystem.name();
-            let mut context = EditorTickContext {
-                delta_time,
-                engine,
-                universe,
-                editor: &self.services,
-            };
             subsystem
-                .tick(&mut context)
+                .tick(engine, &self.services, delta_time)
                 .map_err(|source| Error::EditorSubsystemFailedTick { name, source })?;
         }
         Ok(())
     }
 
-    pub(crate) fn shutdown(
-        &mut self,
-        engine: &EngineHandle,
-        universe: &dirk_universe::Universe,
-    ) -> crate::Result<()> {
+    pub(crate) fn shutdown(&mut self, engine: &EngineHandle) -> crate::Result<()> {
         while let Some(mut subsystem) = self.subsystems.pop() {
             let name = subsystem.name();
-            let mut context = EditorShutdownContext {
-                engine,
-                universe,
-                editor: &self.services,
-            };
             subsystem
-                .shutdown(&mut context)
+                .shutdown(engine, &self.services)
                 .map_err(|source| Error::EditorSubsystemFailedShutdown { name, source })?;
         }
         Ok(())

--- a/crates/dirk_engine/src/editor/tests.rs
+++ b/crates/dirk_engine/src/editor/tests.rs
@@ -10,9 +10,8 @@ use crate::{
     EngineBuilder,
     editor::{
         EDITOR_CATEGORY, EditorMenuDescriptor, EditorRenderContext, EditorRuntime, EditorServices,
-        EditorServicesState, EditorStyle, EditorSubsystem, EditorTickContext,
-        EditorWindowDescriptor, EditorWindowId, EditorWindowInfo, UNIVERSE_CATEGORY,
-        commands::EditorCommand,
+        EditorServicesState, EditorStyle, EditorSubsystem, EditorWindowDescriptor, EditorWindowId,
+        EditorWindowInfo, UNIVERSE_CATEGORY, commands::EditorCommand,
     },
     errors::{Error, Result},
     tests::build_context,
@@ -62,8 +61,11 @@ impl EditorServices {
         title: &str,
         ui: &mut egui::Ui,
         context: &EditorRenderContext<'_>,
+        universe: &Universe,
     ) -> anyhow::Result<()> {
-        self.state.lock().render_menu_for_tests(title, ui, context)
+        self.state
+            .lock()
+            .render_menu_for_tests(title, ui, context, universe)
     }
 }
 
@@ -74,6 +76,7 @@ impl EditorServicesState {
         title: &str,
         ui: &mut egui::Ui,
         context: &EditorRenderContext<'_>,
+        universe: &Universe,
     ) -> anyhow::Result<()> {
         use std::sync::mpsc;
 
@@ -89,7 +92,7 @@ impl EditorServicesState {
             delta_time: context.delta_time(),
             commands: editor_commands,
             handle: context.handle,
-            universe: context.universe,
+            universe,
         };
 
         let Some(menu) = self.menus.iter_mut().find(|menu| menu.title == title) else {
@@ -159,20 +162,27 @@ impl EditorSubsystem for FirstEditorSubsystem {
 
     fn start(
         &mut self,
-        _context: &mut crate::editor::EditorStartContext<'_>,
+        _engine: &crate::EngineHandle,
+        _editor: &EditorServices,
     ) -> anyhow::Result<()> {
         self.events.lock().push("first-start");
         Ok(())
     }
 
-    fn tick(&mut self, _context: &mut EditorTickContext<'_>) -> anyhow::Result<()> {
+    fn tick(
+        &mut self,
+        _engine: &crate::EngineHandle,
+        _editor: &EditorServices,
+        _delta_time: f64,
+    ) -> anyhow::Result<()> {
         self.events.lock().push("first-tick");
         Ok(())
     }
 
     fn shutdown(
         &mut self,
-        _context: &mut crate::editor::EditorShutdownContext<'_>,
+        _engine: &crate::EngineHandle,
+        _editor: &EditorServices,
     ) -> anyhow::Result<()> {
         self.events.lock().push("first-shutdown");
         Ok(())
@@ -190,20 +200,27 @@ impl EditorSubsystem for SecondEditorSubsystem {
 
     fn start(
         &mut self,
-        _context: &mut crate::editor::EditorStartContext<'_>,
+        _engine: &crate::EngineHandle,
+        _editor: &EditorServices,
     ) -> anyhow::Result<()> {
         self.events.lock().push("second-start");
         Ok(())
     }
 
-    fn tick(&mut self, _context: &mut EditorTickContext<'_>) -> anyhow::Result<()> {
+    fn tick(
+        &mut self,
+        _engine: &crate::EngineHandle,
+        _editor: &EditorServices,
+        _delta_time: f64,
+    ) -> anyhow::Result<()> {
         self.events.lock().push("second-tick");
         Ok(())
     }
 
     fn shutdown(
         &mut self,
-        _context: &mut crate::editor::EditorShutdownContext<'_>,
+        _engine: &crate::EngineHandle,
+        _editor: &EditorServices,
     ) -> anyhow::Result<()> {
         self.events.lock().push("second-shutdown");
         Ok(())
@@ -227,7 +244,8 @@ impl EditorSubsystem for StartFailingEditorSubsystem {
 
     fn start(
         &mut self,
-        _context: &mut crate::editor::EditorStartContext<'_>,
+        _engine: &crate::EngineHandle,
+        _editor: &EditorServices,
     ) -> anyhow::Result<()> {
         Err(anyhow::anyhow!("editor start failed"))
     }
@@ -242,8 +260,8 @@ fn render_services_with_input(
     ctx.begin_pass(raw_input);
 
     let handle = build_context().handle().clone();
-    let frame = EditorRenderContext::new(0.016, &handle, universe);
-    let result = services.render_ui(&ctx, &frame);
+    let frame = EditorRenderContext::new(0.016, &handle);
+    let result = services.render_ui(&ctx, &frame, universe);
     let _ = ctx.end_pass();
     result
 }
@@ -723,10 +741,10 @@ fn menu_commands_still_open_windows() -> anyhow::Result<()> {
         ..egui::RawInput::default()
     });
     let handle = build_context().handle().clone();
-    let frame = EditorRenderContext::new(0.016, &handle, &universe);
+    let frame = EditorRenderContext::new(0.016, &handle);
     let mut result = Ok(());
     egui::CentralPanel::default().show(&ctx, |ui| {
-        result = services.render_menu_for_tests("Open", ui, &frame);
+        result = services.render_menu_for_tests("Open", ui, &frame, &universe);
     });
     let _ = ctx.end_pass();
     result?;

--- a/crates/dirk_engine/src/lib.rs
+++ b/crates/dirk_engine/src/lib.rs
@@ -202,7 +202,7 @@ impl Engine {
 
         for subsystem in &mut self.subsystems {
             subsystem
-                .start(&self.handle, &mut self.universe)
+                .start(&self.handle)
                 .map_err(|source| Error::SubsystemFailedStart {
                     name: subsystem.name(),
                     source,
@@ -210,7 +210,7 @@ impl Engine {
         }
 
         #[cfg(feature = "editor")]
-        self.editor.start(&self.handle, &self.universe)?;
+        self.editor.start(&self.handle)?;
 
         self.last_tick = Instant::now();
         self.started = true;
@@ -269,7 +269,7 @@ impl Engine {
             let subsystem = &mut self.subsystems[index];
             let name = subsystem.name();
             subsystem
-                .tick(delta_time, &self.handle, &mut self.universe)
+                .tick(delta_time, &self.handle)
                 .map_err(|source| Error::SubsystemFailedTick { name, source })?;
 
             self.process_commands();
@@ -279,7 +279,7 @@ impl Engine {
         }
 
         #[cfg(feature = "editor")]
-        self.editor.tick(delta_time, &self.handle, &self.universe)?;
+        self.editor.tick(delta_time, &self.handle)?;
 
         self.process_commands();
         Ok(self.status())
@@ -314,11 +314,11 @@ impl Engine {
         }
 
         #[cfg(feature = "editor")]
-        self.editor.shutdown(&self.handle, &self.universe)?;
+        self.editor.shutdown(&self.handle)?;
 
         while let Some(mut subsystem) = self.subsystems.pop() {
             subsystem
-                .shutdown(&self.handle, &mut self.universe)
+                .shutdown(&self.handle)
                 .map_err(|source| Error::SubsystemFailedShutdown {
                     name: subsystem.name(),
                     source,

--- a/crates/dirk_engine/src/lib.rs
+++ b/crates/dirk_engine/src/lib.rs
@@ -269,7 +269,7 @@ impl Engine {
             let subsystem = &mut self.subsystems[index];
             let name = subsystem.name();
             subsystem
-                .tick(delta_time, &self.handle)
+                .tick(delta_time, &self.handle, &self.universe)
                 .map_err(|source| Error::SubsystemFailedTick { name, source })?;
 
             self.process_commands();

--- a/crates/dirk_engine/src/subsystem.rs
+++ b/crates/dirk_engine/src/subsystem.rs
@@ -18,6 +18,8 @@
 //!
 //! [`EngineBuildContext`]: crate::EngineBuildContext
 
+use dirk_universe::Universe;
+
 use crate::{EngineBuilder, EngineHandle};
 
 /// Builder-time extension point for engine features.
@@ -83,7 +85,12 @@ pub trait Subsystem {
     /// # Errors
     ///
     /// Returns an error if the subsystem cannot complete its tick.
-    fn tick(&mut self, _delta_time: f64, _handle: &EngineHandle) -> anyhow::Result<()> {
+    fn tick(
+        &mut self,
+        _delta_time: f64,
+        _handle: &EngineHandle,
+        _universe: &Universe,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/crates/dirk_engine/src/subsystem.rs
+++ b/crates/dirk_engine/src/subsystem.rs
@@ -53,7 +53,7 @@ pub trait EnginePlugin {
 /// necessary.
 pub trait EngineResource: Clone + Send + Sync + 'static {}
 
-impl<T> EngineResource for T where T: Clone + Send + Sync + 'static {}
+impl<T: Clone + Send + Sync + 'static> EngineResource for T {}
 
 /// A runtime system owned and driven by the engine.
 ///

--- a/crates/dirk_engine/src/subsystem.rs
+++ b/crates/dirk_engine/src/subsystem.rs
@@ -18,8 +18,6 @@
 //!
 //! [`EngineBuildContext`]: crate::EngineBuildContext
 
-use dirk_universe::Universe;
-
 use crate::{EngineBuilder, EngineHandle};
 
 /// Builder-time extension point for engine features.
@@ -74,7 +72,7 @@ pub trait Subsystem {
     /// # Errors
     ///
     /// Returns an error if startup fails.
-    fn start(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn start(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -85,12 +83,7 @@ pub trait Subsystem {
     /// # Errors
     ///
     /// Returns an error if the subsystem cannot complete its tick.
-    fn tick(
-        &mut self,
-        _delta_time: f64,
-        _handle: &EngineHandle,
-        _universe: &mut Universe,
-    ) -> anyhow::Result<()> {
+    fn tick(&mut self, _delta_time: f64, _handle: &EngineHandle) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -101,7 +94,7 @@ pub trait Subsystem {
     /// # Errors
     ///
     /// Returns an error if shutdown fails.
-    fn shutdown(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn shutdown(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/crates/dirk_engine/src/tests.rs
+++ b/crates/dirk_engine/src/tests.rs
@@ -179,6 +179,35 @@ impl Subsystem for ReadingSubsystem {
     }
 }
 
+struct UniverseHandleSubsystem {
+    handle: dirk_universe::UniverseHandle,
+    world: Arc<Mutex<Option<dirk_universe::WorldId>>>,
+}
+
+impl Subsystem for UniverseHandleSubsystem {
+    fn name(&self) -> &'static str {
+        "universe-handle"
+    }
+
+    fn start(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+        let mut command_buffer = self.handle.command_buffer();
+        let world = command_buffer.create_world(dirk_universe::World::builder("resource-world"));
+        command_buffer.submit();
+        *self.world.lock() = Some(world);
+        Ok(())
+    }
+
+    fn tick(
+        &mut self,
+        _delta_time: f64,
+        handle: &EngineHandle,
+        _universe: &mut Universe,
+    ) -> anyhow::Result<()> {
+        handle.exit();
+        Ok(())
+    }
+}
+
 pub(crate) fn build_context() -> EngineBuildContext {
     let workers = WorkerPool::new("dirk-engine-test");
     let events = EventManager::new(workers.clone());
@@ -464,5 +493,34 @@ fn subsystem_factories_publish_and_read_resources_and_lifecycle_still_runs() -> 
         ]
     );
 
+    Ok(())
+}
+
+#[test]
+fn universe_handle_is_available_as_engine_resource() -> Result<()> {
+    let world = Arc::new(Mutex::new(None));
+    let mut builder = EngineBuilder::new();
+
+    {
+        let world = Arc::clone(&world);
+        builder.add_subsystem(move |ctx| {
+            Ok(UniverseHandleSubsystem {
+                handle: ctx.resource::<dirk_universe::UniverseHandle>()?,
+                world,
+            })
+        });
+    }
+
+    let mut engine = builder.build()?;
+    let status = engine.tick()?;
+    assert_eq!(status, EngineStatus::ExitRequested);
+
+    let world = world.lock().expect("subsystem should record created world");
+    assert_eq!(
+        engine.universe.world(world).map(dirk_universe::World::name),
+        Some("resource-world")
+    );
+
+    engine.shutdown()?;
     Ok(())
 }

--- a/crates/dirk_engine/src/tests.rs
+++ b/crates/dirk_engine/src/tests.rs
@@ -101,7 +101,7 @@ impl Subsystem for StartFailingSubsystem {
         "start-failing"
     }
 
-    fn start(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn start(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         Err(anyhow::anyhow!("start failed"))
     }
 }
@@ -113,7 +113,7 @@ impl Subsystem for ShutdownFailingSubsystem {
         "shutdown-failing"
     }
 
-    fn shutdown(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn shutdown(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         Err(anyhow::anyhow!("shutdown failed"))
     }
 }
@@ -127,7 +127,7 @@ impl Subsystem for PublishingSubsystem {
         "publishing"
     }
 
-    fn start(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn start(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         self.events.lock().push("publishing-start");
         Ok(())
     }
@@ -136,13 +136,13 @@ impl Subsystem for PublishingSubsystem {
         &mut self,
         _delta_time: f64,
         _handle: &EngineHandle,
-        _universe: &mut Universe,
+        _universe: &Universe,
     ) -> anyhow::Result<()> {
         self.events.lock().push("publishing-tick");
         Ok(())
     }
 
-    fn shutdown(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn shutdown(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         self.events.lock().push("publishing-shutdown");
         Ok(())
     }
@@ -157,7 +157,7 @@ impl Subsystem for ReadingSubsystem {
         "reading"
     }
 
-    fn start(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn start(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         self.events.lock().push("reading-start");
         Ok(())
     }
@@ -166,14 +166,14 @@ impl Subsystem for ReadingSubsystem {
         &mut self,
         _delta_time: f64,
         handle: &EngineHandle,
-        _universe: &mut Universe,
+        _universe: &Universe,
     ) -> anyhow::Result<()> {
         self.events.lock().push("reading-tick");
         handle.exit();
         Ok(())
     }
 
-    fn shutdown(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn shutdown(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         self.events.lock().push("reading-shutdown");
         Ok(())
     }
@@ -189,7 +189,7 @@ impl Subsystem for UniverseHandleSubsystem {
         "universe-handle"
     }
 
-    fn start(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn start(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         let mut command_buffer = self.handle.command_buffer();
         let world = command_buffer.create_world(dirk_universe::World::builder("resource-world"));
         command_buffer.submit();
@@ -201,7 +201,7 @@ impl Subsystem for UniverseHandleSubsystem {
         &mut self,
         _delta_time: f64,
         handle: &EngineHandle,
-        _universe: &mut Universe,
+        _universe: &Universe,
     ) -> anyhow::Result<()> {
         handle.exit();
         Ok(())
@@ -289,7 +289,7 @@ impl Subsystem for CountingTickSubsystem {
         &mut self,
         _delta_time: f64,
         _handle: &EngineHandle,
-        _universe: &mut Universe,
+        _universe: &Universe,
     ) -> anyhow::Result<()> {
         self.ticks.fetch_add(1, Ordering::Relaxed);
         Ok(())

--- a/crates/dirk_engine/tests/signal_handling.rs
+++ b/crates/dirk_engine/tests/signal_handling.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use dirk_engine::{Engine, EngineBuilder, EngineHandle, EnginePlugin, Subsystem};
-use dirk_universe::Universe;
 
 const CHILD_ENV: &str = "DIRK_ENGINE_SIGNAL_TEST_CHILD";
 const SIGINT: i32 = 2;
@@ -33,7 +32,7 @@ impl Subsystem for BlockingShutdownSubsystem {
         "blocking-shutdown"
     }
 
-    fn shutdown(&mut self, _handle: &EngineHandle, _universe: &mut Universe) -> anyhow::Result<()> {
+    fn shutdown(&mut self, _handle: &EngineHandle) -> anyhow::Result<()> {
         loop {
             thread::sleep(Duration::from_secs(1));
         }

--- a/crates/dirk_platform/src/lib.rs
+++ b/crates/dirk_platform/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use dirk_universe::Universe;
 use tracing::info;
 use winit::event_loop::{
     EventLoop,
@@ -102,7 +103,12 @@ impl dirk_engine::Subsystem for Platform {
         "platform"
     }
 
-    fn tick(&mut self, _delta_time: f64, handle: &dirk_engine::EngineHandle) -> anyhow::Result<()> {
+    fn tick(
+        &mut self,
+        _delta_time: f64,
+        handle: &dirk_engine::EngineHandle,
+        _universe: &Universe,
+    ) -> anyhow::Result<()> {
         match self
             .event_loop
             .pump_app_events(Some(Duration::ZERO), &mut self.handler)

--- a/crates/dirk_platform/src/lib.rs
+++ b/crates/dirk_platform/src/lib.rs
@@ -102,12 +102,7 @@ impl dirk_engine::Subsystem for Platform {
         "platform"
     }
 
-    fn tick(
-        &mut self,
-        _delta_time: f64,
-        handle: &dirk_engine::EngineHandle,
-        _universe: &mut dirk_universe::Universe,
-    ) -> anyhow::Result<()> {
+    fn tick(&mut self, _delta_time: f64, handle: &dirk_engine::EngineHandle) -> anyhow::Result<()> {
         match self
             .event_loop
             .pump_app_events(Some(Duration::ZERO), &mut self.handler)

--- a/crates/dirk_player/src/lib.rs
+++ b/crates/dirk_player/src/lib.rs
@@ -13,7 +13,7 @@ use dirk_events::{Dispatcher, EventManager};
 use dirk_platform::WindowId;
 #[cfg(not(feature = "editor"))]
 use dirk_platform::WindowInputEvent;
-use dirk_universe::components::Component;
+use dirk_universe::{Universe, components::Component};
 use input::InputContext;
 use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard};
 
@@ -222,6 +222,7 @@ impl Subsystem for PlayerManager {
         &mut self,
         _delta_time: f64,
         _handle: &EngineHandle,
+        _universe: &Universe,
     ) -> anyhow::Result<()> {
         #[cfg(not(feature = "editor"))]
         for event in self.window_input_consumer.consume_all() {

--- a/crates/dirk_player/src/lib.rs
+++ b/crates/dirk_player/src/lib.rs
@@ -222,7 +222,6 @@ impl Subsystem for PlayerManager {
         &mut self,
         _delta_time: f64,
         _handle: &EngineHandle,
-        _universe: &mut dirk_universe::Universe,
     ) -> anyhow::Result<()> {
         #[cfg(not(feature = "editor"))]
         for event in self.window_input_consumer.consume_all() {

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -237,7 +237,12 @@ impl dirk_engine::Subsystem for Renderer {
         "renderer"
     }
 
-    fn tick(&mut self, delta_time: f64, handle: &dirk_engine::EngineHandle) -> anyhow::Result<()> {
+    fn tick(
+        &mut self,
+        delta_time: f64,
+        handle: &dirk_engine::EngineHandle,
+        universe: &Universe,
+    ) -> anyhow::Result<()> {
         self.tick(delta_time)?;
         #[cfg(feature = "editor")]
         {
@@ -245,7 +250,7 @@ impl dirk_engine::Subsystem for Renderer {
             let frame = dirk_engine::editor::EditorRenderContext::new(delta_time, handle);
 
             self.viewport_editor.sync_ready_state(&self.viewports);
-            self.editor.render_ui(&ctx, &frame)?;
+            self.editor.render_ui(&ctx, &frame, universe)?;
         }
 
         #[cfg(not(feature = "editor"))]

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -237,17 +237,12 @@ impl dirk_engine::Subsystem for Renderer {
         "renderer"
     }
 
-    fn tick(
-        &mut self,
-        delta_time: f64,
-        handle: &dirk_engine::EngineHandle,
-        universe: &mut dirk_universe::Universe,
-    ) -> anyhow::Result<()> {
+    fn tick(&mut self, delta_time: f64, handle: &dirk_engine::EngineHandle) -> anyhow::Result<()> {
         self.tick(delta_time)?;
         #[cfg(feature = "editor")]
         {
             let ctx = self.begin_frame();
-            let frame = dirk_engine::editor::EditorRenderContext::new(delta_time, handle, universe);
+            let frame = dirk_engine::editor::EditorRenderContext::new(delta_time, handle);
 
             self.viewport_editor.sync_ready_state(&self.viewports);
             self.editor.render_ui(&ctx, &frame)?;

--- a/crates/dirk_universe/src/command_buffer.rs
+++ b/crates/dirk_universe/src/command_buffer.rs
@@ -1,5 +1,7 @@
 use std::any::TypeId;
 
+use tracing::warn;
+
 use crate::{
     Entity, EntityBuilder, UniverseHandle, WorldBuilder, WorldId,
     components::{AnyComponent, Component},
@@ -38,7 +40,9 @@ impl CommandBuffer {
     /// Will submit the [`CommandBuffer`] to the [`Universe`]'s queue.
     pub fn submit(self) {
         let sender = self.handle.buffer_sender.clone();
-        let _ = sender.send(self);
+        if sender.send(self).is_err() {
+            warn!("failed to submit CommandBuffer: receiver is closed");
+        }
     }
 
     /// Returns if the command buffer has had no submitted commands. This is useful to skip

--- a/crates/dirk_universe/src/command_buffer.rs
+++ b/crates/dirk_universe/src/command_buffer.rs
@@ -1,14 +1,14 @@
 use std::any::TypeId;
 
 use crate::{
-    Allocator, Entity, EntityBuilder, WorldBuilder, WorldId,
+    Entity, EntityBuilder, UniverseHandle, WorldBuilder, WorldId,
     components::{AnyComponent, Component},
 };
 
 /// A buffer to record edits to the [`Universe`].
 pub struct CommandBuffer {
     commands: Vec<Command>,
-    alloc: Allocator,
+    handle: UniverseHandle,
 }
 
 pub(crate) enum Command {
@@ -24,16 +24,23 @@ pub(crate) enum Command {
 impl CommandBuffer {
     /// Creates a new empty command buffer
     #[must_use]
-    pub(crate) fn new(alloc: Allocator) -> Self {
+    pub(crate) fn new(handle: UniverseHandle) -> Self {
         Self {
             commands: Vec::new(),
-            alloc,
+            handle,
         }
     }
 
     pub(crate) fn commands(self) -> Vec<Command> {
         self.commands
     }
+
+    /// Will submit the [`CommandBuffer`] to the [`Universe`]'s queue.
+    pub fn submit(self) {
+        let sender = self.handle.buffer_sender.clone();
+        let _ = sender.send(self);
+    }
+
     /// Returns if the command buffer has had no submitted commands. This is useful to skip
     /// all submission logic when no commands should be run.
     #[must_use]
@@ -45,7 +52,7 @@ impl CommandBuffer {
 
     /// Will create a new empty world & return its ID.
     pub fn create_world(&mut self, builder: WorldBuilder) -> WorldId {
-        let id = self.alloc.allocate_world();
+        let id = self.handle.allocator.allocate_world();
         self.commands.push(Command::CreateWorld(id, builder.name));
 
         for entity in builder.entities {
@@ -67,7 +74,7 @@ impl CommandBuffer {
     /// If the [`World`] does not exist when this command is applied, the
     /// returned handle will not become alive.
     pub fn spawn(&mut self, world: WorldId, builder: EntityBuilder) -> Entity {
-        let entity = self.alloc.allocate_entity();
+        let entity = self.handle.allocator.allocate_entity();
         self.commands.push(Command::Spawn(entity, builder, world));
         entity
     }

--- a/crates/dirk_universe/src/components.rs
+++ b/crates/dirk_universe/src/components.rs
@@ -12,14 +12,14 @@ use std::{
 };
 
 /// Base marker trait for component types.
-pub trait Component: 'static + Sized + Debug {}
+pub trait Component: 'static + Sized + Debug + Send {}
 #[doc(hidden)]
 pub use dirk_proc::Component;
 
 /// A dyn-compatible wrapper around Component, used wherever
 /// type-erased component values must be passed around at runtime.
 #[doc(hidden)]
-pub(crate) trait AnyComponent: Any + Debug + 'static {
+pub(crate) trait AnyComponent: Send + Any + Debug + 'static {
     fn as_any(&self) -> &dyn Any;
     /// Consume this boxed value and return it as a plain `Box<dyn Any>`,
     /// enabling `Box::downcast::<C>()` at call sites.

--- a/crates/dirk_universe/src/lib.rs
+++ b/crates/dirk_universe/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     any::TypeId,
     collections::{HashMap, HashSet},
     fmt::Debug,
+    sync::mpsc::{self, Receiver, Sender},
 };
 use tracing::warn;
 
@@ -41,12 +42,32 @@ pub struct ComponentInfo<'a> {
     pub debug: &'a dyn Debug,
 }
 
+/// A cheap clonable handle for access to the [`Universe`].
+/// This give write-only access to the [`Universe`]. To write to it, use
+/// a [`System`].
+///
+/// [`System`]: systems::System
+#[derive(Clone)]
+pub struct UniverseHandle {
+    allocator: Allocator,
+    buffer_sender: Sender<CommandBuffer>,
+}
+
+impl UniverseHandle {
+    /// Creates a command buffer
+    #[must_use]
+    pub fn command_buffer(&self) -> CommandBuffer {
+        CommandBuffer::new(self.clone())
+    }
+}
+
 /// This struct is the manager for all the worlds.
 pub struct Universe {
     worlds: HashMap<WorldId, World>,
     entities: HashMap<Entity, WorldId>,
 
-    allocator: Allocator,
+    handle: UniverseHandle,
+    buffer_receiver: Receiver<CommandBuffer>,
 
     // this field starts with `universe`
     #[allow(clippy::struct_field_names)]
@@ -56,9 +77,6 @@ pub struct Universe {
     component_systems: ComponentSystemStorage,
 
     components: Components,
-
-    /// The queue of command buffers that need to be submitted
-    buffers: Vec<CommandBuffer>,
 }
 
 impl Universe {
@@ -70,30 +88,34 @@ impl Universe {
 
     #[must_use]
     fn build(builder: UniverseBuilder) -> Self {
-        let mut universe = Self {
+        let (sender, receiver) = mpsc::channel();
+        let universe = Self {
             worlds: HashMap::new(),
             entities: HashMap::new(),
-            allocator: Allocator::new(),
+            handle: UniverseHandle {
+                allocator: Allocator::new(),
+                buffer_sender: sender,
+            },
+            buffer_receiver: receiver,
             universe_systems: builder.universe_systems,
             ticking_systems: builder.ticking_systems,
             entity_systems: builder.entity_systems,
             component_systems: builder.component_systems,
             components: Components::default(),
-            buffers: Vec::new(),
         };
 
-        let mut cmd = universe.command_buffer();
+        let mut cmd = universe.handle.command_buffer();
         for builder in builder.worlds {
             cmd.create_world(builder);
         }
-        universe.submit_buffer(cmd);
+        cmd.submit();
         universe
     }
 
-    /// Creates a new empty command buffer for this universe.
+    /// Returns a cheap handle to the [`Universe`].
     #[must_use]
-    pub fn command_buffer(&self) -> CommandBuffer {
-        CommandBuffer::new(self.allocator.clone())
+    pub fn handle(&self) -> UniverseHandle {
+        self.handle.clone()
     }
 
     /// Ticks every the entire [`Universe`].
@@ -104,12 +126,10 @@ impl Universe {
     /// was just created is not found in the [`Universe`].
     /// No panic should be caused by user error.
     pub fn tick(&mut self, delta_time: f64) {
-        let mut cmd = self.command_buffer();
-
-        let buffers = std::mem::take(&mut self.buffers);
+        let mut cmd = self.handle.command_buffer();
 
         let mut commands: Vec<Command> = Vec::new();
-        for sub in buffers {
+        for sub in self.buffer_receiver.try_iter() {
             commands.append(&mut sub.commands());
         }
 
@@ -123,7 +143,7 @@ impl Universe {
             system.tick(&mut cmd, self, delta_time, &mut system.query().query(self));
         });
 
-        self.submit_buffer(cmd);
+        cmd.submit();
     }
 
     // HELPERS FOR THE TICK FUNCTION
@@ -351,16 +371,6 @@ impl Universe {
         for world in destroyed_worlds {
             self.worlds.remove(&world);
         }
-    }
-
-    // COMMAND BUFFERS
-
-    /// Will submit a buffer for execution.
-    pub fn submit_buffer(&mut self, buffer: CommandBuffer) {
-        if buffer.is_empty() {
-            return;
-        }
-        self.buffers.push(buffer);
     }
 
     // UTILITIES & GETTERS

--- a/crates/dirk_universe/src/lib.rs
+++ b/crates/dirk_universe/src/lib.rs
@@ -88,15 +88,11 @@ impl Universe {
 
     #[must_use]
     fn build(builder: UniverseBuilder) -> Self {
-        let (sender, receiver) = mpsc::channel();
         let universe = Self {
             worlds: HashMap::new(),
             entities: HashMap::new(),
-            handle: UniverseHandle {
-                allocator: Allocator::new(),
-                buffer_sender: sender,
-            },
-            buffer_receiver: receiver,
+            handle: builder.handle,
+            buffer_receiver: builder.buffer_receiver,
             universe_systems: builder.universe_systems,
             ticking_systems: builder.ticking_systems,
             entity_systems: builder.entity_systems,
@@ -450,8 +446,9 @@ impl Universe {
 }
 
 /// Builder struct used to construct a [`Universe`].
-#[derive(Default)]
 pub struct UniverseBuilder {
+    handle: UniverseHandle,
+    buffer_receiver: Receiver<CommandBuffer>,
     worlds: Vec<WorldBuilder>,
     universe_systems: UniverseSystemStorage,
     ticking_systems: TickingSystemStorage,
@@ -462,7 +459,25 @@ pub struct UniverseBuilder {
 impl UniverseBuilder {
     #[must_use]
     fn new() -> Self {
-        Self::default()
+        let (sender, receiver) = mpsc::channel();
+        Self {
+            handle: UniverseHandle {
+                allocator: Allocator::new(),
+                buffer_sender: sender,
+            },
+            buffer_receiver: receiver,
+            worlds: Vec::new(),
+            universe_systems: UniverseSystemStorage::default(),
+            ticking_systems: TickingSystemStorage::default(),
+            entity_systems: EntitySystemStorage::default(),
+            component_systems: ComponentSystemStorage::default(),
+        }
+    }
+
+    /// Returns the handle that will access the built [`Universe`].
+    #[must_use]
+    pub fn handle(&self) -> UniverseHandle {
+        self.handle.clone()
     }
 
     /// Will build a new [`Universe`] from the current builder.
@@ -532,6 +547,12 @@ impl UniverseBuilder {
         }
 
         self
+    }
+}
+
+impl Default for UniverseBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/dirk_universe/src/tests.rs
+++ b/crates/dirk_universe/src/tests.rs
@@ -11,9 +11,9 @@ struct Health(u32);
 struct Mana(u32);
 
 fn spawn_entity(universe: &mut Universe, world: WorldId, builder: EntityBuilder) -> Entity {
-    let mut command_buffer = universe.command_buffer();
+    let mut command_buffer = universe.handle().command_buffer();
     let entity = command_buffer.spawn(world, builder);
-    universe.submit_buffer(command_buffer);
+    command_buffer.submit();
     universe.tick(0.0);
     entity
 }
@@ -221,10 +221,10 @@ fn inspection_helpers_update_after_despawn_and_world_destruction() {
         Entity::builder().with_component(Mana(20)),
     );
 
-    let mut command_buffer = universe.command_buffer();
+    let mut command_buffer = universe.handle().command_buffer();
     command_buffer.despawn(despawned);
     command_buffer.destroy_world(second_world);
-    universe.submit_buffer(command_buffer);
+    command_buffer.submit();
     universe.tick(0.016);
 
     assert_eq!(universe.component_infos(despawned).count(), 0);

--- a/crates/dirk_universe/tests/integration.rs
+++ b/crates/dirk_universe/tests/integration.rs
@@ -9,9 +9,9 @@ struct Position(i32, i32);
 struct Hidden;
 
 fn spawn_entity(universe: &mut Universe, world: WorldId, builder: EntityBuilder) -> Entity {
-    let mut cmd = universe.command_buffer();
+    let mut cmd = universe.handle().command_buffer();
     let entity = cmd.spawn(world, builder);
-    universe.submit_buffer(cmd);
+    cmd.submit();
     universe.tick(0.0);
     entity
 }
@@ -37,17 +37,17 @@ fn universe_public_api_supports_entity_lifecycle_across_worlds() {
     assert!(universe.is_in_world(overworld, entity));
     assert_eq!(universe.get_world(entity), Some(overworld));
 
-    let mut cmd = universe.command_buffer();
+    let mut cmd = universe.handle().command_buffer();
     cmd.send(entity, dungeon);
-    universe.submit_buffer(cmd);
+    cmd.submit();
     universe.tick(0.016);
 
     assert!(universe.is_in_world(dungeon, entity));
     assert_eq!(universe.get_world(entity), Some(dungeon));
 
-    let mut cmd = universe.command_buffer();
+    let mut cmd = universe.handle().command_buffer();
     cmd.despawn(entity);
-    universe.submit_buffer(cmd);
+    cmd.submit();
     universe.tick(0.016);
 
     assert!(!universe.is_alive(entity));
@@ -59,7 +59,7 @@ fn buffered_spawns_are_applied_on_tick_and_components_are_readable() {
     universe.tick(0.0);
     let world = dirk_universe::WorldId::default();
 
-    let mut cmd = universe.command_buffer();
+    let mut cmd = universe.handle().command_buffer();
     let e0 = cmd.spawn(world, Entity::builder().with_component(Position(1, 1)));
     let e1 = cmd.spawn(
         world,
@@ -67,7 +67,7 @@ fn buffered_spawns_are_applied_on_tick_and_components_are_readable() {
             .with_component(Position(9, 9))
             .with_component(Hidden),
     );
-    universe.submit_buffer(cmd);
+    cmd.submit();
 
     universe.tick(0.016);
 
@@ -90,22 +90,22 @@ fn buffered_spawns_are_applied_on_tick_and_components_are_readable() {
 fn public_command_buffers_allocate_unique_handles() {
     let mut universe = Universe::builder().build();
 
-    let mut first_cmd = universe.command_buffer();
+    let mut first_cmd = universe.handle().command_buffer();
     let first_world = first_cmd.create_world(World::builder("first"));
     let first_entity = first_cmd.spawn(
         first_world,
         Entity::builder().with_component(Position(4, 8)),
     );
 
-    let mut second_cmd = universe.command_buffer();
+    let mut second_cmd = universe.handle().command_buffer();
     let second_world = second_cmd.create_world(World::builder("second"));
     let second_entity = second_cmd.spawn(
         second_world,
         Entity::builder().with_component(Position(16, 32)),
     );
 
-    universe.submit_buffer(first_cmd);
-    universe.submit_buffer(second_cmd);
+    first_cmd.submit();
+    second_cmd.submit();
     universe.tick(0.016);
 
     assert_ne!(first_world, second_world);

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::PI;
 
 use dirk_engine::{EngineHandle, EnginePlugin, Subsystem};
-use dirk_universe::{CommandBuffer, Entity, Universe, World};
+use dirk_universe::{CommandBuffer, Entity, UniverseHandle, World};
 
 /// An [`EnginePlugin`] with a basic demo world.
 pub struct DemoPlugin;
@@ -20,6 +20,7 @@ impl EnginePlugin for DemoPlugin {
         builder.add_subsystem(|ctx| {
             Ok(Demo {
                 players: ctx.resource::<dirk_player::PlayerRegistry>()?,
+                universe: ctx.resource::<dirk_universe::UniverseHandle>()?,
                 started: false,
             })
         });
@@ -30,6 +31,7 @@ impl EnginePlugin for DemoPlugin {
 /// A basic demo [`Subsystem`].
 struct Demo {
     players: dirk_player::PlayerRegistry,
+    universe: UniverseHandle,
     started: bool,
 }
 
@@ -38,12 +40,12 @@ impl Subsystem for Demo {
         "demo-startup"
     }
 
-    fn start(&mut self, _handle: &EngineHandle, universe: &mut Universe) -> anyhow::Result<()> {
+    fn start(&mut self, _engine: &EngineHandle) -> anyhow::Result<()> {
         if self.started {
             return Ok(());
         }
 
-        let mut cmd = universe.handle().command_buffer();
+        let mut cmd = self.universe.command_buffer();
 
         let world_id = create_test_world(&mut cmd);
         let player = self.players.new_player();

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -43,7 +43,7 @@ impl Subsystem for Demo {
             return Ok(());
         }
 
-        let mut cmd = universe.command_buffer();
+        let mut cmd = universe.handle().command_buffer();
 
         let world_id = create_test_world(&mut cmd);
         let player = self.players.new_player();
@@ -59,7 +59,7 @@ impl Subsystem for Demo {
             ),
         );
 
-        universe.submit_buffer(cmd);
+        cmd.submit();
 
         self.started = true;
         Ok(())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Move Universe out of Subsystems & Introduce UniverseHandle

## Architecture & ECS Refactoring

### Universe and UniverseHandle Introduction
- Introduced new public `UniverseHandle` struct that stores an `Allocator` and an `mpsc::Sender<CommandBuffer>`
- Added public method `UniverseHandle::command_buffer(&self) -> CommandBuffer` for decoupled command buffer creation
- Refactored `Universe` command buffering from internal `Vec<CommandBuffer>` to `mpsc` channel architecture, with universe now storing `handle: UniverseHandle` and `buffer_receiver: Receiver<CommandBuffer>`
- Added `Universe::handle(&self) -> UniverseHandle` accessor method
- **Removed public APIs**: `Universe::command_buffer()` and `Universe::submit_buffer()` (replaced by handle-based pattern)
- Updated `UniverseBuilder` to create and wire the mpsc channel, changed from deriving `Default` to implementing it explicitly

### Command Buffer Refactoring
- `CommandBuffer` now owns a `UniverseHandle` instead of an internal `Allocator`
- Updated `CommandBuffer::new()` constructor signature to accept `UniverseHandle`
- Submission now derives the queue sender from `self.handle.buffer_sender`
- World/entity ID allocation routed through `self.handle.allocator`

## Subsystem Trait & Lifecycle API Changes

### Core Subsystem Trait Refactoring
- `Subsystem::start()` signature changed from `(&mut self, &EngineHandle, &mut Universe)` to `(&mut self, &EngineHandle)` — removed mutable Universe access
- `Subsystem::tick()` signature changed to accept `&Universe` instead of `&mut Universe` — universe now immutable during ticking
- `Subsystem::shutdown()` signature changed from `(&mut self, &EngineHandle, &mut Universe)` to `(&mut self, &EngineHandle)` — removed mutable Universe access
- Default implementations remain no-ops returning `Ok(())`

### Generic Constraint Style Update
- Updated `EngineResource` blanket impl from `where` clause to inline bounded generic parameters: `impl<T: Clone + Send + Sync + 'static> EngineResource for T {}`

## Component Trait Updates
- Added `Send` bound to `Component` trait: `pub trait Component: 'static + Sized + Debug + Send {}`
- Added `Send` bound to internal `AnyComponent` trait: `pub(crate) trait AnyComponent: Send + Any + Debug + 'static {}`

## Editor Subsystem Architecture Overhaul

### EditorSubsystem Lifecycle API Redesign
- Replaced context struct-based callbacks (`EditorStartContext`, `EditorTickContext`, `EditorShutdownContext`) with direct handle/service parameters
- `EditorSubsystem::start()`: `(&mut self, &mut EditorStartContext)` → `(&mut self, &EngineHandle, &EditorServices)`
- `EditorSubsystem::tick()`: `(&mut self, &mut EditorTickContext)` → `(&mut self, &EngineHandle, &EditorServices, f64)`
- `EditorSubsystem::shutdown()`: `(&mut self, &mut EditorShutdownContext)` → `(&mut self, &EngineHandle, &EditorServices)`

### EditorRenderContext Refactoring
- Removed `universe: &Universe` field and parameter from `EditorRenderContext`
- Constructor changed from `EditorRenderContext::new(delta_time, handle, universe)` to `EditorRenderContext::new(delta_time, handle)`
- Universe now passed explicitly to rendering methods

### EditorUiContext Changes
- Made `universe` field private (was `pub`)
- Added `universe(&self) -> &Universe` accessor method
- Universe initialization now sourced from passed parameters rather than render context

### EditorServices Rendering API
- `EditorServices::render_ui()` now accepts explicit `universe: &Universe` parameter
- Universe parameter propagated through menu and window rendering functions

## Engine Lifecycle Integration

### Engine Start/Tick/Shutdown Flow
- `Engine::start()`: Subsystems now called with only `&EngineHandle` (removed `&mut Universe`)
- `Engine::tick()`: Subsystems now receive `&self.universe` immutably instead of mutable reference
- `Engine::shutdown()`: Subsystems called with only `&EngineHandle` (removed `&mut Universe`)
- Editor runtime methods similarly updated with reduced parameter passing

### Engine Build Context
- `EngineBuilder::build` now publishes `UniverseHandle` as a typed engine resource immediately after context creation, enabling subsystem factories to resolve it

## Subsystem Implementation Updates

### Affected Subsystems
- **Demo**: Now stores `UniverseHandle` field; `start()` uses `self.universe.command_buffer()` and `cmd.submit()`
- **AssetsSubsystem**: `tick()` parameter changed from `&mut Universe` to `&Universe`
- **EditorSubsystem**: Complete API redesign (see Editor section above)
- **Platform**: `tick()` parameter changed from `&mut Universe` to `&Universe`
- **PlayerManager**: `tick()` parameter changed from `&mut Universe` to `&Universe`
- **Renderer**: `tick()` parameter changed from `&mut Universe` to `&Universe`; `EditorRenderContext::new()` call updated to new signature

## Test Suite Updates

### Universe Tests
- Updated command buffer usage in test helpers: `universe.handle().command_buffer()` with per-command `submit()`
- Integration tests refactored to use handle-based command buffers instead of universe methods
- Added new unit test `universe_handle_is_available_as_engine_resource` validating `UniverseHandle` availability as engine resource

### Editor Tests
- Updated test harness for new editor subsystem API signatures
- `EditorServices::render_menu_for_tests()` now accepts explicit `universe: &Universe` parameter
- Test-only `EditorSubsystem` implementations updated to new trait shape
- Rendering helper code adapted to revised `EditorRenderContext` and `render_ui` APIs

### Signal Handling Tests
- Removed `Universe` dependency; updated `shutdown` trait implementations to new signature

## Summary of Scope

- **Lines Changed**: ~180 lines across codebase
- **Files Modified**: 17 primary files
- **Breaking Changes**: Public API changes to `Universe`, `Subsystem`, `EditorSubsystem`, and associated types
- **Key Architectural Improvement**: Universe now decoupled from subsystem lifecycle, enabling cleaner separation of concerns and supporting handle-based command buffering patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->