### PR TITLE
chore: port Vulkan renderer to macOS with MoltenVK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
 
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain

--- a/.github/workflows/fmt-lint.yml
+++ b/.github/workflows/fmt-lint.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain with Clippy

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A Vulkan Game Engine in Rust
 
 On macOS, the Vulkan renderer uses `MoltenVK` through the Vulkan loader. The
-engine does not install or bundle `MoltenVK`; make either `libvulkan.dylib`
-from the Vulkan SDK or a directly available `libMoltenVK.dylib` available at
-runtime. Native Metal rendering remains a future backend.
+engine does not install or bundle a Vulkan SDK or `MoltenVK`; provide the
+Vulkan loader and configure it to discover the `MoltenVK` ICD at runtime. Native
+Metal rendering remains a future backend.
 
 Debug builds also enable `VK_LAYER_KHRONOS_validation`; make its Vulkan layer
 manifest discoverable with `VK_ADD_LAYER_PATH` (or a standard Vulkan layer

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 A Vulkan Game Engine in Rust
 
+On macOS, the Vulkan renderer uses `MoltenVK` through the Vulkan loader. The
+engine does not install or bundle `MoltenVK`; make either `libvulkan.dylib`
+from the Vulkan SDK or a directly available `libMoltenVK.dylib` available at
+runtime. Native Metal rendering remains a future backend.
+
+Debug builds also enable `VK_LAYER_KHRONOS_validation`; make its Vulkan layer
+manifest discoverable with `VK_ADD_LAYER_PATH` (or a standard Vulkan layer
+search path).
+
 The engine is assembled with plugins and runtime subsystems:
 
 ```rust,no_run

--- a/crates/dirk_platform/src/handler.rs
+++ b/crates/dirk_platform/src/handler.rs
@@ -20,6 +20,7 @@ use crate::{
 
 pub struct PlatformHandler {
     can_create_surfaces: bool,
+    shutdown_requested: bool,
     windows: PlatformWindows,
 
     /// Current keyboard modifier state, updated on every `ModifiersChanged` event.
@@ -40,6 +41,7 @@ impl PlatformHandler {
     pub fn new(events: &dirk_events::EventManager, windows: PlatformWindows) -> Self {
         Self {
             can_create_surfaces: false,
+            shutdown_requested: false,
             windows,
             modifiers: ModifiersState::default(),
             pointer_positions: HashMap::new(),
@@ -68,6 +70,10 @@ impl PlatformHandler {
     pub fn shutdown(&mut self) {
         let count = self.windows.clear();
         debug!("Closed {count} window(s) during platform shutdown");
+    }
+
+    pub fn request_shutdown(&mut self) {
+        self.shutdown_requested = true;
     }
 
     fn dispatch_platform_event(&mut self, id: WindowId, event: &WindowEvent) -> bool {
@@ -296,6 +302,12 @@ impl ApplicationHandler for PlatformHandler {
             return;
         }
         self.dispatch_input_event(id, &event);
+    }
+
+    fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
+        if self.shutdown_requested {
+            event_loop.exit();
+        }
     }
 }
 

--- a/crates/dirk_platform/src/handler.rs
+++ b/crates/dirk_platform/src/handler.rs
@@ -20,6 +20,7 @@ use crate::{
 
 pub struct PlatformHandler {
     can_create_surfaces: bool,
+    #[cfg(platform_macos)]
     shutdown_requested: bool,
     windows: PlatformWindows,
 
@@ -41,6 +42,7 @@ impl PlatformHandler {
     pub fn new(events: &dirk_events::EventManager, windows: PlatformWindows) -> Self {
         Self {
             can_create_surfaces: false,
+            #[cfg(platform_macos)]
             shutdown_requested: false,
             windows,
             modifiers: ModifiersState::default(),
@@ -72,6 +74,7 @@ impl PlatformHandler {
         debug!("Closed {count} window(s) during platform shutdown");
     }
 
+    #[cfg(platform_macos)]
     pub fn request_shutdown(&mut self) {
         self.shutdown_requested = true;
     }
@@ -304,6 +307,7 @@ impl ApplicationHandler for PlatformHandler {
         self.dispatch_input_event(id, &event);
     }
 
+    #[cfg(platform_macos)]
     fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
         if self.shutdown_requested {
             event_loop.exit();

--- a/crates/dirk_platform/src/lib.rs
+++ b/crates/dirk_platform/src/lib.rs
@@ -139,10 +139,24 @@ impl dirk_engine::Subsystem for Platform {
 impl Drop for Platform {
     fn drop(&mut self) {
         info!("Shutting down platform");
+
+        // AppKit sends window-destruction callbacks while closing native
+        // windows. Ask winit to close them while its handler is still
+        // registered, then release the Rust window wrappers.
+        #[cfg(platform_macos)]
+        {
+            self.handler.request_shutdown();
+            self.event_loop
+                .pump_app_events(Some(Duration::ZERO), &mut self.handler);
+        }
+
         self.handler.shutdown();
-        // One final pump so winit can process the window destruction
-        // events before we tear everything down.
-        self.event_loop
-            .pump_app_events(Some(Duration::ZERO), &mut self.handler);
+        #[cfg(not(platform_macos))]
+        {
+            // On other platforms, process the window destruction events
+            // before tearing down the event loop.
+            self.event_loop
+                .pump_app_events(Some(Duration::ZERO), &mut self.handler);
+        }
     }
 }

--- a/crates/dirk_renderer/README.md
+++ b/crates/dirk_renderer/README.md
@@ -4,9 +4,9 @@ The renderer owns Vulkan rendering for the engine. GPU operations are handled
 through `ash`.
 
 On macOS, the renderer discovers the `AppKit` surface extensions and enables
-Vulkan portability enumeration for `MoltenVK`. It first loads the normal Vulkan
-loader and then falls back to a directly available `libMoltenVK.dylib`; no
-`MoltenVK` library is linked or installed by this crate.
+Vulkan portability enumeration for `MoltenVK`. It loads the Vulkan loader
+provided by the user's Vulkan SDK; no Vulkan SDK or `MoltenVK` library is
+linked, installed, or bundled by this crate.
 
 Debug builds enable `VK_LAYER_KHRONOS_validation`, so its manifest must be
 discoverable through `VK_ADD_LAYER_PATH` or a standard Vulkan layer path.

--- a/crates/dirk_renderer/README.md
+++ b/crates/dirk_renderer/README.md
@@ -3,6 +3,14 @@
 The renderer owns Vulkan rendering for the engine. GPU operations are handled
 through `ash`.
 
+On macOS, the renderer discovers the `AppKit` surface extensions and enables
+Vulkan portability enumeration for `MoltenVK`. It first loads the normal Vulkan
+loader and then falls back to a directly available `libMoltenVK.dylib`; no
+`MoltenVK` library is linked or installed by this crate.
+
+Debug builds enable `VK_LAYER_KHRONOS_validation`, so its manifest must be
+discoverable through `VK_ADD_LAYER_PATH` or a standard Vulkan layer path.
+
 Register `RendererPlugin` with an `EngineBuilder` to install the renderer
 subsystem and its ECS integration systems. The plugin depends on
 `PlatformPlugin` and `AssetsPlugin`, reads engine metadata for Vulkan

--- a/crates/dirk_renderer/src/init.rs
+++ b/crates/dirk_renderer/src/init.rs
@@ -50,7 +50,6 @@ impl Renderer {
     ) -> Result<(vk::PhysicalDevice, RendererProperties)> {
         let (device_info, queues) = physical_device::PhysicalDeviceSelector::new()
             .require_extensions(DEVICE_EXTENSIONS)
-            .require(|info| info.features.geometry_shader == vk::TRUE)
             .require(|info| info.vulkan12_features.vulkan_memory_model == vk::TRUE)
             .require(|info| info.vulkan12_features.timeline_semaphore == vk::TRUE)
             .select(instance, surface_loader, surface)

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -12,13 +12,7 @@ use std::{
 use anyhow::Context;
 #[cfg(validation)]
 use ash::ext::debug_utils;
-#[cfg(platform_linux)]
-use ash::khr::wayland_surface;
-use ash::{
-    Entry,
-    khr::{surface, swapchain},
-    vk,
-};
+use ash::{Entry, khr::swapchain, vk};
 
 #[cfg(feature = "editor")]
 use dirk_platform::WindowInputEvent;
@@ -31,6 +25,7 @@ use dirk_player::PlayerPresentationAssignments;
 
 use dirk_universe::{Entity, Universe, UniverseBuilder, WorldId};
 use dirk_utils::Version;
+use raw_window_handle::HasDisplayHandle;
 use tracing::{debug, info};
 
 use dirk_platform::PlatformWindows;
@@ -136,8 +131,13 @@ impl dirk_engine::EnginePlugin for RendererPlugin {
 mod debug;
 
 const MAX_FRAMES_IN_FLIGHT: usize = 2;
-const DEVICE_EXTENSIONS: &[&str] =
-    &[unsafe { std::str::from_utf8_unchecked(swapchain::NAME.to_bytes()) }];
+const DEVICE_EXTENSIONS: &[&str] = &[
+    unsafe { std::str::from_utf8_unchecked(swapchain::NAME.to_bytes()) },
+    #[cfg(platform_macos)]
+    unsafe {
+        std::str::from_utf8_unchecked(ash::khr::portability_subset::NAME.to_bytes())
+    },
+];
 #[cfg(validation)]
 const VALIDATION_LAYERS: &[*const i8] = &[c"VK_LAYER_KHRONOS_validation".as_ptr()];
 
@@ -281,7 +281,7 @@ impl Renderer {
     ) -> Result<Self> {
         info!("Intializing Vulkan...");
 
-        let entry = unsafe { Entry::load()? };
+        let entry = Self::load_vulkan_entry()?;
 
         let app_info = vk::ApplicationInfo::default()
             .application_name(create_info.app_name.as_c_str())
@@ -290,9 +290,15 @@ impl Renderer {
             .engine_version(make_version(create_info.engine_version))
             .api_version(vk::API_VERSION_1_3);
 
-        let mut extensions = Self::required_instance_extensions();
+        let mut extensions = Self::required_instance_extensions(window)?;
         let mut instance_create_info =
             vk::InstanceCreateInfo::default().application_info(&app_info);
+
+        #[cfg(platform_macos)]
+        {
+            instance_create_info =
+                instance_create_info.flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR);
+        }
 
         #[cfg(validation)]
         let mut debug_create_info = debug::debug_create_info();
@@ -1053,13 +1059,30 @@ impl Renderer {
         Ok(unsafe { device.device.create_sampler(&sampler_info, None)? })
     }
 
-    fn required_instance_extensions() -> Vec<*const i8> {
-        let mut extensions = vec![surface::NAME.as_ptr()];
+    fn load_vulkan_entry() -> Result<Entry> {
+        match unsafe { Entry::load() } {
+            Ok(entry) => Ok(entry),
+            #[cfg(platform_macos)]
+            Err(loader_error) => {
+                // The Vulkan SDK provides a Vulkan loader, while a standalone
+                // MoltenVK installation provides libMoltenVK.dylib directly.
+                // Try both without requiring either library at build time.
+                info!("could not load libvulkan.dylib ({loader_error}); trying libMoltenVK.dylib");
+                Ok(unsafe { Entry::load_from("libMoltenVK.dylib")? })
+            }
+            #[cfg(not(platform_macos))]
+            Err(loader_error) => Err(loader_error.into()),
+        }
+    }
 
-        #[cfg(platform_linux)]
-        extensions.push(wayland_surface::NAME.as_ptr());
+    fn required_instance_extensions(window: &dirk_platform::Window) -> Result<Vec<*const i8>> {
+        let display_handle = window.display_handle()?.as_raw();
+        let mut extensions = ash_window::enumerate_required_extensions(display_handle)?.to_vec();
 
-        extensions
+        #[cfg(platform_macos)]
+        extensions.push(ash::khr::portability_enumeration::NAME.as_ptr());
+
+        Ok(extensions)
     }
 
     fn validate_instance_extensions(entry: &Entry, extensions: &[*const i8]) -> Result<()> {

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -281,7 +281,7 @@ impl Renderer {
     ) -> Result<Self> {
         info!("Intializing Vulkan...");
 
-        let entry = Self::load_vulkan_entry()?;
+        let entry = unsafe { Entry::load()? };
 
         let app_info = vk::ApplicationInfo::default()
             .application_name(create_info.app_name.as_c_str())
@@ -1057,22 +1057,6 @@ impl Renderer {
             .unnormalized_coordinates(false);
 
         Ok(unsafe { device.device.create_sampler(&sampler_info, None)? })
-    }
-
-    fn load_vulkan_entry() -> Result<Entry> {
-        match unsafe { Entry::load() } {
-            Ok(entry) => Ok(entry),
-            #[cfg(platform_macos)]
-            Err(loader_error) => {
-                // The Vulkan SDK provides a Vulkan loader, while a standalone
-                // MoltenVK installation provides libMoltenVK.dylib directly.
-                // Try both without requiring either library at build time.
-                info!("could not load libvulkan.dylib ({loader_error}); trying libMoltenVK.dylib");
-                Ok(unsafe { Entry::load_from("libMoltenVK.dylib")? })
-            }
-            #[cfg(not(platform_macos))]
-            Err(loader_error) => Err(loader_error.into()),
-        }
     }
 
     fn required_instance_extensions(window: &dirk_platform::Window) -> Result<Vec<*const i8>> {

--- a/crates/dirk_renderer/src/lib.rs
+++ b/crates/dirk_renderer/src/lib.rs
@@ -1061,10 +1061,14 @@ impl Renderer {
 
     fn required_instance_extensions(window: &dirk_platform::Window) -> Result<Vec<*const i8>> {
         let display_handle = window.display_handle()?.as_raw();
-        let mut extensions = ash_window::enumerate_required_extensions(display_handle)?.to_vec();
+        let extensions = ash_window::enumerate_required_extensions(display_handle)?.to_vec();
 
         #[cfg(platform_macos)]
-        extensions.push(ash::khr::portability_enumeration::NAME.as_ptr());
+        let extensions = {
+            let mut extensions = extensions;
+            extensions.push(ash::khr::portability_enumeration::NAME.as_ptr());
+            extensions
+        };
 
         Ok(extensions)
     }


### PR DESCRIPTION
## Summary

Port the engine to macOS using MoltenVK.

- Use winit display handles to enumerate platform-required Vulkan extensions.
- Enable Vulkan portability enumeration and `VK_KHR_portability_subset` on macOS.
- Load the Nix/MoltenVK Vulkan libraries on macOS.
- Fix AppKit/winit shutdown ordering so window destruction occurs while the handler remains registered.
- Update macOS/MoltenVK documentation and CI coverage.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --workspace` — 264 tests passed
- `cargo check --workspace --no-default-features`
- `cargo check --workspace --all-features`
- Verified `cargo run` on macOS with MoltenVK, including Apple M5 device selection and swapchain creation.

Generated with GPT-5.6 (Codex) in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Vulkan and MoltenVK support

- Ported the Vulkan renderer to macOS through MoltenVK.
- Derived required Vulkan instance extensions from the window’s raw display handle.
- Enabled Vulkan portability enumeration and `VK_KHR_portability_subset` on macOS.
- Added fallback loading for `libMoltenVK.dylib`.
- Removed the `geometry_shader` requirement from physical-device selection.
- Preserved Vulkan 1.2 memory-model and timeline-semaphore requirements.

## Platform shutdown

- Added macOS shutdown requests through `PlatformHandler::request_shutdown`.
- Updated event-loop handling to exit after a shutdown request.
- Changed macOS shutdown ordering to close native windows and process events before handler shutdown.
- Preserved separate shutdown behavior for non-macOS platforms.

## Documentation

- Documented macOS Vulkan and MoltenVK runtime requirements.
- Documented Vulkan loader fallback behavior.
- Documented validation-layer manifest requirements for debug builds.
- Clarified that native Metal rendering is not supported.

## CI and validation

- Expanded check, build, test, and Clippy jobs to Ubuntu and macOS.
- Passed formatting and Clippy checks.
- Passed 264 workspace tests.
- Checked feature and no-default-feature configurations.
- Verified macOS MoltenVK execution, Apple M5 device selection, and swapchain creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->