### PR TITLE
feat: add backend-neutral render hardware interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirk_rhi"
+version = "0.1.0"
+
+[[package]]
 name = "dirk_shaders"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ dirk_proc     = { version = "0.1.0", path = "crates/dirk_proc" }
 dirk_platform = { version = "0.1.0", path = "crates/dirk_platform" }
 dirk_input    = { version = "0.1.0", path = "crates/dirk_input" }
 dirk_renderer = { version = "0.1.0", path = "crates/dirk_renderer" }
+dirk_rhi      = { version = "0.1.0", path = "crates/dirk_rhi" }
 dirk_assets   = { version = "0.1.0", path = "crates/dirk_assets" }
 dirk_world    = { version = "0.1.0", path = "crates/dirk_world" }
 dirk_universe = { version = "0.1.0", path = "crates/dirk_universe" }

--- a/crates/dirk_rhi/Cargo.toml
+++ b/crates/dirk_rhi/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dirk_rhi"
+description = "Backend-neutral rendering hardware interface for DirkEngine"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+homepage.workspace = true
+authors.workspace = true
+documentation.workspace = true
+
+[dependencies]
+
+[features]
+default = []
+presentation = []
+
+[lints]
+workspace = true

--- a/crates/dirk_rhi/src/backend.rs
+++ b/crates/dirk_rhi/src/backend.rs
@@ -1,0 +1,323 @@
+//! Contract implemented by concrete graphics backends.
+
+use crate::{
+    BindGroupCreateInfo, BindGroupLayoutCreateInfo, BufferBarrier, BufferCopy, BufferCreateInfo,
+    BufferImageCopy, CommandBufferBeginInfo, CommandBufferLevel, CommandPoolCreateInfo, Draw,
+    DrawIndexed, Fence, Filter, GraphicsPipelineCreateInfo, ImageBarrier, ImageBlit, ImageCopy,
+    ImageCreateInfo, ImageLayout, ImageViewCreateInfo, IndexFormat, PipelineLayoutCreateInfo,
+    QueueType, Rect2D, RenderingInfo, Result, SamplerCreateInfo, SemaphoreKind,
+    ShaderModuleCreateInfo, SubmitInfo, VertexBufferBinding, Viewport,
+};
+
+pub(crate) mod sealed {
+    /// Prevents application crates from implementing the low-level backend contract.
+    pub trait Sealed {}
+
+    /// Prevents application crates from defining backend-specific interop adapters.
+    pub trait InteropSealed {}
+}
+
+/// A complete graphics-device implementation.
+///
+/// This trait is sealed. Concrete Vulkan and Metal implementations live in
+/// `dirk_rhi`; renderer code interacts with them through [`crate::Device`].
+/// Backend-owned representations must remain safe to drop while submitted GPU
+/// work references them, typically by retaining or deferring native deletion.
+pub trait Backend: sealed::Sealed + Sized + 'static {
+    /// Backend-owned buffer representation.
+    type Buffer: 'static;
+    /// Backend-owned image representation.
+    type Image: 'static;
+    /// Backend-owned image-view representation.
+    type ImageView: 'static;
+    /// Backend-owned sampler representation.
+    type Sampler: 'static;
+    /// Backend-owned shader-module representation.
+    type ShaderModule: 'static;
+    /// Backend-owned bind-group-layout representation.
+    type BindGroupLayout: 'static;
+    /// Backend-owned bind-group representation.
+    type BindGroup: 'static;
+    /// Backend-owned pipeline-layout representation.
+    type PipelineLayout: 'static;
+    /// Backend-owned graphics-pipeline representation.
+    type Pipeline: 'static;
+    /// Backend-owned command-pool representation.
+    type CommandPool: 'static;
+    /// Backend-owned command-buffer representation.
+    type CommandBuffer: 'static;
+    /// Backend-owned fence representation.
+    type Fence: 'static;
+    /// Backend-owned semaphore representation.
+    type Semaphore: 'static;
+
+    /// Waits for all submitted device work.
+    fn wait_idle(&self) -> Result<()>;
+    /// Flushes resources queued for deferred destruction.
+    fn flush(&self);
+
+    /// Creates a buffer.
+    fn create_buffer(&self, info: &BufferCreateInfo<'_>) -> Result<Self::Buffer>;
+    /// Writes host-visible buffer bytes.
+    fn write_buffer(&self, buffer: &Self::Buffer, offset: u64, data: &[u8]) -> Result<()>;
+    /// Creates an image.
+    fn create_image(&self, info: &ImageCreateInfo<'_>) -> Result<Self::Image>;
+    /// Creates an image view.
+    fn create_image_view(
+        &self,
+        image: &Self::Image,
+        info: &ImageViewCreateInfo<'_>,
+    ) -> Result<Self::ImageView>;
+    /// Creates a sampler.
+    fn create_sampler(&self, info: &SamplerCreateInfo<'_>) -> Result<Self::Sampler>;
+    /// Creates a shader module.
+    fn create_shader_module(&self, info: &ShaderModuleCreateInfo<'_>)
+    -> Result<Self::ShaderModule>;
+    /// Creates a bind-group layout.
+    fn create_bind_group_layout(
+        &self,
+        info: &BindGroupLayoutCreateInfo<'_>,
+    ) -> Result<Self::BindGroupLayout>;
+    /// Creates a bind group.
+    fn create_bind_group(&self, info: &BindGroupCreateInfo<'_, Self>) -> Result<Self::BindGroup>;
+    /// Creates a pipeline layout.
+    fn create_pipeline_layout(
+        &self,
+        info: &PipelineLayoutCreateInfo<'_, Self>,
+    ) -> Result<Self::PipelineLayout>;
+    /// Creates a graphics pipeline.
+    fn create_graphics_pipeline(
+        &self,
+        info: &GraphicsPipelineCreateInfo<'_, Self>,
+    ) -> Result<Self::Pipeline>;
+
+    /// Creates an explicit command pool.
+    fn create_command_pool(&self, info: &CommandPoolCreateInfo<'_>) -> Result<Self::CommandPool>;
+    /// Resets a command pool.
+    fn reset_command_pool(&self, pool: &Self::CommandPool) -> Result<()>;
+    /// Allocates a command buffer.
+    fn allocate_command_buffer(
+        &self,
+        pool: &Self::CommandPool,
+        level: CommandBufferLevel,
+    ) -> Result<Self::CommandBuffer>;
+    /// Begins command recording.
+    fn begin_command_buffer(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        info: &CommandBufferBeginInfo,
+    ) -> Result<()>;
+    /// Ends command recording.
+    fn end_command_buffer(&self, command_buffer: &mut Self::CommandBuffer) -> Result<()>;
+    /// Resets one command buffer.
+    fn reset_command_buffer(&self, command_buffer: &mut Self::CommandBuffer) -> Result<()>;
+    /// Records memory barriers.
+    fn command_barriers(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        image_barriers: &[ImageBarrier<'_, Self>],
+        buffer_barriers: &[BufferBarrier<'_, Self>],
+    ) -> Result<()>;
+    /// Begins dynamic rendering.
+    fn command_begin_rendering(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        info: &RenderingInfo<'_, Self>,
+    ) -> Result<()>;
+    /// Ends dynamic rendering.
+    fn command_end_rendering(&self, command_buffer: &mut Self::CommandBuffer) -> Result<()>;
+    /// Records a buffer copy.
+    fn command_copy_buffer(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        source: &Self::Buffer,
+        destination: &Self::Buffer,
+        regions: &[BufferCopy],
+    ) -> Result<()>;
+    /// Records a buffer-to-image copy.
+    fn command_copy_buffer_to_image(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        source: &Self::Buffer,
+        destination: &Self::Image,
+        layout: ImageLayout,
+        regions: &[BufferImageCopy],
+    ) -> Result<()>;
+    /// Records an image copy.
+    #[allow(clippy::too_many_arguments)]
+    fn command_copy_image(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        source: &Self::Image,
+        source_layout: ImageLayout,
+        destination: &Self::Image,
+        destination_layout: ImageLayout,
+        regions: &[ImageCopy],
+    ) -> Result<()>;
+    /// Records a filtered image blit.
+    #[allow(clippy::too_many_arguments)]
+    fn command_blit_image(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        source: &Self::Image,
+        source_layout: ImageLayout,
+        destination: &Self::Image,
+        destination_layout: ImageLayout,
+        regions: &[ImageBlit],
+        filter: Filter,
+    ) -> Result<()>;
+    /// Sets a dynamic viewport.
+    fn command_set_viewport(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        viewport: Viewport,
+    ) -> Result<()>;
+    /// Sets a dynamic scissor rectangle.
+    fn command_set_scissor(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        scissor: Rect2D,
+    ) -> Result<()>;
+    /// Binds a graphics pipeline.
+    fn command_bind_graphics_pipeline(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        pipeline: &Self::Pipeline,
+    ) -> Result<()>;
+    /// Binds graphics resource groups.
+    fn command_bind_graphics_groups(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        layout: &Self::PipelineLayout,
+        first_group: u32,
+        groups: &[&crate::BindGroup<Self>],
+        dynamic_offsets: &[u32],
+    ) -> Result<()>;
+    /// Binds vertex buffers.
+    fn command_bind_vertex_buffers(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        first_binding: u32,
+        buffers: &[VertexBufferBinding<'_, Self>],
+    ) -> Result<()>;
+    /// Binds an index buffer.
+    fn command_bind_index_buffer(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        buffer: &Self::Buffer,
+        offset: u64,
+        format: IndexFormat,
+    ) -> Result<()>;
+    /// Records an indexed draw.
+    fn command_draw_indexed(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        draw: DrawIndexed,
+    ) -> Result<()>;
+    /// Records a non-indexed draw.
+    fn command_draw(&self, command_buffer: &mut Self::CommandBuffer, draw: Draw) -> Result<()>;
+
+    /// Creates a fence.
+    fn create_fence(&self, signaled: bool) -> Result<Self::Fence>;
+    /// Waits for a fence.
+    fn wait_for_fence(&self, fence: &Self::Fence, timeout_ns: u64) -> Result<()>;
+    /// Resets a fence.
+    fn reset_fence(&self, fence: &mut Self::Fence) -> Result<()>;
+    /// Creates a semaphore.
+    fn create_semaphore(&self, kind: SemaphoreKind) -> Result<Self::Semaphore>;
+    /// Waits for a timeline semaphore.
+    fn wait_for_semaphore(
+        &self,
+        semaphore: &Self::Semaphore,
+        value: u64,
+        timeout_ns: u64,
+    ) -> Result<()>;
+    /// Returns a timeline semaphore value.
+    fn semaphore_value(&self, semaphore: &Self::Semaphore) -> Result<u64>;
+    /// Submits command buffers to a queue using the required completion fence.
+    fn submit(
+        &self,
+        queue: QueueType,
+        info: &SubmitInfo<'_, Self>,
+        fence: &Fence<Self>,
+    ) -> Result<()>;
+
+    /// Backend-owned surface target supplied by a platform integration.
+    #[cfg(feature = "presentation")]
+    type SurfaceTarget: ?Sized;
+    /// Backend-owned display surface.
+    #[cfg(feature = "presentation")]
+    type Surface: 'static;
+    /// Backend-owned swapchain.
+    #[cfg(feature = "presentation")]
+    type Swapchain: 'static;
+    /// Backend-owned acquired image token.
+    #[cfg(feature = "presentation")]
+    type RenderImage: 'static;
+
+    /// Creates a display surface.
+    #[cfg(feature = "presentation")]
+    fn create_surface(&self, target: &Self::SurfaceTarget) -> Result<Self::Surface>;
+    /// Creates a swapchain.
+    #[cfg(feature = "presentation")]
+    fn create_swapchain(
+        &self,
+        surface: &Self::Surface,
+        info: &crate::SwapchainCreateInfo<'_>,
+    ) -> Result<Self::Swapchain>;
+    /// Recreates a swapchain in place.
+    #[cfg(feature = "presentation")]
+    fn recreate_swapchain(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        surface: &Self::Surface,
+        info: &crate::SwapchainCreateInfo<'_>,
+    ) -> Result<()>;
+    /// Returns the swapchain's selected extent.
+    #[cfg(feature = "presentation")]
+    fn swapchain_extent(swapchain: &Self::Swapchain) -> crate::Extent2D;
+    /// Returns the swapchain's selected image format.
+    #[cfg(feature = "presentation")]
+    fn swapchain_format(swapchain: &Self::Swapchain) -> crate::Format;
+    /// Acquires a swapchain image.
+    #[cfg(feature = "presentation")]
+    fn acquire_render_image(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        timeout_ns: u64,
+        signal: &Self::Semaphore,
+    ) -> Result<Self::RenderImage>;
+    /// Returns the image, view, and index represented by an acquired image.
+    #[cfg(feature = "presentation")]
+    fn render_image_parts(image: &Self::RenderImage) -> (&Self::Image, &Self::ImageView, u32);
+    /// Presents an acquired image.
+    #[cfg(feature = "presentation")]
+    fn present(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        image: Self::RenderImage,
+        waits: &[&Self::Semaphore],
+    ) -> Result<()>;
+    /// Releases an acquired image that will not be presented.
+    #[cfg(feature = "presentation")]
+    fn abandon_render_image(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        image: Self::RenderImage,
+    ) -> Result<()>;
+}
+
+/// Sealed extension point for narrow, backend-specific compatibility adapters.
+///
+/// Concrete backend modules implement this trait for [`crate::Device`] and
+/// return an adapter exposing only the native handles required by integrations
+/// such as `egui-ash-renderer`. Generic RHI APIs remain backend-neutral.
+pub trait BackendInterop: sealed::InteropSealed {
+    /// Borrowed backend-specific adapter.
+    type Adapter<'a>
+    where
+        Self: 'a;
+
+    /// Returns the backend-specific compatibility adapter.
+    fn interop(&self) -> Self::Adapter<'_>;
+}

--- a/crates/dirk_rhi/src/command.rs
+++ b/crates/dirk_rhi/src/command.rs
@@ -1,0 +1,1065 @@
+//! Explicit command pools, command recording, and queue synchronization.
+
+use std::{
+    cell::{Cell, RefCell},
+    fmt,
+    rc::Rc,
+    sync::Arc,
+};
+
+use crate::{
+    AccessTypes, Backend, BindGroup, Buffer, Device, Error, ImageLayout, ImageRef,
+    ImageSubresourceRange, ImageViewRef, Pipeline, PipelineLayout, PipelineStages, QueueType,
+    ResourceState, Result, Semaphore, SemaphoreKind, flags::define_flags,
+};
+
+define_flags! {
+    /// Command-pool behavior hints.
+    pub struct CommandPoolFlags(u8) {
+        /// Buffers allocated from the pool are short-lived.
+        const TRANSIENT = 1 << 0;
+        /// Individual command buffers may be reset.
+        const RESET_COMMAND_BUFFER = 1 << 1;
+    }
+}
+
+define_flags! {
+    /// Command-buffer recording behavior hints.
+    pub struct CommandBufferUsage(u8) {
+        /// The command buffer will be submitted once before being reset.
+        const ONE_TIME_SUBMIT = 1 << 0;
+        /// Allows native backends to record for simultaneous use.
+        ///
+        /// The safe RHI still requires fence completion before resubmission.
+        const SIMULTANEOUS_USE = 1 << 1;
+    }
+}
+
+/// Command-buffer nesting level.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum CommandBufferLevel {
+    /// A directly submitted command buffer.
+    #[default]
+    Primary,
+    /// A command buffer executed by another command buffer.
+    Secondary,
+}
+
+/// Description of an explicit command pool.
+#[derive(Clone, Copy, Debug)]
+pub struct CommandPoolCreateInfo<'a> {
+    /// Queue used by buffers allocated from this pool.
+    pub queue: QueueType,
+    /// Pool behavior flags.
+    pub flags: CommandPoolFlags,
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+/// Description used when beginning command recording.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CommandBufferBeginInfo {
+    /// Recording and submission behavior flags.
+    pub usage: CommandBufferUsage,
+}
+
+/// An explicit command pool.
+pub struct CommandPool<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    pub(crate) raw: Arc<B::CommandPool>,
+    queue: QueueType,
+    state: Rc<CommandPoolState>,
+}
+
+struct CommandPoolState {
+    generation: Cell<u64>,
+    pending_count: Cell<usize>,
+    flags: CommandPoolFlags,
+}
+
+impl<B: Backend> fmt::Debug for CommandPool<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommandPool")
+            .field("queue", &self.queue)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: Backend> CommandPool<B> {
+    /// Returns the queue used by command buffers from this pool.
+    #[must_use]
+    pub const fn queue_type(&self) -> QueueType {
+        self.queue
+    }
+
+    /// Allocates one command buffer from this pool.
+    pub fn allocate(&self, level: CommandBufferLevel) -> Result<CommandBuffer<B>> {
+        let raw = self
+            .backend
+            .allocate_command_buffer(self.raw.as_ref(), level)?;
+        Ok(CommandBuffer {
+            backend: Arc::clone(&self.backend),
+            _pool: Arc::clone(&self.raw),
+            raw,
+            queue: self.queue,
+            pool_state: Rc::clone(&self.state),
+            observed_generation: Cell::new(self.state.generation.get()),
+            state: Cell::new(CommandBufferState::Initial),
+            usage: Cell::new(CommandBufferUsage::empty()),
+            rendering: Cell::new(false),
+            submitted_once: Cell::new(false),
+            pending: RefCell::new(None),
+        })
+    }
+
+    /// Resets all command buffers allocated from the pool.
+    pub fn reset(&mut self) -> Result<()> {
+        if self.state.pending_count.get() != 0 {
+            return Err(Error::InvalidCommandBufferState {
+                expected: "no pending command buffers",
+                actual: "pending",
+            });
+        }
+        self.backend.reset_command_pool(self.raw.as_ref())?;
+        self.state
+            .generation
+            .set(self.state.generation.get().wrapping_add(1));
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CommandBufferState {
+    Initial,
+    Recording,
+    Executable,
+    Pending,
+}
+
+impl CommandBufferState {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Initial => "initial",
+            Self::Recording => "recording",
+            Self::Executable => "executable",
+            Self::Pending => "pending",
+        }
+    }
+}
+
+/// An owned command buffer allocated from an explicit pool.
+pub struct CommandBuffer<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    _pool: Arc<B::CommandPool>,
+    pub(crate) raw: B::CommandBuffer,
+    queue: QueueType,
+    pool_state: Rc<CommandPoolState>,
+    observed_generation: Cell<u64>,
+    state: Cell<CommandBufferState>,
+    usage: Cell<CommandBufferUsage>,
+    rendering: Cell<bool>,
+    submitted_once: Cell<bool>,
+    pending: RefCell<Option<PendingSubmission>>,
+}
+
+struct PendingSubmission {
+    fence: Rc<FenceTracking>,
+    serial: u64,
+}
+
+impl<B: Backend> fmt::Debug for CommandBuffer<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommandBuffer")
+            .field("queue", &self.queue)
+            .field("state", &self.current_state())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: Backend> CommandBuffer<B> {
+    /// Begins command recording.
+    pub fn begin(&mut self, info: &CommandBufferBeginInfo) -> Result<()> {
+        self.require_state(CommandBufferState::Initial, "initial")?;
+        self.backend.begin_command_buffer(&mut self.raw, info)?;
+        self.state.set(CommandBufferState::Recording);
+        self.usage.set(info.usage);
+        self.rendering.set(false);
+        self.submitted_once.set(false);
+        Ok(())
+    }
+
+    /// Finishes command recording and makes the buffer executable.
+    pub fn end(&mut self) -> Result<()> {
+        self.require_recording()?;
+        self.require_outside_rendering("end command buffer")?;
+        self.backend.end_command_buffer(&mut self.raw)?;
+        self.state.set(CommandBufferState::Executable);
+        Ok(())
+    }
+
+    /// Resets the command buffer to its initial state.
+    pub fn reset(&mut self) -> Result<()> {
+        self.synchronize_state();
+        if !self
+            .pool_state
+            .flags
+            .contains(CommandPoolFlags::RESET_COMMAND_BUFFER)
+        {
+            return Err(Error::invalid_descriptor(
+                "command buffer reset",
+                "the command pool must enable RESET_COMMAND_BUFFER",
+            ));
+        }
+        if self.state.get() == CommandBufferState::Pending {
+            return Err(Error::InvalidCommandBufferState {
+                expected: "not pending",
+                actual: "pending",
+            });
+        }
+        self.backend.reset_command_buffer(&mut self.raw)?;
+        self.reset_local_state();
+        Ok(())
+    }
+
+    /// Records image and buffer synchronization barriers.
+    pub fn barriers(
+        &mut self,
+        image_barriers: &[ImageBarrier<'_, B>],
+        buffer_barriers: &[BufferBarrier<'_, B>],
+    ) -> Result<()> {
+        self.require_recording()?;
+        self.require_outside_rendering("barriers")?;
+        for barrier in image_barriers {
+            self.ensure_backend(barrier.image.backend, "barriers")?;
+        }
+        for barrier in buffer_barriers {
+            self.ensure_backend(&barrier.buffer.backend, "barriers")?;
+        }
+        self.backend
+            .command_barriers(&mut self.raw, image_barriers, buffer_barriers)
+    }
+
+    /// Begins a dynamic rendering scope.
+    pub fn begin_rendering(&mut self, info: &RenderingInfo<'_, B>) -> Result<()> {
+        self.require_recording()?;
+        self.require_outside_rendering("begin rendering")?;
+        for attachment in info.color_attachments {
+            self.ensure_backend(attachment.view.backend, "begin_rendering")?;
+            if let Some(resolve) = attachment.resolve_target {
+                self.ensure_backend(resolve.backend, "begin_rendering")?;
+            }
+        }
+        if let Some(attachment) = &info.depth_stencil_attachment {
+            self.ensure_backend(attachment.view.backend, "begin_rendering")?;
+        }
+        self.backend.command_begin_rendering(&mut self.raw, info)?;
+        self.rendering.set(true);
+        Ok(())
+    }
+
+    /// Ends the current dynamic rendering scope.
+    pub fn end_rendering(&mut self) -> Result<()> {
+        self.require_recording()?;
+        self.require_inside_rendering("end rendering")?;
+        self.backend.command_end_rendering(&mut self.raw)?;
+        self.rendering.set(false);
+        Ok(())
+    }
+
+    /// Copies bytes between buffers.
+    pub fn copy_buffer(
+        &mut self,
+        source: &Buffer<B>,
+        destination: &Buffer<B>,
+        regions: &[BufferCopy],
+    ) -> Result<()> {
+        self.require_recording()?;
+        self.require_outside_rendering("copy buffer")?;
+        self.ensure_backend(&source.backend, "copy_buffer")?;
+        self.ensure_backend(&destination.backend, "copy_buffer")?;
+        self.backend.command_copy_buffer(
+            &mut self.raw,
+            source.raw.as_ref(),
+            destination.raw.as_ref(),
+            regions,
+        )
+    }
+
+    /// Copies bytes from a buffer into an image.
+    pub fn copy_buffer_to_image(
+        &mut self,
+        source: &Buffer<B>,
+        destination: ImageRef<'_, B>,
+        layout: ImageLayout,
+        regions: &[BufferImageCopy],
+    ) -> Result<()> {
+        self.require_recording()?;
+        self.require_outside_rendering("copy buffer to image")?;
+        self.ensure_backend(&source.backend, "copy_buffer_to_image")?;
+        self.ensure_backend(destination.backend, "copy_buffer_to_image")?;
+        self.backend.command_copy_buffer_to_image(
+            &mut self.raw,
+            source.raw.as_ref(),
+            destination.raw,
+            layout,
+            regions,
+        )
+    }
+
+    /// Copies texels between images.
+    pub fn copy_image(
+        &mut self,
+        source: ImageRef<'_, B>,
+        source_layout: ImageLayout,
+        destination: ImageRef<'_, B>,
+        destination_layout: ImageLayout,
+        regions: &[ImageCopy],
+    ) -> Result<()> {
+        self.require_recording()?;
+        self.require_outside_rendering("copy image")?;
+        self.ensure_backend(source.backend, "copy_image")?;
+        self.ensure_backend(destination.backend, "copy_image")?;
+        self.backend.command_copy_image(
+            &mut self.raw,
+            source.raw,
+            source_layout,
+            destination.raw,
+            destination_layout,
+            regions,
+        )
+    }
+
+    /// Blits and optionally filters texels between images.
+    pub fn blit_image(
+        &mut self,
+        source: ImageRef<'_, B>,
+        source_layout: ImageLayout,
+        destination: ImageRef<'_, B>,
+        destination_layout: ImageLayout,
+        regions: &[ImageBlit],
+        filter: crate::Filter,
+    ) -> Result<()> {
+        self.require_recording()?;
+        self.require_outside_rendering("blit image")?;
+        self.ensure_backend(source.backend, "blit_image")?;
+        self.ensure_backend(destination.backend, "blit_image")?;
+        self.backend.command_blit_image(
+            &mut self.raw,
+            source.raw,
+            source_layout,
+            destination.raw,
+            destination_layout,
+            regions,
+            filter,
+        )
+    }
+
+    /// Sets the dynamic viewport.
+    pub fn set_viewport(&mut self, viewport: Viewport) -> Result<()> {
+        self.require_recording()?;
+        self.backend.command_set_viewport(&mut self.raw, viewport)
+    }
+
+    /// Sets the dynamic scissor rectangle.
+    pub fn set_scissor(&mut self, scissor: Rect2D) -> Result<()> {
+        self.require_recording()?;
+        self.backend.command_set_scissor(&mut self.raw, scissor)
+    }
+
+    /// Binds a graphics pipeline.
+    pub fn bind_graphics_pipeline(&mut self, pipeline: &Pipeline<B>) -> Result<()> {
+        self.require_recording()?;
+        self.ensure_backend(&pipeline.backend, "bind_graphics_pipeline")?;
+        self.backend
+            .command_bind_graphics_pipeline(&mut self.raw, &pipeline.raw)
+    }
+
+    /// Binds resource groups to a graphics pipeline layout.
+    pub fn bind_graphics_groups(
+        &mut self,
+        layout: &PipelineLayout<B>,
+        first_group: u32,
+        groups: &[&BindGroup<B>],
+        dynamic_offsets: &[u32],
+    ) -> Result<()> {
+        self.require_recording()?;
+        self.ensure_backend(&layout.backend, "bind_graphics_groups")?;
+        for group in groups {
+            self.ensure_backend(&group.backend, "bind_graphics_groups")?;
+        }
+        self.backend.command_bind_graphics_groups(
+            &mut self.raw,
+            layout.raw.as_ref(),
+            first_group,
+            groups,
+            dynamic_offsets,
+        )
+    }
+
+    /// Binds vertex buffers beginning at `first_binding`.
+    pub fn bind_vertex_buffers(
+        &mut self,
+        first_binding: u32,
+        buffers: &[VertexBufferBinding<'_, B>],
+    ) -> Result<()> {
+        self.require_recording()?;
+        for binding in buffers {
+            self.ensure_backend(&binding.buffer.backend, "bind_vertex_buffers")?;
+        }
+        self.backend
+            .command_bind_vertex_buffers(&mut self.raw, first_binding, buffers)
+    }
+
+    /// Binds an index buffer.
+    pub fn bind_index_buffer(
+        &mut self,
+        buffer: &Buffer<B>,
+        offset: u64,
+        format: IndexFormat,
+    ) -> Result<()> {
+        self.require_recording()?;
+        self.ensure_backend(&buffer.backend, "bind_index_buffer")?;
+        self.backend
+            .command_bind_index_buffer(&mut self.raw, buffer.raw.as_ref(), offset, format)
+    }
+
+    /// Records an indexed draw.
+    pub fn draw_indexed(&mut self, draw: DrawIndexed) -> Result<()> {
+        self.require_recording()?;
+        self.require_inside_rendering("draw indexed")?;
+        self.backend.command_draw_indexed(&mut self.raw, draw)
+    }
+
+    /// Records a non-indexed draw.
+    pub fn draw(&mut self, draw: Draw) -> Result<()> {
+        self.require_recording()?;
+        self.require_inside_rendering("draw")?;
+        self.backend.command_draw(&mut self.raw, draw)
+    }
+
+    fn require_recording(&self) -> Result<()> {
+        self.require_state(CommandBufferState::Recording, "recording")
+    }
+
+    fn require_state(&self, state: CommandBufferState, expected: &'static str) -> Result<()> {
+        let actual = self.current_state();
+        if actual == state {
+            Ok(())
+        } else {
+            Err(Error::InvalidCommandBufferState {
+                expected,
+                actual: actual.name(),
+            })
+        }
+    }
+
+    fn require_inside_rendering(&self, operation: &'static str) -> Result<()> {
+        if self.rendering.get() {
+            Ok(())
+        } else {
+            Err(Error::InvalidCommandBufferState {
+                expected: operation,
+                actual: "recording outside rendering",
+            })
+        }
+    }
+
+    fn require_outside_rendering(&self, operation: &'static str) -> Result<()> {
+        if self.rendering.get() {
+            Err(Error::InvalidCommandBufferState {
+                expected: operation,
+                actual: "recording inside rendering",
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn current_state(&self) -> CommandBufferState {
+        self.synchronize_state();
+        self.state.get()
+    }
+
+    fn synchronize_state(&self) {
+        let generation = self.pool_state.generation.get();
+        if self.observed_generation.get() != generation {
+            self.observed_generation.set(generation);
+            self.reset_local_state();
+            return;
+        }
+
+        let completed = self
+            .pending
+            .borrow()
+            .as_ref()
+            .is_some_and(|pending| pending.fence.completed_serial.get() >= pending.serial);
+        if completed {
+            self.pending.borrow_mut().take();
+            self.state.set(CommandBufferState::Executable);
+        }
+    }
+
+    fn reset_local_state(&self) {
+        self.state.set(CommandBufferState::Initial);
+        self.usage.set(CommandBufferUsage::empty());
+        self.rendering.set(false);
+        self.submitted_once.set(false);
+        self.pending.borrow_mut().take();
+    }
+
+    fn ensure_backend(&self, backend: &Arc<B>, operation: &'static str) -> Result<()> {
+        if Arc::ptr_eq(&self.backend, backend) {
+            Ok(())
+        } else {
+            Err(Error::DeviceMismatch { operation })
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FenceState {
+    Unsignaled,
+    Pending,
+    Signaled,
+}
+
+struct FenceTracking {
+    state: Cell<FenceState>,
+    submitted_serial: Cell<u64>,
+    completed_serial: Cell<u64>,
+    pending_pools: RefCell<Vec<Rc<CommandPoolState>>>,
+}
+
+impl FenceTracking {
+    fn begin_submission(&self) -> u64 {
+        let serial = self.submitted_serial.get().wrapping_add(1);
+        self.submitted_serial.set(serial);
+        self.state.set(FenceState::Pending);
+        serial
+    }
+
+    fn complete(&self) {
+        self.completed_serial.set(self.submitted_serial.get());
+        self.state.set(FenceState::Signaled);
+        for pool in self.pending_pools.borrow_mut().drain(..) {
+            pool.pending_count
+                .set(pool.pending_count.get().saturating_sub(1));
+        }
+    }
+}
+
+/// An owned host-visible completion fence.
+pub struct Fence<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    pub(crate) raw: B::Fence,
+    tracking: Rc<FenceTracking>,
+}
+
+impl<B: Backend> Fence<B> {
+    fn new(backend: Arc<B>, raw: B::Fence, signaled: bool) -> Self {
+        Self {
+            backend,
+            raw,
+            tracking: Rc::new(FenceTracking {
+                state: Cell::new(if signaled {
+                    FenceState::Signaled
+                } else {
+                    FenceState::Unsignaled
+                }),
+                submitted_serial: Cell::new(0),
+                completed_serial: Cell::new(0),
+                pending_pools: RefCell::new(Vec::new()),
+            }),
+        }
+    }
+}
+
+impl<B: Backend> fmt::Debug for Fence<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Fence")
+            .field("state", &self.tracking.state.get())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: Backend> Device<B> {
+    /// Creates an explicit command pool.
+    pub fn create_command_pool(&self, info: &CommandPoolCreateInfo<'_>) -> Result<CommandPool<B>> {
+        Ok(CommandPool {
+            backend: Arc::clone(&self.backend),
+            raw: Arc::new(self.backend.create_command_pool(info)?),
+            queue: info.queue,
+            state: Rc::new(CommandPoolState {
+                generation: Cell::new(0),
+                pending_count: Cell::new(0),
+                flags: info.flags,
+            }),
+        })
+    }
+
+    /// Creates a fence in the requested initial state.
+    pub fn create_fence(&self, signaled: bool) -> Result<Fence<B>> {
+        Ok(Fence::new(
+            Arc::clone(&self.backend),
+            self.backend.create_fence(signaled)?,
+            signaled,
+        ))
+    }
+
+    /// Waits for a fence and releases command buffers tracked by its submission.
+    pub fn wait_for_fence(&self, fence: &Fence<B>, timeout_ns: u64) -> Result<()> {
+        self.ensure_resource(&fence.backend, "wait_for_fence")?;
+        self.backend.wait_for_fence(&fence.raw, timeout_ns)?;
+        fence.tracking.complete();
+        Ok(())
+    }
+
+    /// Resets a fence to the unsignaled state.
+    pub fn reset_fence(&self, fence: &mut Fence<B>) -> Result<()> {
+        self.ensure_resource(&fence.backend, "reset_fence")?;
+        if fence.tracking.state.get() == FenceState::Pending {
+            return Err(Error::invalid_descriptor(
+                "fence reset",
+                "a pending fence must be waited before reset",
+            ));
+        }
+        self.backend.reset_fence(&mut fence.raw)?;
+        fence.tracking.state.set(FenceState::Unsignaled);
+        Ok(())
+    }
+
+    /// Creates a binary or timeline semaphore.
+    pub fn create_semaphore(&self, kind: SemaphoreKind) -> Result<Semaphore<B>> {
+        Ok(Semaphore::new(
+            Arc::clone(&self.backend),
+            self.backend.create_semaphore(kind)?,
+            kind,
+        ))
+    }
+
+    /// Waits until a timeline semaphore reaches `value`.
+    pub fn wait_for_semaphore(
+        &self,
+        semaphore: &Semaphore<B>,
+        value: u64,
+        timeout_ns: u64,
+    ) -> Result<()> {
+        self.ensure_resource(&semaphore.backend, "wait_for_semaphore")?;
+        if semaphore.kind() == SemaphoreKind::Binary {
+            return Err(Error::invalid_descriptor(
+                "semaphore wait",
+                "host waits require a timeline semaphore",
+            ));
+        }
+        self.backend
+            .wait_for_semaphore(&semaphore.raw, value, timeout_ns)
+    }
+
+    /// Returns a timeline semaphore's current value.
+    pub fn semaphore_value(&self, semaphore: &Semaphore<B>) -> Result<u64> {
+        self.ensure_resource(&semaphore.backend, "semaphore_value")?;
+        if semaphore.kind() == SemaphoreKind::Binary {
+            return Err(Error::invalid_descriptor(
+                "semaphore value",
+                "binary semaphores do not have counter values",
+            ));
+        }
+        self.backend.semaphore_value(&semaphore.raw)
+    }
+
+    /// Submits executable command buffers and tracks them until `fence` is waited.
+    pub fn submit(
+        &self,
+        queue: QueueType,
+        info: &SubmitInfo<'_, B>,
+        fence: &Fence<B>,
+    ) -> Result<()> {
+        for wait in info.waits {
+            self.ensure_resource(&wait.semaphore.backend, "submit")?;
+            wait.validate()?;
+        }
+        for (index, command_buffer) in info.command_buffers.iter().enumerate() {
+            if info.command_buffers[..index]
+                .iter()
+                .any(|previous| std::ptr::eq(*previous, *command_buffer))
+            {
+                return Err(Error::invalid_descriptor(
+                    "queue submission",
+                    "a command buffer may appear only once in a submission",
+                ));
+            }
+            self.ensure_resource(&command_buffer.backend, "submit")?;
+            command_buffer.require_state(CommandBufferState::Executable, "executable")?;
+            if command_buffer
+                .usage
+                .get()
+                .contains(CommandBufferUsage::ONE_TIME_SUBMIT)
+                && command_buffer.submitted_once.get()
+            {
+                return Err(Error::invalid_descriptor(
+                    "queue submission",
+                    "a ONE_TIME_SUBMIT command buffer must be reset before reuse",
+                ));
+            }
+            if command_buffer.queue != queue {
+                return Err(Error::invalid_descriptor(
+                    "queue submission",
+                    "command buffer was allocated for a different queue type",
+                ));
+            }
+        }
+        for signal in info.signals {
+            self.ensure_resource(&signal.semaphore.backend, "submit")?;
+            signal.validate()?;
+        }
+        self.ensure_resource(&fence.backend, "submit")?;
+        if fence.tracking.state.get() != FenceState::Unsignaled {
+            return Err(Error::invalid_descriptor(
+                "queue submission",
+                "the submission fence must be unsignaled and not pending",
+            ));
+        }
+        self.backend.submit(queue, info, fence)?;
+
+        let serial = fence.tracking.begin_submission();
+        for command_buffer in info.command_buffers {
+            let pending_count = command_buffer.pool_state.pending_count.get();
+            command_buffer
+                .pool_state
+                .pending_count
+                .set(pending_count + 1);
+            fence
+                .tracking
+                .pending_pools
+                .borrow_mut()
+                .push(Rc::clone(&command_buffer.pool_state));
+            command_buffer.state.set(CommandBufferState::Pending);
+            command_buffer.submitted_once.set(true);
+            command_buffer
+                .pending
+                .borrow_mut()
+                .replace(PendingSubmission {
+                    fence: Rc::clone(&fence.tracking),
+                    serial,
+                });
+        }
+        Ok(())
+    }
+}
+
+/// Offset in three-dimensional image coordinates.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Offset3D {
+    /// X coordinate.
+    pub x: i32,
+    /// Y coordinate.
+    pub y: i32,
+    /// Z coordinate.
+    pub z: i32,
+}
+
+/// Two-dimensional render rectangle.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Rect2D {
+    /// X offset in pixels.
+    pub x: i32,
+    /// Y offset in pixels.
+    pub y: i32,
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+}
+
+/// Dynamic viewport state.
+#[derive(Clone, Copy, Debug)]
+pub struct Viewport {
+    /// Left coordinate.
+    pub x: f32,
+    /// Top coordinate.
+    pub y: f32,
+    /// Width.
+    pub width: f32,
+    /// Height.
+    pub height: f32,
+    /// Minimum depth value.
+    pub min_depth: f32,
+    /// Maximum depth value.
+    pub max_depth: f32,
+}
+
+/// One buffer-to-buffer copy region.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BufferCopy {
+    /// Source byte offset.
+    pub source_offset: u64,
+    /// Destination byte offset.
+    pub destination_offset: u64,
+    /// Number of bytes copied.
+    pub size: u64,
+}
+
+/// Image layers addressed by a copy operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ImageSubresourceLayers {
+    /// Selected aspect.
+    pub aspects: crate::ImageAspects,
+    /// Selected mip level.
+    pub mip_level: u32,
+    /// First array layer.
+    pub base_array_layer: u32,
+    /// Number of array layers.
+    pub array_layer_count: u32,
+}
+
+/// One buffer-to-image copy region.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BufferImageCopy {
+    /// Source byte offset.
+    pub buffer_offset: u64,
+    /// Image subresources copied.
+    pub image_subresource: ImageSubresourceLayers,
+    /// Destination image offset.
+    pub image_offset: Offset3D,
+    /// Copied image extent.
+    pub image_extent: crate::Extent3D,
+}
+
+/// One image-to-image copy region.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ImageCopy {
+    /// Source image subresources.
+    pub source_subresource: ImageSubresourceLayers,
+    /// Source image offset.
+    pub source_offset: Offset3D,
+    /// Destination image subresources.
+    pub destination_subresource: ImageSubresourceLayers,
+    /// Destination image offset.
+    pub destination_offset: Offset3D,
+    /// Copied extent.
+    pub extent: crate::Extent3D,
+}
+
+/// One filtered image blit region.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ImageBlit {
+    /// Source image subresources.
+    pub source_subresource: ImageSubresourceLayers,
+    /// Opposite source-region corners.
+    pub source_offsets: [Offset3D; 2],
+    /// Destination image subresources.
+    pub destination_subresource: ImageSubresourceLayers,
+    /// Opposite destination-region corners.
+    pub destination_offsets: [Offset3D; 2],
+}
+
+/// An image transition and memory dependency.
+#[derive(Clone, Copy, Debug)]
+pub struct ImageBarrier<'a, B: Backend> {
+    /// Image being synchronized.
+    pub image: ImageRef<'a, B>,
+    /// Selected image subresources.
+    pub range: ImageSubresourceRange,
+    /// State before the barrier.
+    pub before: ResourceState,
+    /// State after the barrier.
+    pub after: ResourceState,
+}
+
+/// A buffer memory dependency.
+#[derive(Clone, Copy, Debug)]
+pub struct BufferBarrier<'a, B: Backend> {
+    /// Buffer being synchronized.
+    pub buffer: &'a Buffer<B>,
+    /// First synchronized byte.
+    pub offset: u64,
+    /// Number of synchronized bytes.
+    pub size: u64,
+    /// Source pipeline stages.
+    pub source_stages: PipelineStages,
+    /// Source accesses.
+    pub source_access: AccessTypes,
+    /// Destination pipeline stages.
+    pub destination_stages: PipelineStages,
+    /// Destination accesses.
+    pub destination_access: AccessTypes,
+}
+
+/// Attachment load behavior.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LoadOperation<T> {
+    /// Preserve existing contents.
+    Load,
+    /// Clear to the supplied value.
+    Clear(T),
+    /// Existing contents may be discarded.
+    DontCare,
+}
+
+/// Attachment store behavior.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum StoreOperation {
+    /// Preserve rendered contents.
+    Store,
+    /// Rendered contents may be discarded.
+    DontCare,
+}
+
+/// Depth and stencil clear value.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DepthStencilValue {
+    /// Depth clear value.
+    pub depth: f32,
+    /// Stencil clear value.
+    pub stencil: u32,
+}
+
+/// One color rendering attachment.
+#[derive(Clone, Copy, Debug)]
+pub struct ColorAttachment<'a, B: Backend> {
+    /// Attachment image view.
+    pub view: ImageViewRef<'a, B>,
+    /// Optional multisample resolve target.
+    pub resolve_target: Option<ImageViewRef<'a, B>>,
+    /// Load behavior and clear color.
+    pub load: LoadOperation<[f32; 4]>,
+    /// Store behavior.
+    pub store: StoreOperation,
+}
+
+/// One depth/stencil rendering attachment.
+#[derive(Clone, Copy, Debug)]
+pub struct DepthStencilAttachment<'a, B: Backend> {
+    /// Attachment image view.
+    pub view: ImageViewRef<'a, B>,
+    /// Load behavior and clear value.
+    pub load: LoadOperation<DepthStencilValue>,
+    /// Store behavior.
+    pub store: StoreOperation,
+}
+
+/// Dynamic rendering scope description.
+#[derive(Clone, Copy, Debug)]
+pub struct RenderingInfo<'a, B: Backend> {
+    /// Render area.
+    pub render_area: Rect2D,
+    /// Number of rendered array layers.
+    pub layer_count: u32,
+    /// Color attachments in shader output order.
+    pub color_attachments: &'a [ColorAttachment<'a, B>],
+    /// Optional depth/stencil attachment.
+    pub depth_stencil_attachment: Option<DepthStencilAttachment<'a, B>>,
+}
+
+/// One bound vertex buffer and byte offset.
+#[derive(Clone, Copy, Debug)]
+pub struct VertexBufferBinding<'a, B: Backend> {
+    /// Bound buffer.
+    pub buffer: &'a Buffer<B>,
+    /// First vertex-data byte.
+    pub offset: u64,
+}
+
+/// Index element format.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum IndexFormat {
+    /// Unsigned 16-bit index.
+    Uint16,
+    /// Unsigned 32-bit index.
+    Uint32,
+}
+
+/// Parameters for one indexed draw.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DrawIndexed {
+    /// First index element.
+    pub first_index: u32,
+    /// Number of index elements.
+    pub index_count: u32,
+    /// Value added to each index before vertex lookup.
+    pub vertex_offset: i32,
+    /// First instance.
+    pub first_instance: u32,
+    /// Number of instances.
+    pub instance_count: u32,
+}
+
+/// Parameters for one non-indexed draw.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Draw {
+    /// First vertex.
+    pub first_vertex: u32,
+    /// Number of vertices.
+    pub vertex_count: u32,
+    /// First instance.
+    pub first_instance: u32,
+    /// Number of instances.
+    pub instance_count: u32,
+}
+
+/// A semaphore dependency before queue work begins.
+#[derive(Clone, Copy, Debug)]
+pub struct SemaphoreWait<'a, B: Backend> {
+    /// Semaphore to wait on.
+    pub semaphore: &'a Semaphore<B>,
+    /// Timeline value, or `None` for a binary semaphore.
+    pub value: Option<u64>,
+    /// Pipeline stages blocked by the wait.
+    pub stages: PipelineStages,
+}
+
+impl<B: Backend> SemaphoreWait<'_, B> {
+    fn validate(&self) -> Result<()> {
+        if self.stages.is_empty() {
+            return Err(Error::invalid_descriptor(
+                "semaphore wait",
+                "at least one destination stage must be selected",
+            ));
+        }
+        validate_semaphore_value(self.semaphore.kind(), self.value)
+    }
+}
+
+/// A semaphore signaled after queue work completes.
+#[derive(Clone, Copy, Debug)]
+pub struct SemaphoreSignal<'a, B: Backend> {
+    /// Semaphore to signal.
+    pub semaphore: &'a Semaphore<B>,
+    /// Timeline value, or `None` for a binary semaphore.
+    pub value: Option<u64>,
+}
+
+impl<B: Backend> SemaphoreSignal<'_, B> {
+    fn validate(&self) -> Result<()> {
+        validate_semaphore_value(self.semaphore.kind(), self.value)
+    }
+}
+
+fn validate_semaphore_value(kind: SemaphoreKind, value: Option<u64>) -> Result<()> {
+    let valid = matches!(
+        (kind, value),
+        (SemaphoreKind::Binary, None) | (SemaphoreKind::Timeline { .. }, Some(_))
+    );
+    if valid {
+        Ok(())
+    } else {
+        Err(Error::invalid_descriptor(
+            "semaphore operation",
+            "binary semaphores omit values and timeline semaphores require them",
+        ))
+    }
+}
+
+/// One queue submission batch.
+#[derive(Clone, Copy, Debug)]
+pub struct SubmitInfo<'a, B: Backend> {
+    /// Semaphores waited before execution.
+    pub waits: &'a [SemaphoreWait<'a, B>],
+    /// Executable command buffers in submission order.
+    pub command_buffers: &'a [&'a CommandBuffer<B>],
+    /// Semaphores signaled after execution.
+    pub signals: &'a [SemaphoreSignal<'a, B>],
+}

--- a/crates/dirk_rhi/src/error.rs
+++ b/crates/dirk_rhi/src/error.rs
@@ -1,0 +1,75 @@
+//! Errors returned by the RHI contract.
+
+use std::{error, fmt};
+
+/// A result returned by an RHI operation.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// An error reported by descriptor validation or a concrete backend.
+#[derive(Debug)]
+pub enum Error {
+    /// A descriptor contains an invalid combination of values.
+    InvalidDescriptor {
+        /// The kind of descriptor that failed validation.
+        descriptor: &'static str,
+        /// A concise explanation of the invalid value.
+        reason: &'static str,
+    },
+    /// A resource belongs to a different device.
+    DeviceMismatch {
+        /// The operation that received the mismatched resource.
+        operation: &'static str,
+    },
+    /// A command buffer operation is invalid in its current state.
+    InvalidCommandBufferState {
+        /// The state required by the operation.
+        expected: &'static str,
+        /// The command buffer's actual state.
+        actual: &'static str,
+    },
+    /// A concrete graphics backend reported an error.
+    Backend(Box<dyn error::Error + Send + Sync>),
+}
+
+impl Error {
+    /// Wraps an error reported by a concrete backend.
+    pub fn backend(error: impl error::Error + Send + Sync + 'static) -> Self {
+        Self::Backend(Box::new(error))
+    }
+
+    pub(crate) const fn invalid_descriptor(descriptor: &'static str, reason: &'static str) -> Self {
+        Self::InvalidDescriptor { descriptor, reason }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidDescriptor { descriptor, reason } => {
+                write!(formatter, "invalid {descriptor} descriptor: {reason}")
+            }
+            Self::DeviceMismatch { operation } => {
+                write!(
+                    formatter,
+                    "{operation} received a resource from another device"
+                )
+            }
+            Self::InvalidCommandBufferState { expected, actual } => write!(
+                formatter,
+                "command buffer must be {expected}, but is {actual}"
+            ),
+            Self::Backend(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Backend(error) => Some(error.as_ref()),
+            Self::InvalidDescriptor { .. }
+            | Self::DeviceMismatch { .. }
+            | Self::InvalidCommandBufferState { .. } => None,
+        }
+    }
+}

--- a/crates/dirk_rhi/src/flags.rs
+++ b/crates/dirk_rhi/src/flags.rs
@@ -1,0 +1,71 @@
+macro_rules! define_flags {
+    (
+        $(#[$meta:meta])*
+        $visibility:vis struct $name:ident($bits:ty) {
+            $($(#[$constant_meta:meta])* const $constant:ident = $value:expr;)+
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+        $visibility struct $name($bits);
+
+        impl $name {
+            $($(#[$constant_meta])*
+            $visibility const $constant: Self = Self($value);)+
+
+            /// Returns a value with no flags set.
+            #[must_use]
+            $visibility const fn empty() -> Self {
+                Self(0)
+            }
+
+            /// Returns the raw bits represented by this value.
+            #[must_use]
+            $visibility const fn bits(self) -> $bits {
+                self.0
+            }
+
+            /// Returns whether no flags are set.
+            #[must_use]
+            $visibility const fn is_empty(self) -> bool {
+                self.0 == 0
+            }
+
+            /// Returns whether every flag in `other` is present.
+            #[must_use]
+            $visibility const fn contains(self, other: Self) -> bool {
+                self.0 & other.0 == other.0
+            }
+
+            /// Returns whether any flag in `other` is present.
+            #[must_use]
+            $visibility const fn intersects(self, other: Self) -> bool {
+                self.0 & other.0 != 0
+            }
+        }
+
+        impl std::ops::BitOr for $name {
+            type Output = Self;
+
+            fn bitor(self, rhs: Self) -> Self::Output {
+                Self(self.0 | rhs.0)
+            }
+        }
+
+        impl std::ops::BitOrAssign for $name {
+            fn bitor_assign(&mut self, rhs: Self) {
+                self.0 |= rhs.0;
+            }
+        }
+
+        impl std::ops::BitAnd for $name {
+            type Output = Self;
+
+            fn bitand(self, rhs: Self) -> Self::Output {
+                Self(self.0 & rhs.0)
+            }
+        }
+    };
+}
+
+pub(crate) use define_flags;

--- a/crates/dirk_rhi/src/lib.rs
+++ b/crates/dirk_rhi/src/lib.rs
@@ -1,0 +1,25 @@
+//! Backend-neutral GPU resources and command recording for `DirkEngine`.
+//!
+//! The renderer owns frame scheduling and its render graph. This crate owns
+//! the lower-level contract implemented by concrete graphics backends.
+
+#![allow(clippy::missing_errors_doc)]
+
+mod backend;
+mod command;
+mod error;
+mod flags;
+#[cfg(feature = "presentation")]
+mod presentation;
+mod resource;
+#[cfg(test)]
+mod test_backend;
+mod types;
+
+pub use backend::{Backend, BackendInterop};
+pub use command::*;
+pub use error::{Error, Result};
+#[cfg(feature = "presentation")]
+pub use presentation::{PresentMode, RenderImage, Surface, Swapchain, SwapchainCreateInfo};
+pub use resource::*;
+pub use types::*;

--- a/crates/dirk_rhi/src/presentation.rs
+++ b/crates/dirk_rhi/src/presentation.rs
@@ -1,0 +1,289 @@
+//! Optional display-surface and swapchain abstractions.
+
+use std::{
+    cell::{Cell, RefCell},
+    fmt,
+    sync::Arc,
+};
+
+use crate::{
+    Backend, Device, Error, Extent2D, Format, ImageRef, ImageUsage, ImageViewRef, Result,
+    Semaphore, SemaphoreKind,
+};
+
+/// Preferred display scheduling mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum PresentMode {
+    /// Wait for the display refresh and avoid tearing.
+    #[default]
+    Fifo,
+    /// Replace pending frames while waiting for refresh when supported.
+    Mailbox,
+    /// Present immediately when supported.
+    Immediate,
+}
+
+/// Swapchain configuration shared by concrete backends.
+#[derive(Clone, Copy, Debug)]
+pub struct SwapchainCreateInfo<'a> {
+    /// Requested drawable extent.
+    pub extent: Extent2D,
+    /// Required image usages.
+    pub image_usage: ImageUsage,
+    /// Preferred image formats in priority order.
+    pub preferred_formats: &'a [Format],
+    /// Preferred display scheduling mode.
+    pub present_mode: PresentMode,
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+impl SwapchainCreateInfo<'_> {
+    fn validate(&self) -> Result<()> {
+        if self.extent.is_empty() {
+            return Err(Error::invalid_descriptor(
+                "swapchain",
+                "requested extent must be non-zero",
+            ));
+        }
+        if self.image_usage.is_empty() {
+            return Err(Error::invalid_descriptor(
+                "swapchain",
+                "at least one image usage must be selected",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// An owned platform display surface.
+pub struct Surface<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    pub(crate) raw: Arc<B::Surface>,
+}
+
+impl<B: Backend> Clone for Surface<B> {
+    fn clone(&self) -> Self {
+        Self {
+            backend: Arc::clone(&self.backend),
+            raw: Arc::clone(&self.raw),
+        }
+    }
+}
+
+impl<B: Backend> fmt::Debug for Surface<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("Surface").finish_non_exhaustive()
+    }
+}
+
+struct SwapchainState<B: Backend> {
+    raw: RefCell<B::Swapchain>,
+    surface: Surface<B>,
+    acquired_count: Cell<usize>,
+}
+
+/// An owned presentation swapchain.
+pub struct Swapchain<B: Backend> {
+    backend: Arc<B>,
+    state: Arc<SwapchainState<B>>,
+}
+
+impl<B: Backend> fmt::Debug for Swapchain<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Swapchain")
+            .field("extent", &self.extent())
+            .field("format", &self.format())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: Backend> Device<B> {
+    /// Creates a surface from the concrete backend's platform target.
+    pub fn create_surface(&self, target: &B::SurfaceTarget) -> Result<Surface<B>> {
+        Ok(Surface {
+            backend: Arc::clone(&self.backend),
+            raw: Arc::new(self.backend.create_surface(target)?),
+        })
+    }
+
+    /// Creates a swapchain for a surface.
+    pub fn create_swapchain(
+        &self,
+        surface: &Surface<B>,
+        info: &SwapchainCreateInfo<'_>,
+    ) -> Result<Swapchain<B>> {
+        self.ensure_resource(&surface.backend, "create_swapchain")?;
+        info.validate()?;
+        let raw = self.backend.create_swapchain(surface.raw.as_ref(), info)?;
+        Ok(Swapchain {
+            backend: Arc::clone(&self.backend),
+            state: Arc::new(SwapchainState {
+                raw: RefCell::new(raw),
+                surface: surface.clone(),
+                acquired_count: Cell::new(0),
+            }),
+        })
+    }
+}
+
+impl<B: Backend> Swapchain<B> {
+    /// Returns the selected drawable extent.
+    #[must_use]
+    pub fn extent(&self) -> Extent2D {
+        B::swapchain_extent(&self.state.raw.borrow())
+    }
+
+    /// Returns the selected image format.
+    #[must_use]
+    pub fn format(&self) -> Format {
+        B::swapchain_format(&self.state.raw.borrow())
+    }
+
+    /// Recreates this swapchain for changed surface configuration.
+    pub fn recreate(&mut self, info: &SwapchainCreateInfo<'_>) -> Result<()> {
+        info.validate()?;
+        if self.state.acquired_count.get() != 0 {
+            return Err(Error::invalid_descriptor(
+                "swapchain recreation",
+                "all acquired images must be presented or abandoned first",
+            ));
+        }
+        let mut raw = self.state.raw.borrow_mut();
+        self.backend
+            .recreate_swapchain(&mut raw, self.state.surface.raw.as_ref(), info)
+    }
+
+    /// Acquires the next renderable swapchain image.
+    pub fn acquire_next_image(
+        &self,
+        timeout_ns: u64,
+        signal: &Semaphore<B>,
+    ) -> Result<RenderImage<B>> {
+        if !Arc::ptr_eq(&self.backend, &signal.backend) {
+            return Err(Error::DeviceMismatch {
+                operation: "acquire_next_image",
+            });
+        }
+        if signal.kind() != SemaphoreKind::Binary {
+            return Err(Error::invalid_descriptor(
+                "swapchain acquisition",
+                "image acquisition requires a binary semaphore",
+            ));
+        }
+        let raw = self.backend.acquire_render_image(
+            &mut self.state.raw.borrow_mut(),
+            timeout_ns,
+            &signal.raw,
+        )?;
+        self.state
+            .acquired_count
+            .set(self.state.acquired_count.get() + 1);
+        Ok(RenderImage {
+            backend: Arc::clone(&self.backend),
+            swapchain: Arc::clone(&self.state),
+            raw: Some(raw),
+        })
+    }
+}
+
+/// An acquired swapchain image that must be presented or abandoned.
+#[must_use = "an acquired image must be presented or abandoned"]
+pub struct RenderImage<B: Backend> {
+    backend: Arc<B>,
+    swapchain: Arc<SwapchainState<B>>,
+    raw: Option<B::RenderImage>,
+}
+
+impl<B: Backend> fmt::Debug for RenderImage<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RenderImage")
+            .field("index", &self.index())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: Backend> RenderImage<B> {
+    /// Returns the acquired image index.
+    #[must_use]
+    pub fn index(&self) -> u32 {
+        B::render_image_parts(self.raw()).2
+    }
+
+    /// Returns the acquired image for barriers and copy operations.
+    #[must_use]
+    pub fn image(&self) -> ImageRef<'_, B> {
+        ImageRef {
+            backend: &self.backend,
+            raw: B::render_image_parts(self.raw()).0,
+        }
+    }
+
+    /// Returns the acquired image view for rendering attachments.
+    #[must_use]
+    pub fn view(&self) -> ImageViewRef<'_, B> {
+        ImageViewRef {
+            backend: &self.backend,
+            raw: B::render_image_parts(self.raw()).1,
+        }
+    }
+
+    /// Presents the acquired image after waiting on binary semaphores.
+    pub fn present(mut self, waits: &[&Semaphore<B>]) -> Result<()> {
+        for wait in waits {
+            if !Arc::ptr_eq(&self.backend, &wait.backend) {
+                return Err(Error::DeviceMismatch {
+                    operation: "present",
+                });
+            }
+            if wait.kind() != SemaphoreKind::Binary {
+                return Err(Error::invalid_descriptor(
+                    "presentation",
+                    "presentation waits require binary semaphores",
+                ));
+            }
+        }
+        let backend_waits = waits.iter().map(|wait| &wait.raw).collect::<Vec<_>>();
+        let raw = self.take_raw();
+        self.backend
+            .present(&mut self.swapchain.raw.borrow_mut(), raw, &backend_waits)
+    }
+
+    /// Releases an acquired image that will not be presented.
+    pub fn abandon(mut self) -> Result<()> {
+        let raw = self.take_raw();
+        self.backend
+            .abandon_render_image(&mut self.swapchain.raw.borrow_mut(), raw)
+    }
+
+    fn raw(&self) -> &B::RenderImage {
+        self.raw
+            .as_ref()
+            .expect("render image is inaccessible after consumption")
+    }
+
+    fn take_raw(&mut self) -> B::RenderImage {
+        self.swapchain
+            .acquired_count
+            .set(self.swapchain.acquired_count.get().saturating_sub(1));
+        self.raw
+            .take()
+            .expect("render image can only be consumed once")
+    }
+}
+
+impl<B: Backend> Drop for RenderImage<B> {
+    fn drop(&mut self) {
+        let Some(raw) = self.raw.take() else {
+            return;
+        };
+        self.swapchain
+            .acquired_count
+            .set(self.swapchain.acquired_count.get().saturating_sub(1));
+        let _ = self
+            .backend
+            .abandon_render_image(&mut self.swapchain.raw.borrow_mut(), raw);
+    }
+}

--- a/crates/dirk_rhi/src/resource.rs
+++ b/crates/dirk_rhi/src/resource.rs
@@ -1,0 +1,654 @@
+//! Devices and owned GPU resources.
+
+use std::{fmt, sync::Arc};
+
+use crate::{
+    Backend, BindGroupLayoutCreateInfo, BufferCreateInfo, BufferUsage, Error, Extent3D, Format,
+    ImageCreateInfo, ImageSubresourceRange, ImageViewCreateInfo, Result, SamplerCreateInfo,
+    ShaderModuleCreateInfo,
+};
+
+/// A logical device implemented by a concrete backend.
+pub struct Device<B: Backend> {
+    pub(crate) backend: Arc<B>,
+}
+
+impl<B: Backend> Clone for Device<B> {
+    fn clone(&self) -> Self {
+        Self {
+            backend: Arc::clone(&self.backend),
+        }
+    }
+}
+
+impl<B: Backend> fmt::Debug for Device<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("Device").finish_non_exhaustive()
+    }
+}
+
+impl<B: Backend> Device<B> {
+    /// Wraps an initialized backend device.
+    #[must_use]
+    pub fn new(backend: B) -> Self {
+        Self {
+            backend: Arc::new(backend),
+        }
+    }
+
+    /// Waits until all device work has completed.
+    pub fn wait_idle(&self) -> Result<()> {
+        self.backend.wait_idle()
+    }
+
+    /// Flushes backend-managed deferred destruction at a caller-defined safe point.
+    pub fn flush(&self) {
+        self.backend.flush();
+    }
+
+    /// Creates an owned buffer.
+    pub fn create_buffer(&self, info: &BufferCreateInfo<'_>) -> Result<Buffer<B>> {
+        info.validate()?;
+        let raw = Arc::new(self.backend.create_buffer(info)?);
+        Ok(Buffer {
+            backend: Arc::clone(&self.backend),
+            raw,
+            size: info.size,
+            usage: info.usage,
+        })
+    }
+
+    /// Writes bytes into host-writable buffer memory.
+    pub fn write_buffer(&self, buffer: &Buffer<B>, offset: u64, data: &[u8]) -> Result<()> {
+        self.ensure_resource(&buffer.backend, "write_buffer")?;
+        let end = offset
+            .checked_add(data.len() as u64)
+            .ok_or_else(|| Error::invalid_descriptor("buffer write", "byte range overflows"))?;
+        if end > buffer.size {
+            return Err(Error::invalid_descriptor(
+                "buffer write",
+                "byte range exceeds the buffer size",
+            ));
+        }
+        self.backend.write_buffer(buffer.raw.as_ref(), offset, data)
+    }
+
+    /// Creates an owned image.
+    pub fn create_image(&self, info: &ImageCreateInfo<'_>) -> Result<Image<B>> {
+        info.validate()?;
+        let raw = Arc::new(self.backend.create_image(info)?);
+        Ok(Image {
+            backend: Arc::clone(&self.backend),
+            raw,
+            extent: info.extent,
+            format: info.format,
+            mip_levels: info.mip_levels,
+            array_layers: info.array_layers,
+        })
+    }
+
+    /// Creates an owned view into an image.
+    pub fn create_image_view(
+        &self,
+        image: &Image<B>,
+        info: &ImageViewCreateInfo<'_>,
+    ) -> Result<ImageView<B>> {
+        self.ensure_resource(&image.backend, "create_image_view")?;
+        info.validate()?;
+        let raw = self.backend.create_image_view(image.raw.as_ref(), info)?;
+        Ok(ImageView {
+            backend: Arc::clone(&self.backend),
+            inner: Arc::new(ImageViewInner {
+                raw,
+                _image: Arc::clone(&image.raw),
+            }),
+            format: info.format.unwrap_or(image.format),
+            range: info.range,
+        })
+    }
+
+    /// Creates an owned sampler.
+    pub fn create_sampler(&self, info: &SamplerCreateInfo<'_>) -> Result<Sampler<B>> {
+        if info.lod_min > info.lod_max {
+            return Err(Error::invalid_descriptor(
+                "sampler",
+                "minimum LOD must not exceed maximum LOD",
+            ));
+        }
+        Ok(Sampler::new(
+            Arc::clone(&self.backend),
+            Arc::new(self.backend.create_sampler(info)?),
+        ))
+    }
+
+    /// Creates an owned shader module.
+    pub fn create_shader_module(
+        &self,
+        info: &ShaderModuleCreateInfo<'_>,
+    ) -> Result<ShaderModule<B>> {
+        info.validate()?;
+        Ok(ShaderModule::new(
+            Arc::clone(&self.backend),
+            Arc::new(self.backend.create_shader_module(info)?),
+        ))
+    }
+
+    /// Creates an owned bind-group layout.
+    pub fn create_bind_group_layout(
+        &self,
+        info: &BindGroupLayoutCreateInfo<'_>,
+    ) -> Result<BindGroupLayout<B>> {
+        info.validate()?;
+        Ok(BindGroupLayout::new(
+            Arc::clone(&self.backend),
+            Arc::new(self.backend.create_bind_group_layout(info)?),
+        ))
+    }
+
+    /// Creates an owned bind group.
+    pub fn create_bind_group(&self, info: &BindGroupCreateInfo<'_, B>) -> Result<BindGroup<B>> {
+        self.ensure_resource(&info.layout.backend, "create_bind_group")?;
+        for entry in info.entries {
+            match entry.resource {
+                BindingResource::Buffer { buffer, .. } => {
+                    self.ensure_resource(&buffer.backend, "create_bind_group")?;
+                }
+                BindingResource::ImageView(view) => {
+                    self.ensure_resource(&view.backend, "create_bind_group")?;
+                }
+                BindingResource::Sampler(sampler) => {
+                    self.ensure_resource(&sampler.backend, "create_bind_group")?;
+                }
+                BindingResource::CombinedImageSampler { view, sampler } => {
+                    self.ensure_resource(&view.backend, "create_bind_group")?;
+                    self.ensure_resource(&sampler.backend, "create_bind_group")?;
+                }
+            }
+        }
+        let dependencies = info
+            .entries
+            .iter()
+            .map(|entry| BindingDependency::from(entry.resource))
+            .collect();
+        Ok(BindGroup {
+            backend: Arc::clone(&self.backend),
+            raw: self.backend.create_bind_group(info)?,
+            _layout: Arc::clone(&info.layout.raw),
+            _resources: dependencies,
+        })
+    }
+
+    /// Creates an owned pipeline layout.
+    pub fn create_pipeline_layout(
+        &self,
+        info: &PipelineLayoutCreateInfo<'_, B>,
+    ) -> Result<PipelineLayout<B>> {
+        for layout in info.bind_group_layouts {
+            self.ensure_resource(&layout.backend, "create_pipeline_layout")?;
+        }
+        Ok(PipelineLayout {
+            backend: Arc::clone(&self.backend),
+            raw: Arc::new(self.backend.create_pipeline_layout(info)?),
+            bind_group_layouts: info
+                .bind_group_layouts
+                .iter()
+                .map(|layout| Arc::clone(&layout.raw))
+                .collect(),
+        })
+    }
+
+    /// Creates an owned graphics pipeline.
+    pub fn create_graphics_pipeline(
+        &self,
+        info: &GraphicsPipelineCreateInfo<'_, B>,
+    ) -> Result<Pipeline<B>> {
+        self.ensure_resource(&info.layout.backend, "create_graphics_pipeline")?;
+        self.ensure_resource(&info.vertex.module.backend, "create_graphics_pipeline")?;
+        if let Some(fragment) = &info.fragment {
+            self.ensure_resource(&fragment.module.backend, "create_graphics_pipeline")?;
+        }
+        if info.vertex.entry_point.is_empty()
+            || info
+                .fragment
+                .as_ref()
+                .is_some_and(|fragment| fragment.entry_point.is_empty())
+        {
+            return Err(Error::invalid_descriptor(
+                "graphics pipeline",
+                "shader entry points must not be empty",
+            ));
+        }
+        let mut shaders = vec![Arc::clone(&info.vertex.module.raw)];
+        if let Some(fragment) = &info.fragment {
+            shaders.push(Arc::clone(&fragment.module.raw));
+        }
+        Ok(Pipeline {
+            backend: Arc::clone(&self.backend),
+            raw: self.backend.create_graphics_pipeline(info)?,
+            _layout: Arc::clone(&info.layout.raw),
+            _bind_group_layouts: info.layout.bind_group_layouts.clone(),
+            _shaders: shaders,
+        })
+    }
+
+    pub(crate) fn ensure_resource(&self, backend: &Arc<B>, operation: &'static str) -> Result<()> {
+        if Arc::ptr_eq(&self.backend, backend) {
+            Ok(())
+        } else {
+            Err(Error::DeviceMismatch { operation })
+        }
+    }
+}
+
+/// An owned GPU buffer.
+pub struct Buffer<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    pub(crate) raw: Arc<B::Buffer>,
+    size: u64,
+    usage: BufferUsage,
+}
+
+impl<B: Backend> Buffer<B> {
+    /// Returns the buffer size in bytes.
+    #[must_use]
+    pub const fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Returns the declared buffer usage.
+    #[must_use]
+    pub const fn usage(&self) -> BufferUsage {
+        self.usage
+    }
+}
+
+impl<B: Backend> fmt::Debug for Buffer<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Buffer")
+            .field("size", &self.size)
+            .field("usage", &self.usage)
+            .finish_non_exhaustive()
+    }
+}
+
+/// An owned GPU image.
+pub struct Image<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    pub(crate) raw: Arc<B::Image>,
+    extent: Extent3D,
+    format: Format,
+    mip_levels: u32,
+    array_layers: u32,
+}
+
+impl<B: Backend> Image<B> {
+    /// Returns a non-owning image reference for command recording.
+    #[must_use]
+    pub fn as_ref(&self) -> ImageRef<'_, B> {
+        ImageRef {
+            backend: &self.backend,
+            raw: self.raw.as_ref(),
+        }
+    }
+
+    /// Returns the image extent.
+    #[must_use]
+    pub const fn extent(&self) -> Extent3D {
+        self.extent
+    }
+
+    /// Returns the image format.
+    #[must_use]
+    pub const fn format(&self) -> Format {
+        self.format
+    }
+
+    /// Returns the mip-level count.
+    #[must_use]
+    pub const fn mip_levels(&self) -> u32 {
+        self.mip_levels
+    }
+
+    /// Returns the array-layer count.
+    #[must_use]
+    pub const fn array_layers(&self) -> u32 {
+        self.array_layers
+    }
+}
+
+impl<B: Backend> fmt::Debug for Image<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Image")
+            .field("extent", &self.extent)
+            .field("format", &self.format)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A borrowed image accepted by command recording methods.
+pub struct ImageRef<'a, B: Backend> {
+    pub(crate) backend: &'a Arc<B>,
+    pub(crate) raw: &'a B::Image,
+}
+
+impl<B: Backend> Copy for ImageRef<'_, B> {}
+
+impl<B: Backend> Clone for ImageRef<'_, B> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<B: Backend> fmt::Debug for ImageRef<'_, B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("ImageRef").finish_non_exhaustive()
+    }
+}
+
+/// An owned view into an image.
+pub struct ImageView<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    inner: Arc<ImageViewInner<B>>,
+    format: Format,
+    range: ImageSubresourceRange,
+}
+
+struct ImageViewInner<B: Backend> {
+    raw: B::ImageView,
+    _image: Arc<B::Image>,
+}
+
+impl<B: Backend> ImageView<B> {
+    /// Returns a non-owning image-view reference for command recording.
+    #[must_use]
+    pub fn as_ref(&self) -> ImageViewRef<'_, B> {
+        ImageViewRef {
+            backend: &self.backend,
+            raw: &self.inner.raw,
+        }
+    }
+
+    /// Returns the view format.
+    #[must_use]
+    pub const fn format(&self) -> Format {
+        self.format
+    }
+
+    /// Returns the selected image subresources.
+    #[must_use]
+    pub const fn range(&self) -> ImageSubresourceRange {
+        self.range
+    }
+}
+
+impl<B: Backend> fmt::Debug for ImageView<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ImageView")
+            .field("format", &self.format)
+            .field("range", &self.range)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A borrowed image view accepted by rendering descriptors.
+pub struct ImageViewRef<'a, B: Backend> {
+    pub(crate) backend: &'a Arc<B>,
+    #[allow(dead_code)] // Read by concrete backend implementations.
+    pub(crate) raw: &'a B::ImageView,
+}
+
+impl<B: Backend> Copy for ImageViewRef<'_, B> {}
+
+impl<B: Backend> Clone for ImageViewRef<'_, B> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<B: Backend> fmt::Debug for ImageViewRef<'_, B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ImageViewRef")
+            .finish_non_exhaustive()
+    }
+}
+
+macro_rules! shared_opaque_resource {
+    ($name:ident, $associated:ident, $docs:literal) => {
+        #[doc = $docs]
+        pub struct $name<B: Backend> {
+            pub(crate) backend: Arc<B>,
+            #[allow(dead_code)] // Read by concrete backend implementations.
+            pub(crate) raw: Arc<B::$associated>,
+        }
+
+        impl<B: Backend> $name<B> {
+            pub(crate) fn new(backend: Arc<B>, raw: Arc<B::$associated>) -> Self {
+                Self { backend, raw }
+            }
+        }
+
+        impl<B: Backend> fmt::Debug for $name<B> {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_struct(stringify!($name))
+                    .finish_non_exhaustive()
+            }
+        }
+    };
+}
+
+shared_opaque_resource!(Sampler, Sampler, "An owned texture sampler.");
+shared_opaque_resource!(ShaderModule, ShaderModule, "An owned shader module.");
+shared_opaque_resource!(
+    BindGroupLayout,
+    BindGroupLayout,
+    "An owned bind-group layout."
+);
+/// An owned group of bound resources.
+pub struct BindGroup<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    #[allow(dead_code)] // Read by concrete backend implementations.
+    pub(crate) raw: B::BindGroup,
+    _layout: Arc<B::BindGroupLayout>,
+    _resources: Vec<BindingDependency<B>>,
+}
+
+/// An owned pipeline resource layout.
+pub struct PipelineLayout<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    pub(crate) raw: Arc<B::PipelineLayout>,
+    bind_group_layouts: Vec<Arc<B::BindGroupLayout>>,
+}
+
+/// An owned graphics pipeline.
+pub struct Pipeline<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    pub(crate) raw: B::Pipeline,
+    _layout: Arc<B::PipelineLayout>,
+    _bind_group_layouts: Vec<Arc<B::BindGroupLayout>>,
+    _shaders: Vec<Arc<B::ShaderModule>>,
+}
+
+macro_rules! debug_opaque_resource {
+    ($($name:ident),+ $(,)?) => {$ (
+        impl<B: Backend> fmt::Debug for $name<B> {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_struct(stringify!($name))
+                    .finish_non_exhaustive()
+            }
+        }
+    )+ };
+}
+
+debug_opaque_resource!(BindGroup, PipelineLayout, Pipeline);
+
+/// Kind and initial value of a semaphore.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SemaphoreKind {
+    /// A binary semaphore.
+    Binary,
+    /// A monotonically increasing timeline semaphore.
+    Timeline {
+        /// Initial counter value.
+        initial_value: u64,
+    },
+}
+
+/// An owned GPU semaphore.
+pub struct Semaphore<B: Backend> {
+    pub(crate) backend: Arc<B>,
+    pub(crate) raw: B::Semaphore,
+    kind: SemaphoreKind,
+}
+
+impl<B: Backend> Semaphore<B> {
+    pub(crate) fn new(backend: Arc<B>, raw: B::Semaphore, kind: SemaphoreKind) -> Self {
+        Self { backend, raw, kind }
+    }
+
+    /// Returns the semaphore kind.
+    #[must_use]
+    pub const fn kind(&self) -> SemaphoreKind {
+        self.kind
+    }
+}
+
+impl<B: Backend> fmt::Debug for Semaphore<B> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Semaphore")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Resource supplied to one bind-group entry.
+#[derive(Debug)]
+pub enum BindingResource<'a, B: Backend> {
+    /// A byte range within a buffer.
+    Buffer {
+        /// Bound buffer.
+        buffer: &'a Buffer<B>,
+        /// First bound byte.
+        offset: u64,
+        /// Number of bound bytes.
+        size: u64,
+    },
+    /// An image view.
+    ImageView(&'a ImageView<B>),
+    /// A sampler.
+    Sampler(&'a Sampler<B>),
+    /// An image view and sampler occupying one combined binding.
+    CombinedImageSampler {
+        /// Sampled image view.
+        view: &'a ImageView<B>,
+        /// Sampler used to read the image.
+        sampler: &'a Sampler<B>,
+    },
+}
+
+impl<B: Backend> Copy for BindingResource<'_, B> {}
+
+impl<B: Backend> Clone for BindingResource<'_, B> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[allow(dead_code)] // Ownership is the purpose of each stored handle.
+enum BindingDependency<B: Backend> {
+    Buffer(Arc<B::Buffer>),
+    ImageView(Arc<ImageViewInner<B>>),
+    Sampler(Arc<B::Sampler>),
+    CombinedImageSampler(Arc<ImageViewInner<B>>, Arc<B::Sampler>),
+}
+
+impl<B: Backend> From<BindingResource<'_, B>> for BindingDependency<B> {
+    fn from(resource: BindingResource<'_, B>) -> Self {
+        match resource {
+            BindingResource::Buffer { buffer, .. } => Self::Buffer(Arc::clone(&buffer.raw)),
+            BindingResource::ImageView(view) => Self::ImageView(Arc::clone(&view.inner)),
+            BindingResource::Sampler(sampler) => Self::Sampler(Arc::clone(&sampler.raw)),
+            BindingResource::CombinedImageSampler { view, sampler } => {
+                Self::CombinedImageSampler(Arc::clone(&view.inner), Arc::clone(&sampler.raw))
+            }
+        }
+    }
+}
+
+/// One resource written into a bind group.
+#[derive(Clone, Copy, Debug)]
+pub struct BindGroupEntry<'a, B: Backend> {
+    /// Binding number in the layout.
+    pub binding: u32,
+    /// First array element written by this entry.
+    pub array_element: u32,
+    /// Bound resource.
+    pub resource: BindingResource<'a, B>,
+}
+
+/// Description of an owned bind group.
+#[derive(Clone, Copy, Debug)]
+pub struct BindGroupCreateInfo<'a, B: Backend> {
+    /// Layout implemented by the bind group.
+    pub layout: &'a BindGroupLayout<B>,
+    /// Resources written into the group.
+    pub entries: &'a [BindGroupEntry<'a, B>],
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+/// Description of an owned pipeline layout.
+#[derive(Clone, Copy, Debug)]
+pub struct PipelineLayoutCreateInfo<'a, B: Backend> {
+    /// Bind-group layouts in shader group order.
+    pub bind_group_layouts: &'a [&'a BindGroupLayout<B>],
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+/// Vertex shader state for a graphics pipeline.
+#[derive(Clone, Copy, Debug)]
+pub struct VertexState<'a, B: Backend> {
+    /// Vertex shader module.
+    pub module: &'a ShaderModule<B>,
+    /// Shader entry point.
+    pub entry_point: &'a str,
+    /// Vertex-buffer layouts by binding number.
+    pub buffers: &'a [crate::VertexBufferLayout<'a>],
+}
+
+/// Fragment shader state for a graphics pipeline.
+#[derive(Clone, Copy, Debug)]
+pub struct FragmentState<'a, B: Backend> {
+    /// Fragment shader module.
+    pub module: &'a ShaderModule<B>,
+    /// Shader entry point.
+    pub entry_point: &'a str,
+    /// Color attachment output states.
+    pub targets: &'a [crate::ColorTargetState],
+}
+
+/// Description of an owned graphics pipeline.
+#[derive(Clone, Copy, Debug)]
+pub struct GraphicsPipelineCreateInfo<'a, B: Backend> {
+    /// Pipeline resource layout.
+    pub layout: &'a PipelineLayout<B>,
+    /// Vertex shader and input state.
+    pub vertex: VertexState<'a, B>,
+    /// Optional fragment shader and output state.
+    pub fragment: Option<FragmentState<'a, B>>,
+    /// Primitive assembly and rasterization state.
+    pub primitive: crate::PrimitiveState,
+    /// Optional depth state.
+    pub depth: Option<crate::DepthState>,
+    /// Rasterization sample count.
+    pub samples: crate::SampleCount,
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}

--- a/crates/dirk_rhi/src/test_backend.rs
+++ b/crates/dirk_rhi/src/test_backend.rs
@@ -1,0 +1,621 @@
+#[cfg(feature = "presentation")]
+use std::cell::Cell;
+
+use crate::*;
+
+#[derive(Default)]
+pub(crate) struct FakeBackend {
+    #[cfg(feature = "presentation")]
+    abandoned_images: Cell<usize>,
+    #[cfg(feature = "presentation")]
+    presented_images: Cell<usize>,
+}
+
+impl backend::sealed::Sealed for FakeBackend {}
+
+pub(crate) fn device() -> Device<FakeBackend> {
+    Device::new(FakeBackend::default())
+}
+
+impl Backend for FakeBackend {
+    type Buffer = ();
+    type Image = ();
+    type ImageView = ();
+    type Sampler = ();
+    type ShaderModule = ();
+    type BindGroupLayout = ();
+    type BindGroup = ();
+    type PipelineLayout = ();
+    type Pipeline = ();
+    type CommandPool = ();
+    type CommandBuffer = ();
+    type Fence = ();
+    type Semaphore = ();
+
+    fn wait_idle(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn flush(&self) {}
+
+    fn create_buffer(&self, _info: &BufferCreateInfo<'_>) -> Result<Self::Buffer> {
+        Ok(())
+    }
+
+    fn write_buffer(&self, _buffer: &Self::Buffer, _offset: u64, _data: &[u8]) -> Result<()> {
+        Ok(())
+    }
+
+    fn create_image(&self, _info: &ImageCreateInfo<'_>) -> Result<Self::Image> {
+        Ok(())
+    }
+
+    fn create_image_view(
+        &self,
+        _image: &Self::Image,
+        _info: &ImageViewCreateInfo<'_>,
+    ) -> Result<Self::ImageView> {
+        Ok(())
+    }
+
+    fn create_sampler(&self, _info: &SamplerCreateInfo<'_>) -> Result<Self::Sampler> {
+        Ok(())
+    }
+
+    fn create_shader_module(
+        &self,
+        _info: &ShaderModuleCreateInfo<'_>,
+    ) -> Result<Self::ShaderModule> {
+        Ok(())
+    }
+
+    fn create_bind_group_layout(
+        &self,
+        _info: &BindGroupLayoutCreateInfo<'_>,
+    ) -> Result<Self::BindGroupLayout> {
+        Ok(())
+    }
+
+    fn create_bind_group(&self, _info: &BindGroupCreateInfo<'_, Self>) -> Result<Self::BindGroup> {
+        Ok(())
+    }
+
+    fn create_pipeline_layout(
+        &self,
+        _info: &PipelineLayoutCreateInfo<'_, Self>,
+    ) -> Result<Self::PipelineLayout> {
+        Ok(())
+    }
+
+    fn create_graphics_pipeline(
+        &self,
+        _info: &GraphicsPipelineCreateInfo<'_, Self>,
+    ) -> Result<Self::Pipeline> {
+        Ok(())
+    }
+
+    fn create_command_pool(&self, _info: &CommandPoolCreateInfo<'_>) -> Result<Self::CommandPool> {
+        Ok(())
+    }
+
+    fn reset_command_pool(&self, _pool: &Self::CommandPool) -> Result<()> {
+        Ok(())
+    }
+
+    fn allocate_command_buffer(
+        &self,
+        _pool: &Self::CommandPool,
+        _level: CommandBufferLevel,
+    ) -> Result<Self::CommandBuffer> {
+        Ok(())
+    }
+
+    fn begin_command_buffer(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _info: &CommandBufferBeginInfo,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn end_command_buffer(&self, _command_buffer: &mut Self::CommandBuffer) -> Result<()> {
+        Ok(())
+    }
+
+    fn reset_command_buffer(&self, _command_buffer: &mut Self::CommandBuffer) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_barriers(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _image_barriers: &[ImageBarrier<'_, Self>],
+        _buffer_barriers: &[BufferBarrier<'_, Self>],
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_begin_rendering(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _info: &RenderingInfo<'_, Self>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_end_rendering(&self, _command_buffer: &mut Self::CommandBuffer) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_copy_buffer(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _source: &Self::Buffer,
+        _destination: &Self::Buffer,
+        _regions: &[BufferCopy],
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_copy_buffer_to_image(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _source: &Self::Buffer,
+        _destination: &Self::Image,
+        _layout: ImageLayout,
+        _regions: &[BufferImageCopy],
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_copy_image(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _source: &Self::Image,
+        _source_layout: ImageLayout,
+        _destination: &Self::Image,
+        _destination_layout: ImageLayout,
+        _regions: &[ImageCopy],
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_blit_image(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _source: &Self::Image,
+        _source_layout: ImageLayout,
+        _destination: &Self::Image,
+        _destination_layout: ImageLayout,
+        _regions: &[ImageBlit],
+        _filter: Filter,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_set_viewport(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _viewport: Viewport,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_set_scissor(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _scissor: Rect2D,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_bind_graphics_pipeline(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _pipeline: &Self::Pipeline,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_bind_graphics_groups(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _layout: &Self::PipelineLayout,
+        _first_group: u32,
+        _groups: &[&BindGroup<Self>],
+        _dynamic_offsets: &[u32],
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_bind_vertex_buffers(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _first_binding: u32,
+        _buffers: &[VertexBufferBinding<'_, Self>],
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_bind_index_buffer(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _buffer: &Self::Buffer,
+        _offset: u64,
+        _format: IndexFormat,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_draw_indexed(
+        &self,
+        _command_buffer: &mut Self::CommandBuffer,
+        _draw: DrawIndexed,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn command_draw(&self, _command_buffer: &mut Self::CommandBuffer, _draw: Draw) -> Result<()> {
+        Ok(())
+    }
+
+    fn create_fence(&self, _signaled: bool) -> Result<Self::Fence> {
+        Ok(())
+    }
+
+    fn wait_for_fence(&self, _fence: &Self::Fence, _timeout_ns: u64) -> Result<()> {
+        Ok(())
+    }
+
+    fn reset_fence(&self, _fence: &mut Self::Fence) -> Result<()> {
+        Ok(())
+    }
+
+    fn create_semaphore(&self, _kind: SemaphoreKind) -> Result<Self::Semaphore> {
+        Ok(())
+    }
+
+    fn wait_for_semaphore(
+        &self,
+        _semaphore: &Self::Semaphore,
+        _value: u64,
+        _timeout_ns: u64,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn semaphore_value(&self, _semaphore: &Self::Semaphore) -> Result<u64> {
+        Ok(0)
+    }
+
+    fn submit(
+        &self,
+        _queue: QueueType,
+        _info: &SubmitInfo<'_, Self>,
+        _fence: &Fence<Self>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    #[cfg(feature = "presentation")]
+    type SurfaceTarget = ();
+    #[cfg(feature = "presentation")]
+    type Surface = ();
+    #[cfg(feature = "presentation")]
+    type Swapchain = FakeSwapchain;
+    #[cfg(feature = "presentation")]
+    type RenderImage = FakeRenderImage;
+
+    #[cfg(feature = "presentation")]
+    fn create_surface(&self, _target: &Self::SurfaceTarget) -> Result<Self::Surface> {
+        Ok(())
+    }
+
+    #[cfg(feature = "presentation")]
+    fn create_swapchain(
+        &self,
+        _surface: &Self::Surface,
+        info: &SwapchainCreateInfo<'_>,
+    ) -> Result<Self::Swapchain> {
+        Ok(FakeSwapchain {
+            extent: info.extent,
+            format: info
+                .preferred_formats
+                .first()
+                .copied()
+                .unwrap_or(Format::Bgra8Srgb),
+        })
+    }
+
+    #[cfg(feature = "presentation")]
+    fn recreate_swapchain(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        _surface: &Self::Surface,
+        info: &SwapchainCreateInfo<'_>,
+    ) -> Result<()> {
+        swapchain.extent = info.extent;
+        Ok(())
+    }
+
+    #[cfg(feature = "presentation")]
+    fn swapchain_extent(swapchain: &Self::Swapchain) -> Extent2D {
+        swapchain.extent
+    }
+
+    #[cfg(feature = "presentation")]
+    fn swapchain_format(swapchain: &Self::Swapchain) -> Format {
+        swapchain.format
+    }
+
+    #[cfg(feature = "presentation")]
+    fn acquire_render_image(
+        &self,
+        _swapchain: &mut Self::Swapchain,
+        _timeout_ns: u64,
+        _signal: &Self::Semaphore,
+    ) -> Result<Self::RenderImage> {
+        Ok(FakeRenderImage {
+            image: (),
+            view: (),
+            index: 0,
+        })
+    }
+
+    #[cfg(feature = "presentation")]
+    fn render_image_parts(image: &Self::RenderImage) -> (&Self::Image, &Self::ImageView, u32) {
+        (&image.image, &image.view, image.index)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn present(
+        &self,
+        _swapchain: &mut Self::Swapchain,
+        _image: Self::RenderImage,
+        _waits: &[&Self::Semaphore],
+    ) -> Result<()> {
+        self.presented_images.set(self.presented_images.get() + 1);
+        Ok(())
+    }
+
+    #[cfg(feature = "presentation")]
+    fn abandon_render_image(
+        &self,
+        _swapchain: &mut Self::Swapchain,
+        _image: Self::RenderImage,
+    ) -> Result<()> {
+        self.abandoned_images.set(self.abandoned_images.get() + 1);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "presentation")]
+pub(crate) struct FakeSwapchain {
+    extent: Extent2D,
+    format: Format,
+}
+
+#[cfg(feature = "presentation")]
+pub(crate) struct FakeRenderImage {
+    image: (),
+    view: (),
+    index: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command_pool(
+        device: &Device<FakeBackend>,
+        flags: CommandPoolFlags,
+    ) -> CommandPool<FakeBackend> {
+        device
+            .create_command_pool(&CommandPoolCreateInfo {
+                queue: QueueType::Graphics,
+                flags,
+                label: None,
+            })
+            .expect("fake command pool creation should succeed")
+    }
+
+    fn executable(
+        pool: &CommandPool<FakeBackend>,
+        usage: CommandBufferUsage,
+    ) -> CommandBuffer<FakeBackend> {
+        let mut command_buffer = pool
+            .allocate(CommandBufferLevel::Primary)
+            .expect("fake command buffer allocation should succeed");
+        command_buffer
+            .begin(&CommandBufferBeginInfo { usage })
+            .expect("begin should succeed");
+        command_buffer.end().expect("end should succeed");
+        command_buffer
+    }
+
+    #[test]
+    fn rejects_resources_from_another_device() {
+        let first = device();
+        let second = device();
+        let buffer = first
+            .create_buffer(&BufferCreateInfo {
+                size: 4,
+                usage: BufferUsage::UNIFORM,
+                memory: MemoryLocation::Upload,
+                label: None,
+            })
+            .expect("fake buffer creation should succeed");
+
+        assert!(matches!(
+            second.write_buffer(&buffer, 0, &[0; 4]),
+            Err(Error::DeviceMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn pool_reset_returns_allocated_buffers_to_initial() {
+        let device = device();
+        let mut pool = command_pool(&device, CommandPoolFlags::empty());
+        let mut command_buffer = executable(&pool, CommandBufferUsage::empty());
+
+        pool.reset().expect("pool reset should succeed");
+        command_buffer
+            .begin(&CommandBufferBeginInfo::default())
+            .expect("generation change should restore initial state");
+    }
+
+    #[test]
+    fn individual_reset_requires_pool_flag() {
+        let device = device();
+        let pool = command_pool(&device, CommandPoolFlags::empty());
+        let mut command_buffer = executable(&pool, CommandBufferUsage::empty());
+
+        assert!(matches!(
+            command_buffer.reset(),
+            Err(Error::InvalidDescriptor { .. })
+        ));
+    }
+
+    #[test]
+    fn rendering_scope_transitions_are_checked() {
+        let device = device();
+        let pool = command_pool(&device, CommandPoolFlags::empty());
+        let mut command_buffer = pool
+            .allocate(CommandBufferLevel::Primary)
+            .expect("allocation should succeed");
+        command_buffer
+            .begin(&CommandBufferBeginInfo::default())
+            .expect("begin should succeed");
+        let rendering = RenderingInfo {
+            render_area: Rect2D::default(),
+            layer_count: 1,
+            color_attachments: &[],
+            depth_stencil_attachment: None,
+        };
+
+        assert!(command_buffer.end_rendering().is_err());
+        assert!(
+            command_buffer
+                .draw(Draw {
+                    first_vertex: 0,
+                    vertex_count: 3,
+                    first_instance: 0,
+                    instance_count: 1,
+                })
+                .is_err()
+        );
+        command_buffer
+            .begin_rendering(&rendering)
+            .expect("first rendering scope should begin");
+        command_buffer
+            .draw(Draw {
+                first_vertex: 0,
+                vertex_count: 3,
+                first_instance: 0,
+                instance_count: 1,
+            })
+            .expect("draw should be valid inside rendering");
+        assert!(command_buffer.begin_rendering(&rendering).is_err());
+        assert!(command_buffer.barriers(&[], &[]).is_err());
+        assert!(command_buffer.end().is_err());
+        command_buffer
+            .end_rendering()
+            .expect("active rendering scope should end");
+        command_buffer.end().expect("command buffer should end");
+    }
+
+    #[test]
+    fn submission_blocks_reset_until_fence_completion() {
+        let device = device();
+        let mut pool = command_pool(&device, CommandPoolFlags::RESET_COMMAND_BUFFER);
+        let mut command_buffer = executable(&pool, CommandBufferUsage::ONE_TIME_SUBMIT);
+        let mut fence = device
+            .create_fence(false)
+            .expect("fence creation should succeed");
+
+        device
+            .submit(
+                QueueType::Graphics,
+                &SubmitInfo {
+                    waits: &[],
+                    command_buffers: &[&command_buffer],
+                    signals: &[],
+                },
+                &fence,
+            )
+            .expect("submission should succeed");
+        assert!(command_buffer.reset().is_err());
+        assert!(pool.reset().is_err());
+        assert!(device.reset_fence(&mut fence).is_err());
+
+        device
+            .wait_for_fence(&fence, u64::MAX)
+            .expect("fence wait should complete submission");
+        device
+            .reset_fence(&mut fence)
+            .expect("completed fence should reset");
+        assert!(
+            device
+                .submit(
+                    QueueType::Graphics,
+                    &SubmitInfo {
+                        waits: &[],
+                        command_buffers: &[&command_buffer],
+                        signals: &[],
+                    },
+                    &fence,
+                )
+                .is_err()
+        );
+
+        command_buffer
+            .reset()
+            .expect("completed buffer should reset");
+        command_buffer
+            .begin(&CommandBufferBeginInfo::default())
+            .expect("reset buffer should record again");
+    }
+
+    #[cfg(feature = "presentation")]
+    #[test]
+    fn render_image_present_and_abandon_consume_acquisition() {
+        let device = device();
+        let surface = device
+            .create_surface(&())
+            .expect("surface creation should succeed");
+        let swapchain = device
+            .create_swapchain(
+                &surface,
+                &SwapchainCreateInfo {
+                    extent: Extent2D::new(640, 480),
+                    image_usage: ImageUsage::COLOR_ATTACHMENT,
+                    preferred_formats: &[Format::Bgra8Srgb],
+                    present_mode: PresentMode::Fifo,
+                    label: None,
+                },
+            )
+            .expect("swapchain creation should succeed");
+        let acquire = device
+            .create_semaphore(SemaphoreKind::Binary)
+            .expect("semaphore creation should succeed");
+
+        swapchain
+            .acquire_next_image(u64::MAX, &acquire)
+            .expect("image acquisition should succeed")
+            .abandon()
+            .expect("abandon should succeed");
+        swapchain
+            .acquire_next_image(u64::MAX, &acquire)
+            .expect("second acquisition should succeed")
+            .present(&[])
+            .expect("presentation should succeed");
+        drop(
+            swapchain
+                .acquire_next_image(u64::MAX, &acquire)
+                .expect("third acquisition should succeed"),
+        );
+
+        assert_eq!(device.backend.abandoned_images.get(), 2);
+        assert_eq!(device.backend.presented_images.get(), 1);
+    }
+}

--- a/crates/dirk_rhi/src/types.rs
+++ b/crates/dirk_rhi/src/types.rs
@@ -1,0 +1,879 @@
+//! Backend-neutral descriptors and value types.
+
+use crate::{Error, Result, flags::define_flags};
+
+define_flags! {
+    /// Ways a buffer may be used.
+    pub struct BufferUsage(u32) {
+        /// Source of a transfer operation.
+        const TRANSFER_SRC = 1 << 0;
+        /// Destination of a transfer operation.
+        const TRANSFER_DST = 1 << 1;
+        /// Uniform buffer binding.
+        const UNIFORM = 1 << 2;
+        /// Storage buffer binding.
+        const STORAGE = 1 << 3;
+        /// Vertex buffer binding.
+        const VERTEX = 1 << 4;
+        /// Index buffer binding.
+        const INDEX = 1 << 5;
+    }
+}
+
+define_flags! {
+    /// Ways an image may be used.
+    pub struct ImageUsage(u32) {
+        /// Source of a transfer operation.
+        const TRANSFER_SRC = 1 << 0;
+        /// Destination of a transfer operation.
+        const TRANSFER_DST = 1 << 1;
+        /// Sampled by a shader.
+        const SAMPLED = 1 << 2;
+        /// Read or written as a storage image.
+        const STORAGE = 1 << 3;
+        /// Color rendering attachment.
+        const COLOR_ATTACHMENT = 1 << 4;
+        /// Depth or stencil rendering attachment.
+        const DEPTH_STENCIL_ATTACHMENT = 1 << 5;
+        /// Short-lived rendering attachment.
+        const TRANSIENT_ATTACHMENT = 1 << 6;
+    }
+}
+
+define_flags! {
+    /// Image aspects selected by a view or operation.
+    pub struct ImageAspects(u8) {
+        /// Color aspect.
+        const COLOR = 1 << 0;
+        /// Depth aspect.
+        const DEPTH = 1 << 1;
+        /// Stencil aspect.
+        const STENCIL = 1 << 2;
+    }
+}
+
+define_flags! {
+    /// Shader stages that can access a resource.
+    pub struct ShaderStages(u8) {
+        /// Vertex stage.
+        const VERTEX = 1 << 0;
+        /// Fragment stage.
+        const FRAGMENT = 1 << 1;
+        /// Compute stage.
+        const COMPUTE = 1 << 2;
+    }
+}
+
+define_flags! {
+    /// Pipeline stages used by synchronization barriers.
+    pub struct PipelineStages(u32) {
+        /// The start of submitted work.
+        const TOP = 1 << 0;
+        /// Vertex shader work.
+        const VERTEX_SHADER = 1 << 1;
+        /// Fragment shader work.
+        const FRAGMENT_SHADER = 1 << 2;
+        /// Compute shader work.
+        const COMPUTE_SHADER = 1 << 3;
+        /// Early depth and stencil tests.
+        const EARLY_DEPTH_STENCIL = 1 << 4;
+        /// Late depth and stencil tests.
+        const LATE_DEPTH_STENCIL = 1 << 5;
+        /// Color attachment output.
+        const COLOR_OUTPUT = 1 << 6;
+        /// Transfer operations.
+        const TRANSFER = 1 << 7;
+        /// The end of submitted work.
+        const BOTTOM = 1 << 8;
+        /// Every command stage.
+        const ALL_COMMANDS = 1 << 9;
+    }
+}
+
+define_flags! {
+    /// Resource accesses used by synchronization barriers.
+    pub struct AccessTypes(u32) {
+        /// Uniform buffer reads.
+        const UNIFORM_READ = 1 << 0;
+        /// Shader reads.
+        const SHADER_READ = 1 << 1;
+        /// Shader writes.
+        const SHADER_WRITE = 1 << 2;
+        /// Color attachment reads.
+        const COLOR_ATTACHMENT_READ = 1 << 3;
+        /// Color attachment writes.
+        const COLOR_ATTACHMENT_WRITE = 1 << 4;
+        /// Depth or stencil attachment reads.
+        const DEPTH_STENCIL_READ = 1 << 5;
+        /// Depth or stencil attachment writes.
+        const DEPTH_STENCIL_WRITE = 1 << 6;
+        /// Transfer reads.
+        const TRANSFER_READ = 1 << 7;
+        /// Transfer writes.
+        const TRANSFER_WRITE = 1 << 8;
+        /// Host reads.
+        const HOST_READ = 1 << 9;
+        /// Host writes.
+        const HOST_WRITE = 1 << 10;
+        /// General memory reads.
+        const MEMORY_READ = 1 << 11;
+        /// General memory writes.
+        const MEMORY_WRITE = 1 << 12;
+    }
+}
+
+define_flags! {
+    /// Color channels written by a graphics pipeline.
+    pub struct ColorWrites(u8) {
+        /// Red channel.
+        const RED = 1 << 0;
+        /// Green channel.
+        const GREEN = 1 << 1;
+        /// Blue channel.
+        const BLUE = 1 << 2;
+        /// Alpha channel.
+        const ALPHA = 1 << 3;
+    }
+}
+
+impl ColorWrites {
+    /// All color channels.
+    pub const ALL: Self =
+        Self(Self::RED.bits() | Self::GREEN.bits() | Self::BLUE.bits() | Self::ALPHA.bits());
+}
+
+/// Queue capability used for command allocation and submission.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum QueueType {
+    /// Graphics and transfer commands.
+    Graphics,
+    /// Compute commands.
+    Compute,
+    /// Transfer commands.
+    Transfer,
+}
+
+/// Preferred placement and host visibility for an allocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MemoryLocation {
+    /// Device-local memory.
+    Device,
+    /// Host-writable memory intended for uploads.
+    Upload,
+    /// Host-readable memory intended for readback.
+    Readback,
+}
+
+/// Two-dimensional unsigned extent.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Extent2D {
+    /// Width in texels or pixels.
+    pub width: u32,
+    /// Height in texels or pixels.
+    pub height: u32,
+}
+
+impl Extent2D {
+    /// Creates a two-dimensional extent.
+    #[must_use]
+    pub const fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+
+    /// Returns the complete mip chain length for this extent.
+    #[must_use]
+    pub const fn max_mip_levels(self) -> u32 {
+        let longest = if self.width > self.height {
+            self.width
+        } else {
+            self.height
+        };
+        u32::BITS - longest.leading_zeros()
+    }
+
+    #[cfg(feature = "presentation")]
+    pub(crate) const fn is_empty(self) -> bool {
+        self.width == 0 || self.height == 0
+    }
+}
+
+/// Three-dimensional unsigned extent.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Extent3D {
+    /// Width in texels.
+    pub width: u32,
+    /// Height in texels.
+    pub height: u32,
+    /// Depth in texels.
+    pub depth: u32,
+}
+
+impl Extent3D {
+    /// Creates a three-dimensional extent.
+    #[must_use]
+    pub const fn new(width: u32, height: u32, depth: u32) -> Self {
+        Self {
+            width,
+            height,
+            depth,
+        }
+    }
+
+    pub(crate) const fn is_empty(self) -> bool {
+        self.width == 0 || self.height == 0 || self.depth == 0
+    }
+}
+
+/// Pixel and texel formats understood by every backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Format {
+    /// Four 8-bit normalized color channels.
+    Rgba8Unorm,
+    /// Four 8-bit normalized sRGB color channels.
+    Rgba8Srgb,
+    /// BGRA ordered 8-bit normalized color channels.
+    Bgra8Unorm,
+    /// BGRA ordered 8-bit normalized sRGB color channels.
+    Bgra8Srgb,
+    /// Two 32-bit floating-point channels.
+    Rg32Float,
+    /// Three 32-bit floating-point channels.
+    Rgb32Float,
+    /// Four 32-bit floating-point channels.
+    Rgba32Float,
+    /// A 16-bit normalized depth channel.
+    Depth16Unorm,
+    /// A 32-bit floating-point depth channel.
+    Depth32Float,
+    /// A 24-bit normalized depth channel and 8-bit stencil channel.
+    Depth24UnormStencil8,
+    /// A 32-bit floating-point depth channel and 8-bit stencil channel.
+    Depth32FloatStencil8,
+}
+
+impl Format {
+    /// Returns the aspects stored by this format.
+    #[must_use]
+    pub const fn aspects(self) -> ImageAspects {
+        match self {
+            Self::Depth16Unorm | Self::Depth32Float => ImageAspects::DEPTH,
+            Self::Depth24UnormStencil8 | Self::Depth32FloatStencil8 => {
+                ImageAspects(ImageAspects::DEPTH.bits() | ImageAspects::STENCIL.bits())
+            }
+            Self::Rgba8Unorm
+            | Self::Rgba8Srgb
+            | Self::Bgra8Unorm
+            | Self::Bgra8Srgb
+            | Self::Rg32Float
+            | Self::Rgb32Float
+            | Self::Rgba32Float => ImageAspects::COLOR,
+        }
+    }
+}
+
+/// Number of samples stored per pixel.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum SampleCount {
+    /// One sample per pixel.
+    #[default]
+    One,
+    /// Two samples per pixel.
+    Two,
+    /// Four samples per pixel.
+    Four,
+    /// Eight samples per pixel.
+    Eight,
+    /// Sixteen samples per pixel.
+    Sixteen,
+    /// Thirty-two samples per pixel.
+    ThirtyTwo,
+    /// Sixty-four samples per pixel.
+    SixtyFour,
+}
+
+/// Image dimensionality.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ImageDimension {
+    /// One-dimensional image.
+    One,
+    /// Two-dimensional image.
+    #[default]
+    Two,
+    /// Three-dimensional image.
+    Three,
+}
+
+/// Image view dimensionality.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ImageViewDimension {
+    /// One-dimensional view.
+    One,
+    /// Two-dimensional view.
+    #[default]
+    Two,
+    /// Three-dimensional view.
+    Three,
+    /// Cube view.
+    Cube,
+    /// One-dimensional array view.
+    OneArray,
+    /// Two-dimensional array view.
+    TwoArray,
+    /// Cube array view.
+    CubeArray,
+}
+
+/// Description of an owned buffer.
+#[derive(Clone, Copy, Debug)]
+pub struct BufferCreateInfo<'a> {
+    /// Buffer size in bytes.
+    pub size: u64,
+    /// All ways the buffer will be used.
+    pub usage: BufferUsage,
+    /// Preferred memory placement.
+    pub memory: MemoryLocation,
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+impl BufferCreateInfo<'_> {
+    /// Validates values that are independent of a concrete backend.
+    pub fn validate(&self) -> Result<()> {
+        if self.size == 0 {
+            return Err(Error::invalid_descriptor("buffer", "size must be non-zero"));
+        }
+        if self.usage.is_empty() {
+            return Err(Error::invalid_descriptor(
+                "buffer",
+                "at least one usage must be selected",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Description of an owned image.
+#[derive(Clone, Copy, Debug)]
+pub struct ImageCreateInfo<'a> {
+    /// Image dimensionality.
+    pub dimension: ImageDimension,
+    /// Image extent.
+    pub extent: Extent3D,
+    /// Texel format.
+    pub format: Format,
+    /// All ways the image will be used.
+    pub usage: ImageUsage,
+    /// Preferred memory placement.
+    pub memory: MemoryLocation,
+    /// Number of mip levels.
+    pub mip_levels: u32,
+    /// Number of array layers.
+    pub array_layers: u32,
+    /// Number of samples per pixel.
+    pub samples: SampleCount,
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+impl ImageCreateInfo<'_> {
+    /// Validates values that are independent of a concrete backend.
+    pub fn validate(&self) -> Result<()> {
+        if self.extent.is_empty() {
+            return Err(Error::invalid_descriptor(
+                "image",
+                "every extent dimension must be non-zero",
+            ));
+        }
+        if self.usage.is_empty() {
+            return Err(Error::invalid_descriptor(
+                "image",
+                "at least one usage must be selected",
+            ));
+        }
+        if self.mip_levels == 0 {
+            return Err(Error::invalid_descriptor(
+                "image",
+                "mip level count must be non-zero",
+            ));
+        }
+        if self.array_layers == 0 {
+            return Err(Error::invalid_descriptor(
+                "image",
+                "array layer count must be non-zero",
+            ));
+        }
+        if self.samples != SampleCount::One && self.mip_levels != 1 {
+            return Err(Error::invalid_descriptor(
+                "image",
+                "multisampled images must have exactly one mip level",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// A contiguous image subresource range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ImageSubresourceRange {
+    /// Selected image aspects.
+    pub aspects: ImageAspects,
+    /// First selected mip level.
+    pub base_mip_level: u32,
+    /// Number of selected mip levels.
+    pub mip_level_count: u32,
+    /// First selected array layer.
+    pub base_array_layer: u32,
+    /// Number of selected array layers.
+    pub array_layer_count: u32,
+}
+
+impl ImageSubresourceRange {
+    /// Selects all subresources represented by the supplied counts.
+    #[must_use]
+    pub const fn all(aspects: ImageAspects, mip_levels: u32, array_layers: u32) -> Self {
+        Self {
+            aspects,
+            base_mip_level: 0,
+            mip_level_count: mip_levels,
+            base_array_layer: 0,
+            array_layer_count: array_layers,
+        }
+    }
+}
+
+/// Description of a view into an image.
+#[derive(Clone, Copy, Debug)]
+pub struct ImageViewCreateInfo<'a> {
+    /// View dimensionality.
+    pub dimension: ImageViewDimension,
+    /// Optional reinterpretation format.
+    pub format: Option<Format>,
+    /// Selected image subresources.
+    pub range: ImageSubresourceRange,
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+impl ImageViewCreateInfo<'_> {
+    /// Validates values that are independent of a concrete backend.
+    pub fn validate(&self) -> Result<()> {
+        if self.range.aspects.is_empty() {
+            return Err(Error::invalid_descriptor(
+                "image view",
+                "at least one aspect must be selected",
+            ));
+        }
+        if self.range.mip_level_count == 0 || self.range.array_layer_count == 0 {
+            return Err(Error::invalid_descriptor(
+                "image view",
+                "subresource counts must be non-zero",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Texture filtering mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Filter {
+    /// Select the nearest texel.
+    Nearest,
+    /// Linearly interpolate neighboring texels.
+    #[default]
+    Linear,
+}
+
+/// Texture coordinate addressing mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum AddressMode {
+    /// Repeat at integer boundaries.
+    #[default]
+    Repeat,
+    /// Mirror at integer boundaries.
+    MirrorRepeat,
+    /// Clamp to the edge texel.
+    ClampToEdge,
+}
+
+/// Description of a texture sampler.
+#[derive(Clone, Copy, Debug)]
+pub struct SamplerCreateInfo<'a> {
+    /// Magnification filter.
+    pub mag_filter: Filter,
+    /// Minification filter.
+    pub min_filter: Filter,
+    /// Mipmap filter.
+    pub mipmap_filter: Filter,
+    /// U coordinate addressing.
+    pub address_u: AddressMode,
+    /// V coordinate addressing.
+    pub address_v: AddressMode,
+    /// W coordinate addressing.
+    pub address_w: AddressMode,
+    /// Smallest accessible mip level.
+    pub lod_min: f32,
+    /// Largest accessible mip level.
+    pub lod_max: f32,
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+impl Default for SamplerCreateInfo<'_> {
+    fn default() -> Self {
+        Self {
+            mag_filter: Filter::Linear,
+            min_filter: Filter::Linear,
+            mipmap_filter: Filter::Linear,
+            address_u: AddressMode::Repeat,
+            address_v: AddressMode::Repeat,
+            address_w: AddressMode::Repeat,
+            lod_min: 0.0,
+            lod_max: 32.0,
+            label: None,
+        }
+    }
+}
+
+/// Portable shader input accepted by current `DirkEngine` backends.
+///
+/// A backend may need to validate or translate this source. Creation can fail
+/// when the source cannot be represented by the target shading language.
+#[derive(Clone, Copy, Debug)]
+pub enum ShaderSource<'a> {
+    /// SPIR-V words. Backends that do not consume SPIR-V directly may translate it.
+    SpirV(&'a [u32]),
+}
+
+/// Description of a shader module.
+#[derive(Clone, Copy, Debug)]
+pub struct ShaderModuleCreateInfo<'a> {
+    /// Shader source code.
+    pub source: ShaderSource<'a>,
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+impl ShaderModuleCreateInfo<'_> {
+    /// Validates values that are independent of a concrete backend.
+    pub fn validate(&self) -> Result<()> {
+        let Self {
+            source: ShaderSource::SpirV(words),
+            ..
+        } = self;
+        if words.is_empty() {
+            return Err(Error::invalid_descriptor(
+                "shader module",
+                "source must not be empty",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Kind of resource exposed by one bind-group binding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BindingType {
+    /// Uniform buffer.
+    UniformBuffer,
+    /// Storage buffer.
+    StorageBuffer {
+        /// Whether shaders may only read the buffer.
+        read_only: bool,
+    },
+    /// Sampled image view.
+    SampledImage,
+    /// Storage image view.
+    StorageImage {
+        /// Whether shaders may only read the image.
+        read_only: bool,
+    },
+    /// Sampler.
+    Sampler,
+    /// A sampled image view and sampler occupying one binding.
+    CombinedImageSampler,
+}
+
+/// One binding declared by a bind-group layout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BindGroupLayoutEntry {
+    /// Binding number visible to shaders.
+    pub binding: u32,
+    /// Shader stages that can access the binding.
+    pub visibility: ShaderStages,
+    /// Resource kind at this binding.
+    pub binding_type: BindingType,
+    /// Number of resources in the binding array.
+    pub count: u32,
+}
+
+/// Description of a bind-group layout.
+#[derive(Clone, Copy, Debug)]
+pub struct BindGroupLayoutCreateInfo<'a> {
+    /// Declared bindings.
+    pub entries: &'a [BindGroupLayoutEntry],
+    /// Optional diagnostic label.
+    pub label: Option<&'a str>,
+}
+
+impl BindGroupLayoutCreateInfo<'_> {
+    /// Validates binding uniqueness and basic binding values.
+    pub fn validate(&self) -> Result<()> {
+        for (index, entry) in self.entries.iter().enumerate() {
+            if entry.visibility.is_empty() {
+                return Err(Error::invalid_descriptor(
+                    "bind group layout",
+                    "binding visibility must not be empty",
+                ));
+            }
+            if entry.count == 0 {
+                return Err(Error::invalid_descriptor(
+                    "bind group layout",
+                    "binding count must be non-zero",
+                ));
+            }
+            if self.entries[..index]
+                .iter()
+                .any(|previous| previous.binding == entry.binding)
+            {
+                return Err(Error::invalid_descriptor(
+                    "bind group layout",
+                    "binding numbers must be unique",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Primitive assembly topology.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum PrimitiveTopology {
+    /// Independent triangle primitives.
+    #[default]
+    TriangleList,
+    /// Connected triangle strip.
+    TriangleStrip,
+    /// Independent line primitives.
+    LineList,
+    /// Connected line strip.
+    LineStrip,
+    /// Point primitives.
+    PointList,
+}
+
+/// Polygon face culling mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum CullMode {
+    /// Do not cull polygons.
+    None,
+    /// Cull front-facing polygons.
+    Front,
+    /// Cull back-facing polygons.
+    #[default]
+    Back,
+}
+
+/// Vertex winding considered front-facing.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum FrontFace {
+    /// Clockwise winding.
+    Clockwise,
+    /// Counter-clockwise winding.
+    #[default]
+    CounterClockwise,
+}
+
+/// Depth and stencil comparison operation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum CompareOperation {
+    /// Never pass.
+    Never,
+    /// Pass when less.
+    #[default]
+    Less,
+    /// Pass when equal.
+    Equal,
+    /// Pass when less or equal.
+    LessEqual,
+    /// Pass when greater.
+    Greater,
+    /// Pass when not equal.
+    NotEqual,
+    /// Pass when greater or equal.
+    GreaterEqual,
+    /// Always pass.
+    Always,
+}
+
+/// Format of one vertex attribute.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum VertexFormat {
+    /// Two 32-bit floating-point values.
+    Float32x2,
+    /// Three 32-bit floating-point values.
+    Float32x3,
+    /// Four 32-bit floating-point values.
+    Float32x4,
+    /// One unsigned 32-bit integer.
+    Uint32,
+}
+
+/// Rate at which a vertex buffer advances.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum VertexStepMode {
+    /// Advance for every vertex.
+    #[default]
+    Vertex,
+    /// Advance for every instance.
+    Instance,
+}
+
+/// One shader input read from a vertex buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct VertexAttribute {
+    /// Byte offset from the start of the vertex.
+    pub offset: u64,
+    /// Shader location.
+    pub location: u32,
+    /// Attribute format.
+    pub format: VertexFormat,
+}
+
+/// Layout of one bound vertex buffer.
+#[derive(Clone, Copy, Debug)]
+pub struct VertexBufferLayout<'a> {
+    /// Byte stride between elements.
+    pub stride: u64,
+    /// Element stepping mode.
+    pub step_mode: VertexStepMode,
+    /// Attributes sourced from the buffer.
+    pub attributes: &'a [VertexAttribute],
+}
+
+/// Depth state used by a graphics pipeline.
+#[derive(Clone, Copy, Debug)]
+pub struct DepthState {
+    /// Depth attachment format.
+    pub format: Format,
+    /// Whether depth tests are enabled.
+    pub test_enabled: bool,
+    /// Whether passing fragments write depth.
+    pub write_enabled: bool,
+    /// Comparison used by depth tests.
+    pub compare: CompareOperation,
+}
+
+/// Color output state used by a graphics pipeline.
+#[derive(Clone, Copy, Debug)]
+pub struct ColorTargetState {
+    /// Color attachment format.
+    pub format: Format,
+    /// Color channels written by the pipeline.
+    pub write_mask: ColorWrites,
+}
+
+/// Rasterization state used by a graphics pipeline.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PrimitiveState {
+    /// Primitive topology.
+    pub topology: PrimitiveTopology,
+    /// Face culling mode.
+    pub cull_mode: CullMode,
+    /// Front-face winding.
+    pub front_face: FrontFace,
+}
+
+/// Logical image layout used by render-graph synchronization.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ImageLayout {
+    /// Contents are undefined and may be discarded.
+    #[default]
+    Undefined,
+    /// General read/write layout.
+    General,
+    /// Color rendering attachment.
+    ColorAttachment,
+    /// Depth or stencil rendering attachment.
+    DepthStencilAttachment,
+    /// Shader-readable image.
+    ShaderReadOnly,
+    /// Transfer source.
+    TransferSource,
+    /// Transfer destination.
+    TransferDestination,
+    /// Ready for display presentation.
+    Present,
+}
+
+/// Synchronization state tracked for an image resource.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct ResourceState {
+    /// Required image layout.
+    pub layout: ImageLayout,
+    /// Pipeline stages that access the resource.
+    pub stages: PipelineStages,
+    /// Types of accesses performed in those stages.
+    pub access: AccessTypes,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_descriptor_rejects_empty_usage() {
+        let info = BufferCreateInfo {
+            size: 16,
+            usage: BufferUsage::empty(),
+            memory: MemoryLocation::Device,
+            label: None,
+        };
+        assert!(matches!(
+            info.validate(),
+            Err(Error::InvalidDescriptor { .. })
+        ));
+    }
+
+    #[test]
+    fn multisampled_image_rejects_mip_chain() {
+        let info = ImageCreateInfo {
+            dimension: ImageDimension::Two,
+            extent: Extent3D::new(64, 64, 1),
+            format: Format::Rgba8Unorm,
+            usage: ImageUsage::COLOR_ATTACHMENT,
+            memory: MemoryLocation::Device,
+            mip_levels: 2,
+            array_layers: 1,
+            samples: SampleCount::Four,
+            label: None,
+        };
+        assert!(matches!(
+            info.validate(),
+            Err(Error::InvalidDescriptor { .. })
+        ));
+    }
+
+    #[test]
+    fn bind_group_layout_rejects_duplicate_bindings() {
+        let entry = BindGroupLayoutEntry {
+            binding: 0,
+            visibility: ShaderStages::VERTEX,
+            binding_type: BindingType::UniformBuffer,
+            count: 1,
+        };
+        let info = BindGroupLayoutCreateInfo {
+            entries: &[entry, entry],
+            label: None,
+        };
+        assert!(matches!(
+            info.validate(),
+            Err(Error::InvalidDescriptor { .. })
+        ));
+    }
+
+    #[test]
+    fn mip_count_reaches_one_by_one_level() {
+        assert_eq!(Extent2D::new(1, 1).max_mip_levels(), 1);
+        assert_eq!(Extent2D::new(1024, 512).max_mip_levels(), 11);
+    }
+}


### PR DESCRIPTION
The renderer currently talks directly to Vulkan, which prevents the render graph and renderer resources from targeting another graphics API.

This adds a backend-neutral `dirk_rhi` contract below the render graph. It defines typed opaque resources, explicit command pools and command recording, synchronization, presentation, pipeline/resource descriptors, and a sealed backend implementation boundary. No concrete backend or renderer behavior changes are included in this layer.

The API prevents resources from different devices or backends from being mixed and validates command-buffer, submission, and acquired-image lifecycles. Focused fake-backend tests cover those invariants.

Validation:
- `cargo fmt --all -- --check`
- `cargo check -p dirk_rhi --no-default-features`
- `cargo check -p dirk_rhi --all-features`
- `cargo clippy -p dirk_rhi --no-default-features`
- `cargo clippy -p dirk_rhi --all-features`
- `cargo nextest run -p dirk_rhi --no-default-features` (9 passed)
- `cargo nextest run -p dirk_rhi --all-features` (10 passed)

Built with GPT-5.6 in the Codex harness through T3 Code.