### PR TITLE
feat: add Vulkan RHI backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,14 @@ dependencies = [
 [[package]]
 name = "dirk_rhi"
 version = "0.1.0"
+dependencies = [
+ "ash",
+ "ash-window",
+ "dirk_utils",
+ "gpu-allocator",
+ "raw-window-handle",
+ "tracing",
+]
 
 [[package]]
 name = "dirk_shaders"

--- a/crates/dirk_rhi/Cargo.toml
+++ b/crates/dirk_rhi/Cargo.toml
@@ -12,10 +12,30 @@ authors.workspace = true
 documentation.workspace = true
 
 [dependencies]
+ash = { workspace = true, optional = true }
+ash-window = { workspace = true, optional = true }
+gpu-allocator = { workspace = true, optional = true }
+raw-window-handle = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
+dirk_utils = { workspace = true, optional = true }
 
 [features]
 default = []
 presentation = []
+vulkan = [
+    "dep:ash",
+    "dep:ash-window",
+    "dep:dirk_utils",
+    "dep:gpu-allocator",
+    "dep:raw-window-handle",
+    "dep:tracing",
+]
 
-[lints]
-workspace = true
+[lints.rust]
+missing_docs = "warn"
+unsafe_code = "allow"
+
+[lints.clippy]
+pedantic = "warn"
+unwrap_used = "warn"

--- a/crates/dirk_rhi/build.rs
+++ b/crates/dirk_rhi/build.rs
@@ -1,0 +1,9 @@
+//! Configures development-build Vulkan validation.
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(validation)");
+
+    if std::env::var("PROFILE").is_ok_and(|profile| profile != "release") {
+        println!("cargo:rustc-cfg=validation");
+    }
+}

--- a/crates/dirk_rhi/src/command.rs
+++ b/crates/dirk_rhi/src/command.rs
@@ -3,8 +3,10 @@
 use std::{
     cell::{Cell, RefCell},
     fmt,
-    rc::Rc,
-    sync::Arc,
+    sync::{
+        Arc, Mutex, MutexGuard,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
 };
 
 use crate::{
@@ -68,12 +70,12 @@ pub struct CommandPool<B: Backend> {
     pub(crate) backend: Arc<B>,
     pub(crate) raw: Arc<B::CommandPool>,
     queue: QueueType,
-    state: Rc<CommandPoolState>,
+    state: Arc<CommandPoolState>,
 }
 
 struct CommandPoolState {
-    generation: Cell<u64>,
-    pending_count: Cell<usize>,
+    generation: AtomicU64,
+    pending_count: AtomicUsize,
     flags: CommandPoolFlags,
 }
 
@@ -103,8 +105,8 @@ impl<B: Backend> CommandPool<B> {
             _pool: Arc::clone(&self.raw),
             raw,
             queue: self.queue,
-            pool_state: Rc::clone(&self.state),
-            observed_generation: Cell::new(self.state.generation.get()),
+            pool_state: Arc::clone(&self.state),
+            observed_generation: Cell::new(self.state.generation.load(Ordering::Acquire)),
             state: Cell::new(CommandBufferState::Initial),
             usage: Cell::new(CommandBufferUsage::empty()),
             rendering: Cell::new(false),
@@ -115,16 +117,14 @@ impl<B: Backend> CommandPool<B> {
 
     /// Resets all command buffers allocated from the pool.
     pub fn reset(&mut self) -> Result<()> {
-        if self.state.pending_count.get() != 0 {
+        if self.state.pending_count.load(Ordering::Acquire) != 0 {
             return Err(Error::InvalidCommandBufferState {
                 expected: "no pending command buffers",
                 actual: "pending",
             });
         }
         self.backend.reset_command_pool(self.raw.as_ref())?;
-        self.state
-            .generation
-            .set(self.state.generation.get().wrapping_add(1));
+        self.state.generation.fetch_add(1, Ordering::AcqRel);
         Ok(())
     }
 }
@@ -154,7 +154,7 @@ pub struct CommandBuffer<B: Backend> {
     _pool: Arc<B::CommandPool>,
     pub(crate) raw: B::CommandBuffer,
     queue: QueueType,
-    pool_state: Rc<CommandPoolState>,
+    pool_state: Arc<CommandPoolState>,
     observed_generation: Cell<u64>,
     state: Cell<CommandBufferState>,
     usage: Cell<CommandBufferUsage>,
@@ -164,7 +164,7 @@ pub struct CommandBuffer<B: Backend> {
 }
 
 struct PendingSubmission {
-    fence: Rc<FenceTracking>,
+    fence: Arc<FenceTracking>,
     serial: u64,
 }
 
@@ -483,18 +483,16 @@ impl<B: Backend> CommandBuffer<B> {
     }
 
     fn synchronize_state(&self) {
-        let generation = self.pool_state.generation.get();
+        let generation = self.pool_state.generation.load(Ordering::Acquire);
         if self.observed_generation.get() != generation {
             self.observed_generation.set(generation);
             self.reset_local_state();
             return;
         }
 
-        let completed = self
-            .pending
-            .borrow()
-            .as_ref()
-            .is_some_and(|pending| pending.fence.completed_serial.get() >= pending.serial);
+        let completed = self.pending.borrow().as_ref().is_some_and(|pending| {
+            pending.fence.completed_serial.load(Ordering::Acquire) >= pending.serial
+        });
         if completed {
             self.pending.borrow_mut().take();
             self.state.set(CommandBufferState::Executable);
@@ -526,27 +524,83 @@ enum FenceState {
 }
 
 struct FenceTracking {
-    state: Cell<FenceState>,
-    submitted_serial: Cell<u64>,
-    completed_serial: Cell<u64>,
-    pending_pools: RefCell<Vec<Rc<CommandPoolState>>>,
+    state: Mutex<FenceState>,
+    submitted_serial: AtomicU64,
+    completed_serial: AtomicU64,
+    pending_pools: Mutex<Vec<Arc<CommandPoolState>>>,
+}
+
+#[derive(Default)]
+pub(crate) struct SubmissionRegistry {
+    pending: Mutex<Vec<Arc<FenceTracking>>>,
+}
+
+impl SubmissionRegistry {
+    fn track(&self, tracking: &Arc<FenceTracking>) {
+        lock(&self.pending).push(Arc::clone(tracking));
+    }
+
+    fn complete(&self, tracking: &Arc<FenceTracking>) {
+        let tracked = {
+            let mut pending = lock(&self.pending);
+            pending
+                .iter()
+                .position(|pending| Arc::ptr_eq(pending, tracking))
+                .map(|index| pending.swap_remove(index))
+        };
+
+        if let Some(tracked) = tracked {
+            if tracked.state() == FenceState::Pending {
+                tracked.complete();
+            }
+        } else if tracking.state() == FenceState::Pending {
+            tracking.complete();
+        }
+    }
+
+    pub(crate) fn complete_all(&self) {
+        let pending = std::mem::take(&mut *lock(&self.pending));
+        for tracking in pending {
+            if tracking.state() == FenceState::Pending {
+                tracking.complete();
+            }
+        }
+    }
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 impl FenceTracking {
     fn begin_submission(&self) -> u64 {
-        let serial = self.submitted_serial.get().wrapping_add(1);
-        self.submitted_serial.set(serial);
-        self.state.set(FenceState::Pending);
+        let serial = self
+            .submitted_serial
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1);
+        self.set_state(FenceState::Pending);
         serial
     }
 
     fn complete(&self) {
-        self.completed_serial.set(self.submitted_serial.get());
-        self.state.set(FenceState::Signaled);
-        for pool in self.pending_pools.borrow_mut().drain(..) {
-            pool.pending_count
-                .set(pool.pending_count.get().saturating_sub(1));
+        self.completed_serial.store(
+            self.submitted_serial.load(Ordering::Acquire),
+            Ordering::Release,
+        );
+        self.set_state(FenceState::Signaled);
+        for pool in lock(&self.pending_pools).drain(..) {
+            pool.pending_count.fetch_sub(1, Ordering::AcqRel);
         }
+    }
+
+    fn state(&self) -> FenceState {
+        *lock(&self.state)
+    }
+
+    fn set_state(&self, state: FenceState) {
+        *lock(&self.state) = state;
     }
 }
 
@@ -554,7 +608,7 @@ impl FenceTracking {
 pub struct Fence<B: Backend> {
     pub(crate) backend: Arc<B>,
     pub(crate) raw: B::Fence,
-    tracking: Rc<FenceTracking>,
+    tracking: Arc<FenceTracking>,
 }
 
 impl<B: Backend> Fence<B> {
@@ -562,15 +616,15 @@ impl<B: Backend> Fence<B> {
         Self {
             backend,
             raw,
-            tracking: Rc::new(FenceTracking {
-                state: Cell::new(if signaled {
+            tracking: Arc::new(FenceTracking {
+                state: Mutex::new(if signaled {
                     FenceState::Signaled
                 } else {
                     FenceState::Unsignaled
                 }),
-                submitted_serial: Cell::new(0),
-                completed_serial: Cell::new(0),
-                pending_pools: RefCell::new(Vec::new()),
+                submitted_serial: AtomicU64::new(0),
+                completed_serial: AtomicU64::new(0),
+                pending_pools: Mutex::new(Vec::new()),
             }),
         }
     }
@@ -580,7 +634,7 @@ impl<B: Backend> fmt::Debug for Fence<B> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("Fence")
-            .field("state", &self.tracking.state.get())
+            .field("state", &self.tracking.state())
             .finish_non_exhaustive()
     }
 }
@@ -592,9 +646,9 @@ impl<B: Backend> Device<B> {
             backend: Arc::clone(&self.backend),
             raw: Arc::new(self.backend.create_command_pool(info)?),
             queue: info.queue,
-            state: Rc::new(CommandPoolState {
-                generation: Cell::new(0),
-                pending_count: Cell::new(0),
+            state: Arc::new(CommandPoolState {
+                generation: AtomicU64::new(0),
+                pending_count: AtomicUsize::new(0),
                 flags: info.flags,
             }),
         })
@@ -613,21 +667,21 @@ impl<B: Backend> Device<B> {
     pub fn wait_for_fence(&self, fence: &Fence<B>, timeout_ns: u64) -> Result<()> {
         self.ensure_resource(&fence.backend, "wait_for_fence")?;
         self.backend.wait_for_fence(&fence.raw, timeout_ns)?;
-        fence.tracking.complete();
+        self.submissions.complete(&fence.tracking);
         Ok(())
     }
 
     /// Resets a fence to the unsignaled state.
     pub fn reset_fence(&self, fence: &mut Fence<B>) -> Result<()> {
         self.ensure_resource(&fence.backend, "reset_fence")?;
-        if fence.tracking.state.get() == FenceState::Pending {
+        if fence.tracking.state() == FenceState::Pending {
             return Err(Error::invalid_descriptor(
                 "fence reset",
                 "a pending fence must be waited before reset",
             ));
         }
         self.backend.reset_fence(&mut fence.raw)?;
-        fence.tracking.state.set(FenceState::Unsignaled);
+        fence.tracking.set_state(FenceState::Unsignaled);
         Ok(())
     }
 
@@ -716,7 +770,7 @@ impl<B: Backend> Device<B> {
             signal.validate()?;
         }
         self.ensure_resource(&fence.backend, "submit")?;
-        if fence.tracking.state.get() != FenceState::Unsignaled {
+        if fence.tracking.state() != FenceState::Unsignaled {
             return Err(Error::invalid_descriptor(
                 "queue submission",
                 "the submission fence must be unsignaled and not pending",
@@ -725,24 +779,20 @@ impl<B: Backend> Device<B> {
         self.backend.submit(queue, info, fence)?;
 
         let serial = fence.tracking.begin_submission();
+        self.submissions.track(&fence.tracking);
         for command_buffer in info.command_buffers {
-            let pending_count = command_buffer.pool_state.pending_count.get();
             command_buffer
                 .pool_state
                 .pending_count
-                .set(pending_count + 1);
-            fence
-                .tracking
-                .pending_pools
-                .borrow_mut()
-                .push(Rc::clone(&command_buffer.pool_state));
+                .fetch_add(1, Ordering::AcqRel);
+            lock(&fence.tracking.pending_pools).push(Arc::clone(&command_buffer.pool_state));
             command_buffer.state.set(CommandBufferState::Pending);
             command_buffer.submitted_once.set(true);
             command_buffer
                 .pending
                 .borrow_mut()
                 .replace(PendingSubmission {
-                    fence: Rc::clone(&fence.tracking),
+                    fence: Arc::clone(&fence.tracking),
                     serial,
                 });
         }

--- a/crates/dirk_rhi/src/lib.rs
+++ b/crates/dirk_rhi/src/lib.rs
@@ -15,6 +15,8 @@ mod resource;
 #[cfg(test)]
 mod test_backend;
 mod types;
+#[cfg(feature = "vulkan")]
+pub mod vulkan;
 
 pub use backend::{Backend, BackendInterop};
 pub use command::*;

--- a/crates/dirk_rhi/src/presentation.rs
+++ b/crates/dirk_rhi/src/presentation.rs
@@ -181,9 +181,9 @@ impl<B: Backend> Swapchain<B> {
             .acquired_count
             .set(self.state.acquired_count.get() + 1);
         Ok(RenderImage {
+            raw: Some(raw),
             backend: Arc::clone(&self.backend),
             swapchain: Arc::clone(&self.state),
-            raw: Some(raw),
         })
     }
 }
@@ -191,9 +191,10 @@ impl<B: Backend> Swapchain<B> {
 /// An acquired swapchain image that must be presented or abandoned.
 #[must_use = "an acquired image must be presented or abandoned"]
 pub struct RenderImage<B: Backend> {
+    // Fields drop in declaration order. Release image/view references before the swapchain state.
+    raw: Option<B::RenderImage>,
     backend: Arc<B>,
     swapchain: Arc<SwapchainState<B>>,
-    raw: Option<B::RenderImage>,
 }
 
 impl<B: Backend> fmt::Debug for RenderImage<B> {
@@ -232,6 +233,26 @@ impl<B: Backend> RenderImage<B> {
 
     /// Presents the acquired image after waiting on binary semaphores.
     pub fn present(mut self, waits: &[&Semaphore<B>]) -> Result<()> {
+        if let Err(error) = self.validate_present_waits(waits) {
+            return self.abandon_after_validation_error(error);
+        }
+        let backend_waits = waits.iter().map(|wait| &wait.raw).collect::<Vec<_>>();
+        let raw = self.take_raw();
+        self.backend
+            .present(&mut self.swapchain.raw.borrow_mut(), raw, &backend_waits)
+    }
+
+    /// Releases an acquired image that will not be presented.
+    ///
+    /// This is only valid before queue work has consumed the semaphore used to
+    /// acquire the image. Once rendering has been submitted, present the image.
+    pub fn abandon(mut self) -> Result<()> {
+        let raw = self.take_raw();
+        self.backend
+            .abandon_render_image(&mut self.swapchain.raw.borrow_mut(), raw)
+    }
+
+    fn validate_present_waits(&self, waits: &[&Semaphore<B>]) -> Result<()> {
         for wait in waits {
             if !Arc::ptr_eq(&self.backend, &wait.backend) {
                 return Err(Error::DeviceMismatch {
@@ -245,17 +266,14 @@ impl<B: Backend> RenderImage<B> {
                 ));
             }
         }
-        let backend_waits = waits.iter().map(|wait| &wait.raw).collect::<Vec<_>>();
-        let raw = self.take_raw();
-        self.backend
-            .present(&mut self.swapchain.raw.borrow_mut(), raw, &backend_waits)
+        Ok(())
     }
 
-    /// Releases an acquired image that will not be presented.
-    pub fn abandon(mut self) -> Result<()> {
-        let raw = self.take_raw();
-        self.backend
-            .abandon_render_image(&mut self.swapchain.raw.borrow_mut(), raw)
+    fn abandon_after_validation_error(self, error: Error) -> Result<()> {
+        match self.abandon() {
+            Ok(()) => Err(error),
+            Err(abandon_error) => Err(abandon_error),
+        }
     }
 
     fn raw(&self) -> &B::RenderImage {
@@ -271,19 +289,5 @@ impl<B: Backend> RenderImage<B> {
         self.raw
             .take()
             .expect("render image can only be consumed once")
-    }
-}
-
-impl<B: Backend> Drop for RenderImage<B> {
-    fn drop(&mut self) {
-        let Some(raw) = self.raw.take() else {
-            return;
-        };
-        self.swapchain
-            .acquired_count
-            .set(self.swapchain.acquired_count.get().saturating_sub(1));
-        let _ = self
-            .backend
-            .abandon_render_image(&mut self.swapchain.raw.borrow_mut(), raw);
     }
 }

--- a/crates/dirk_rhi/src/resource.rs
+++ b/crates/dirk_rhi/src/resource.rs
@@ -11,12 +11,14 @@ use crate::{
 /// A logical device implemented by a concrete backend.
 pub struct Device<B: Backend> {
     pub(crate) backend: Arc<B>,
+    pub(crate) submissions: Arc<crate::command::SubmissionRegistry>,
 }
 
 impl<B: Backend> Clone for Device<B> {
     fn clone(&self) -> Self {
         Self {
             backend: Arc::clone(&self.backend),
+            submissions: Arc::clone(&self.submissions),
         }
     }
 }
@@ -33,12 +35,15 @@ impl<B: Backend> Device<B> {
     pub fn new(backend: B) -> Self {
         Self {
             backend: Arc::new(backend),
+            submissions: Arc::new(crate::command::SubmissionRegistry::default()),
         }
     }
 
     /// Waits until all device work has completed.
     pub fn wait_idle(&self) -> Result<()> {
-        self.backend.wait_idle()
+        self.backend.wait_idle()?;
+        self.submissions.complete_all();
+        Ok(())
     }
 
     /// Flushes backend-managed deferred destruction at a caller-defined safe point.
@@ -84,6 +89,7 @@ impl<B: Backend> Device<B> {
             format: info.format,
             mip_levels: info.mip_levels,
             array_layers: info.array_layers,
+            dimension: info.dimension,
         })
     }
 
@@ -95,6 +101,7 @@ impl<B: Backend> Device<B> {
     ) -> Result<ImageView<B>> {
         self.ensure_resource(&image.backend, "create_image_view")?;
         info.validate()?;
+        image.validate_view(info)?;
         let raw = self.backend.create_image_view(image.raw.as_ref(), info)?;
         Ok(ImageView {
             backend: Arc::clone(&self.backend),
@@ -280,9 +287,57 @@ pub struct Image<B: Backend> {
     format: Format,
     mip_levels: u32,
     array_layers: u32,
+    dimension: crate::ImageDimension,
 }
 
 impl<B: Backend> Image<B> {
+    fn validate_view(&self, info: &ImageViewCreateInfo<'_>) -> Result<()> {
+        let mip_end = info
+            .range
+            .base_mip_level
+            .checked_add(info.range.mip_level_count)
+            .ok_or_else(|| Error::invalid_descriptor("image view", "mip range overflows"))?;
+        let layer_end = info
+            .range
+            .base_array_layer
+            .checked_add(info.range.array_layer_count)
+            .ok_or_else(|| Error::invalid_descriptor("image view", "layer range overflows"))?;
+        if mip_end > self.mip_levels || layer_end > self.array_layers {
+            return Err(Error::invalid_descriptor(
+                "image view",
+                "selected subresources exceed the image",
+            ));
+        }
+
+        match info.dimension {
+            crate::ImageViewDimension::Cube | crate::ImageViewDimension::CubeArray => {
+                if self.dimension != crate::ImageDimension::Two
+                    || self.extent.width != self.extent.height
+                    || self.array_layers < 6
+                {
+                    return Err(Error::invalid_descriptor(
+                        "image view",
+                        "cube views require a square two-dimensional image with at least six layers",
+                    ));
+                }
+                let layers = info.range.array_layer_count;
+                let valid_layers = match info.dimension {
+                    crate::ImageViewDimension::Cube => layers == 6,
+                    crate::ImageViewDimension::CubeArray => layers >= 6 && layers.is_multiple_of(6),
+                    _ => unreachable!(),
+                };
+                if !valid_layers {
+                    return Err(Error::invalid_descriptor(
+                        "image view",
+                        "cube views require six layers per cube",
+                    ));
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
     /// Returns a non-owning image reference for command recording.
     #[must_use]
     pub fn as_ref(&self) -> ImageRef<'_, B> {

--- a/crates/dirk_rhi/src/test_backend.rs
+++ b/crates/dirk_rhi/src/test_backend.rs
@@ -576,6 +576,94 @@ mod tests {
             .expect("reset buffer should record again");
     }
 
+    #[test]
+    fn wait_idle_completes_tracked_submissions() {
+        let device = device();
+        let mut pool = command_pool(&device, CommandPoolFlags::RESET_COMMAND_BUFFER);
+        let mut command_buffer = executable(&pool, CommandBufferUsage::empty());
+        let fence = device
+            .create_fence(false)
+            .expect("fence creation should succeed");
+
+        device
+            .submit(
+                QueueType::Graphics,
+                &SubmitInfo {
+                    waits: &[],
+                    command_buffers: &[&command_buffer],
+                    signals: &[],
+                },
+                &fence,
+            )
+            .expect("submission should succeed");
+        device.wait_idle().expect("device wait should succeed");
+
+        command_buffer
+            .reset()
+            .expect("wait_idle should release command buffers");
+        pool.reset()
+            .expect("wait_idle should release command pools");
+    }
+
+    #[test]
+    fn wait_idle_recovers_submission_after_wrappers_drop() {
+        let device = device();
+        let mut pool = command_pool(&device, CommandPoolFlags::RESET_COMMAND_BUFFER);
+        let command_buffer = executable(&pool, CommandBufferUsage::empty());
+        let fence = device
+            .create_fence(false)
+            .expect("fence creation should succeed");
+
+        device
+            .submit(
+                QueueType::Graphics,
+                &SubmitInfo {
+                    waits: &[],
+                    command_buffers: &[&command_buffer],
+                    signals: &[],
+                },
+                &fence,
+            )
+            .expect("submission should succeed");
+        drop(fence);
+        drop(command_buffer);
+        device.wait_idle().expect("device wait should succeed");
+
+        pool.reset()
+            .expect("registry should retain dropped submission state");
+    }
+
+    #[test]
+    fn cube_view_validation_rejects_incompatible_images() {
+        let device = device();
+        let image = device
+            .create_image(&ImageCreateInfo {
+                dimension: ImageDimension::Two,
+                extent: Extent3D::new(64, 32, 1),
+                format: Format::Rgba8Unorm,
+                usage: ImageUsage::SAMPLED,
+                memory: MemoryLocation::Device,
+                mip_levels: 1,
+                array_layers: 6,
+                samples: SampleCount::One,
+                label: None,
+            })
+            .expect("fake image creation should succeed");
+
+        assert!(matches!(
+            device.create_image_view(
+                &image,
+                &ImageViewCreateInfo {
+                    dimension: ImageViewDimension::Cube,
+                    format: None,
+                    range: ImageSubresourceRange::all(ImageAspects::COLOR, 1, 6),
+                    label: None,
+                },
+            ),
+            Err(Error::InvalidDescriptor { .. })
+        ));
+    }
+
     #[cfg(feature = "presentation")]
     #[test]
     fn render_image_present_and_abandon_consume_acquisition() {
@@ -583,7 +671,7 @@ mod tests {
         let surface = device
             .create_surface(&())
             .expect("surface creation should succeed");
-        let swapchain = device
+        let mut swapchain = device
             .create_swapchain(
                 &surface,
                 &SwapchainCreateInfo {
@@ -615,7 +703,62 @@ mod tests {
                 .expect("third acquisition should succeed"),
         );
 
-        assert_eq!(device.backend.abandoned_images.get(), 2);
+        assert!(
+            swapchain
+                .recreate(&SwapchainCreateInfo {
+                    extent: Extent2D::new(800, 600),
+                    image_usage: ImageUsage::COLOR_ATTACHMENT,
+                    preferred_formats: &[Format::Bgra8Srgb],
+                    present_mode: PresentMode::Fifo,
+                    label: None,
+                })
+                .is_err()
+        );
+        assert_eq!(device.backend.abandoned_images.get(), 1);
         assert_eq!(device.backend.presented_images.get(), 1);
+    }
+
+    #[cfg(feature = "presentation")]
+    #[test]
+    fn invalid_present_wait_releases_acquisition() {
+        let device = device();
+        let surface = device
+            .create_surface(&())
+            .expect("surface creation should succeed");
+        let mut swapchain = device
+            .create_swapchain(
+                &surface,
+                &SwapchainCreateInfo {
+                    extent: Extent2D::new(640, 480),
+                    image_usage: ImageUsage::COLOR_ATTACHMENT,
+                    preferred_formats: &[Format::Bgra8Srgb],
+                    present_mode: PresentMode::Fifo,
+                    label: None,
+                },
+            )
+            .expect("swapchain creation should succeed");
+        let acquire = device
+            .create_semaphore(SemaphoreKind::Binary)
+            .expect("semaphore creation should succeed");
+        let invalid_wait = device
+            .create_semaphore(SemaphoreKind::Timeline { initial_value: 0 })
+            .expect("timeline semaphore creation should succeed");
+
+        let error = swapchain
+            .acquire_next_image(u64::MAX, &acquire)
+            .expect("image acquisition should succeed")
+            .present(&[&invalid_wait])
+            .expect_err("timeline presentation wait should fail");
+        assert!(matches!(error, Error::InvalidDescriptor { .. }));
+        assert_eq!(device.backend.abandoned_images.get(), 1);
+        swapchain
+            .recreate(&SwapchainCreateInfo {
+                extent: Extent2D::new(800, 600),
+                image_usage: ImageUsage::COLOR_ATTACHMENT,
+                preferred_formats: &[Format::Bgra8Srgb],
+                present_mode: PresentMode::Fifo,
+                label: None,
+            })
+            .expect("invalid presentation should release the acquisition");
     }
 }

--- a/crates/dirk_rhi/src/types.rs
+++ b/crates/dirk_rhi/src/types.rs
@@ -514,6 +514,8 @@ pub struct SamplerCreateInfo<'a> {
     pub lod_min: f32,
     /// Largest accessible mip level.
     pub lod_max: f32,
+    /// Enables the backend's maximum supported anisotropy.
+    pub anisotropy: bool,
     /// Optional diagnostic label.
     pub label: Option<&'a str>,
 }
@@ -529,6 +531,7 @@ impl Default for SamplerCreateInfo<'_> {
             address_w: AddressMode::Repeat,
             lod_min: 0.0,
             lod_max: 32.0,
+            anisotropy: true,
             label: None,
         }
     }

--- a/crates/dirk_rhi/src/vulkan/backend.rs
+++ b/crates/dirk_rhi/src/vulkan/backend.rs
@@ -1,0 +1,1429 @@
+use std::{collections::HashMap, ffi::CString, sync::Arc};
+
+use ash::vk;
+use gpu_allocator::vulkan::{AllocationCreateDesc, AllocationScheme};
+
+use super::{
+    VulkanBackend, VulkanBindGroup, VulkanBindGroupLayout, VulkanBuffer, VulkanCommandBuffer,
+    VulkanCommandPool, VulkanFence, VulkanImage, VulkanImageInner, VulkanImageView,
+    VulkanImageViewInner, VulkanPipeline, VulkanPipelineLayout, VulkanSampler, VulkanSemaphore,
+    VulkanShaderModule, map_error, mapping, unsupported,
+};
+use crate::{
+    Backend, BindGroupCreateInfo, BindGroupLayoutCreateInfo, BindingResource, BindingType,
+    BufferBarrier, BufferCopy, BufferCreateInfo, BufferImageCopy, ColorAttachment,
+    CommandBufferBeginInfo, CommandBufferLevel, CommandBufferUsage, CommandPoolCreateInfo,
+    CommandPoolFlags, DepthStencilAttachment, Draw, DrawIndexed, Fence, Filter,
+    GraphicsPipelineCreateInfo, ImageBarrier, ImageBlit, ImageCopy, ImageCreateInfo, ImageLayout,
+    ImageViewCreateInfo, IndexFormat, LoadOperation, PipelineLayoutCreateInfo, QueueType, Rect2D,
+    RenderingInfo, Result, SamplerCreateInfo, SemaphoreKind, ShaderModuleCreateInfo, ShaderSource,
+    StoreOperation, SubmitInfo, VertexBufferBinding, Viewport,
+};
+
+impl crate::backend::sealed::Sealed for VulkanBackend {}
+
+impl Backend for VulkanBackend {
+    type Buffer = VulkanBuffer;
+    type Image = VulkanImage;
+    type ImageView = VulkanImageView;
+    type Sampler = VulkanSampler;
+    type ShaderModule = VulkanShaderModule;
+    type BindGroupLayout = VulkanBindGroupLayout;
+    type BindGroup = VulkanBindGroup;
+    type PipelineLayout = VulkanPipelineLayout;
+    type Pipeline = VulkanPipeline;
+    type CommandPool = VulkanCommandPool;
+    type CommandBuffer = VulkanCommandBuffer;
+    type Fence = VulkanFence;
+    type Semaphore = VulkanSemaphore;
+
+    fn wait_idle(&self) -> Result<()> {
+        unsafe { self.inner.device.device_wait_idle() }
+            .map_err(|error| map_error("wait for Vulkan device", error))
+    }
+
+    fn flush(&self) {
+        self.inner.flush_deletions();
+    }
+
+    fn create_buffer(&self, info: &BufferCreateInfo<'_>) -> Result<Self::Buffer> {
+        let create_info = vk::BufferCreateInfo::default()
+            .size(info.size)
+            .usage(mapping::buffer_usage(info.usage))
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+        let raw = unsafe { self.inner.device.create_buffer(&create_info, None) }
+            .map_err(|error| map_error("create Vulkan buffer", error))?;
+        let requirements = unsafe { self.inner.device.get_buffer_memory_requirements(raw) };
+        let allocation = self
+            .inner
+            .allocator()
+            .as_mut()
+            .expect("Vulkan allocator exists while the device is alive")
+            .allocate(&AllocationCreateDesc {
+                name: info.label.unwrap_or("RHI buffer"),
+                requirements,
+                location: mapping::memory_location(info.memory),
+                linear: true,
+                allocation_scheme: AllocationScheme::GpuAllocatorManaged,
+            })
+            .map_err(|error| map_error("allocate Vulkan buffer memory", error));
+        let allocation = match allocation {
+            Ok(allocation) => allocation,
+            Err(error) => {
+                unsafe { self.inner.device.destroy_buffer(raw, None) };
+                return Err(error);
+            }
+        };
+        if let Err(error) = unsafe {
+            self.inner
+                .device
+                .bind_buffer_memory(raw, allocation.memory(), allocation.offset())
+        } {
+            unsafe { self.inner.device.destroy_buffer(raw, None) };
+            self.inner
+                .allocator()
+                .as_mut()
+                .expect("Vulkan allocator exists while the device is alive")
+                .free(allocation)
+                .map_err(|free_error| map_error("free Vulkan buffer memory", free_error))?;
+            return Err(map_error("bind Vulkan buffer memory", error));
+        }
+        Ok(VulkanBuffer {
+            inner: Arc::clone(&self.inner),
+            raw,
+            allocation: std::sync::Mutex::new(Some(allocation)),
+            size: info.size,
+        })
+    }
+
+    fn write_buffer(&self, buffer: &Self::Buffer, offset: u64, data: &[u8]) -> Result<()> {
+        let allocation = super::lock(&buffer.allocation);
+        let allocation = allocation
+            .as_ref()
+            .expect("live Vulkan buffer has an allocation");
+        let mapped = allocation.mapped_ptr().ok_or_else(|| {
+            unsupported("Vulkan buffer memory is not host-writable; use an upload buffer and copy")
+        })?;
+        let offset = usize::try_from(offset)
+            .map_err(|_| unsupported("Vulkan buffer write offset does not fit usize"))?;
+        let end = offset
+            .checked_add(data.len())
+            .ok_or_else(|| unsupported("Vulkan buffer write range overflows usize"))?;
+        if u64::try_from(end).unwrap_or(u64::MAX) > buffer.size {
+            return Err(unsupported("Vulkan buffer write exceeds the allocation"));
+        }
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                data.as_ptr(),
+                mapped.as_ptr().cast::<u8>().add(offset),
+                data.len(),
+            );
+        }
+        Ok(())
+    }
+
+    fn create_image(&self, info: &ImageCreateInfo<'_>) -> Result<Self::Image> {
+        match info.dimension {
+            crate::ImageDimension::One if info.extent.height != 1 || info.extent.depth != 1 => {
+                return Err(unsupported(
+                    "one-dimensional Vulkan images require height and depth of one",
+                ));
+            }
+            crate::ImageDimension::Two if info.extent.depth != 1 => {
+                return Err(unsupported(
+                    "two-dimensional Vulkan images require depth of one",
+                ));
+            }
+            _ => {}
+        }
+        let create_info = vk::ImageCreateInfo::default()
+            .flags(image_create_flags(info))
+            .image_type(mapping::image_type(info.dimension))
+            .format(mapping::format(info.format))
+            .extent(vk::Extent3D {
+                width: info.extent.width,
+                height: info.extent.height,
+                depth: info.extent.depth,
+            })
+            .mip_levels(info.mip_levels)
+            .array_layers(info.array_layers)
+            .samples(mapping::sample_count(info.samples))
+            .tiling(vk::ImageTiling::OPTIMAL)
+            .usage(mapping::image_usage(info.usage))
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED);
+        let raw = unsafe { self.inner.device.create_image(&create_info, None) }
+            .map_err(|error| map_error("create Vulkan image", error))?;
+        let requirements = unsafe { self.inner.device.get_image_memory_requirements(raw) };
+        let allocation = self
+            .inner
+            .allocator()
+            .as_mut()
+            .expect("Vulkan allocator exists while the device is alive")
+            .allocate(&AllocationCreateDesc {
+                name: info.label.unwrap_or("RHI image"),
+                requirements,
+                location: mapping::memory_location(info.memory),
+                linear: false,
+                allocation_scheme: AllocationScheme::GpuAllocatorManaged,
+            })
+            .map_err(|error| map_error("allocate Vulkan image memory", error));
+        let allocation = match allocation {
+            Ok(allocation) => allocation,
+            Err(error) => {
+                unsafe { self.inner.device.destroy_image(raw, None) };
+                return Err(error);
+            }
+        };
+        if let Err(error) = unsafe {
+            self.inner
+                .device
+                .bind_image_memory(raw, allocation.memory(), allocation.offset())
+        } {
+            unsafe { self.inner.device.destroy_image(raw, None) };
+            self.inner
+                .allocator()
+                .as_mut()
+                .expect("Vulkan allocator exists while the device is alive")
+                .free(allocation)
+                .map_err(|free_error| map_error("free Vulkan image memory", free_error))?;
+            return Err(map_error("bind Vulkan image memory", error));
+        }
+        Ok(VulkanImage(Arc::new(VulkanImageInner {
+            device: Arc::clone(&self.inner),
+            raw,
+            format: mapping::format(info.format),
+            allocation: Some(allocation),
+        })))
+    }
+
+    fn create_image_view(
+        &self,
+        image: &Self::Image,
+        info: &ImageViewCreateInfo<'_>,
+    ) -> Result<Self::ImageView> {
+        match info.dimension {
+            crate::ImageViewDimension::Cube if info.range.array_layer_count != 6 => {
+                return Err(unsupported("Vulkan cube image views require six layers"));
+            }
+            crate::ImageViewDimension::CubeArray
+                if info.range.array_layer_count < 6
+                    || !info.range.array_layer_count.is_multiple_of(6) =>
+            {
+                return Err(unsupported(
+                    "Vulkan cube-array views require a layer count divisible by six",
+                ));
+            }
+            _ => {}
+        }
+        let create_info = vk::ImageViewCreateInfo::default()
+            .image(image.raw())
+            .view_type(mapping::image_view_type(info.dimension))
+            .format(info.format.map_or_else(|| image.format(), mapping::format))
+            .subresource_range(mapping::subresource_range(info.range));
+        let format = create_info.format;
+        let raw = unsafe { self.inner.device.create_image_view(&create_info, None) }
+            .map_err(|error| map_error("create Vulkan image view", error))?;
+        Ok(VulkanImageView(Arc::new(VulkanImageViewInner {
+            device: Arc::clone(&self.inner),
+            raw,
+            format,
+        })))
+    }
+
+    fn create_sampler(&self, info: &SamplerCreateInfo<'_>) -> Result<Self::Sampler> {
+        let create_info = vk::SamplerCreateInfo::default()
+            .mag_filter(mapping::filter(info.mag_filter))
+            .min_filter(mapping::filter(info.min_filter))
+            .mipmap_mode(mapping::mipmap_mode(info.mipmap_filter))
+            .address_mode_u(mapping::address_mode(info.address_u))
+            .address_mode_v(mapping::address_mode(info.address_v))
+            .address_mode_w(mapping::address_mode(info.address_w))
+            .min_lod(info.lod_min)
+            .max_lod(info.lod_max)
+            .anisotropy_enable(info.anisotropy)
+            .max_anisotropy(if info.anisotropy {
+                self.inner.max_sampler_anisotropy
+            } else {
+                1.0
+            });
+        let raw = unsafe { self.inner.device.create_sampler(&create_info, None) }
+            .map_err(|error| map_error("create Vulkan sampler", error))?;
+        Ok(VulkanSampler {
+            inner: Arc::clone(&self.inner),
+            raw,
+        })
+    }
+
+    fn create_shader_module(
+        &self,
+        info: &ShaderModuleCreateInfo<'_>,
+    ) -> Result<Self::ShaderModule> {
+        let ShaderSource::SpirV(words) = info.source;
+        let create_info = vk::ShaderModuleCreateInfo::default().code(words);
+        let raw = unsafe { self.inner.device.create_shader_module(&create_info, None) }
+            .map_err(|error| map_error("create Vulkan shader module", error))?;
+        Ok(VulkanShaderModule {
+            inner: Arc::clone(&self.inner),
+            raw,
+        })
+    }
+
+    fn create_bind_group_layout(
+        &self,
+        info: &BindGroupLayoutCreateInfo<'_>,
+    ) -> Result<Self::BindGroupLayout> {
+        let bindings = info
+            .entries
+            .iter()
+            .map(|entry| {
+                vk::DescriptorSetLayoutBinding::default()
+                    .binding(entry.binding)
+                    .descriptor_type(mapping::descriptor_type(entry.binding_type))
+                    .descriptor_count(entry.count)
+                    .stage_flags(mapping::shader_stages(entry.visibility))
+            })
+            .collect::<Vec<_>>();
+        let create_info = vk::DescriptorSetLayoutCreateInfo::default().bindings(&bindings);
+        let raw = unsafe {
+            self.inner
+                .device
+                .create_descriptor_set_layout(&create_info, None)
+        }
+        .map_err(|error| map_error("create Vulkan descriptor-set layout", error))?;
+        Ok(VulkanBindGroupLayout {
+            inner: Arc::clone(&self.inner),
+            raw,
+            entries: info.entries.to_vec(),
+        })
+    }
+
+    fn create_bind_group(&self, info: &BindGroupCreateInfo<'_, Self>) -> Result<Self::BindGroup> {
+        let layout = info.layout.raw.as_ref();
+        validate_bind_group_entries(layout, info)?;
+        let mut counts = HashMap::<vk::DescriptorType, u32>::new();
+        for entry in &layout.entries {
+            *counts
+                .entry(mapping::descriptor_type(entry.binding_type))
+                .or_default() += entry.count;
+        }
+        let pool_sizes = counts
+            .into_iter()
+            .map(|(ty, descriptor_count)| vk::DescriptorPoolSize {
+                ty,
+                descriptor_count,
+            })
+            .collect::<Vec<_>>();
+        let pool_info = vk::DescriptorPoolCreateInfo::default()
+            .max_sets(1)
+            .pool_sizes(&pool_sizes);
+        let pool = unsafe { self.inner.device.create_descriptor_pool(&pool_info, None) }
+            .map_err(|error| map_error("create Vulkan descriptor pool", error))?;
+        let layouts = [layout.raw];
+        let allocate_info = vk::DescriptorSetAllocateInfo::default()
+            .descriptor_pool(pool)
+            .set_layouts(&layouts);
+        let set = match unsafe { self.inner.device.allocate_descriptor_sets(&allocate_info) } {
+            Ok(sets) => sets[0],
+            Err(error) => {
+                unsafe { self.inner.device.destroy_descriptor_pool(pool, None) };
+                return Err(map_error("allocate Vulkan descriptor set", error));
+            }
+        };
+        for entry in info.entries {
+            write_descriptor(&self.inner.device, set, entry, layout)?;
+        }
+        Ok(VulkanBindGroup {
+            inner: Arc::clone(&self.inner),
+            pool,
+            set,
+        })
+    }
+
+    fn create_pipeline_layout(
+        &self,
+        info: &PipelineLayoutCreateInfo<'_, Self>,
+    ) -> Result<Self::PipelineLayout> {
+        let layouts = info
+            .bind_group_layouts
+            .iter()
+            .map(|layout| layout.raw.raw)
+            .collect::<Vec<_>>();
+        let create_info = vk::PipelineLayoutCreateInfo::default().set_layouts(&layouts);
+        let raw = unsafe { self.inner.device.create_pipeline_layout(&create_info, None) }
+            .map_err(|error| map_error("create Vulkan pipeline layout", error))?;
+        Ok(VulkanPipelineLayout {
+            inner: Arc::clone(&self.inner),
+            raw,
+        })
+    }
+
+    fn create_graphics_pipeline(
+        &self,
+        info: &GraphicsPipelineCreateInfo<'_, Self>,
+    ) -> Result<Self::Pipeline> {
+        create_graphics_pipeline(self, info)
+    }
+
+    fn create_command_pool(&self, info: &CommandPoolCreateInfo<'_>) -> Result<Self::CommandPool> {
+        let mut flags = vk::CommandPoolCreateFlags::empty();
+        if info.flags.contains(CommandPoolFlags::TRANSIENT) {
+            flags |= vk::CommandPoolCreateFlags::TRANSIENT;
+        }
+        if info.flags.contains(CommandPoolFlags::RESET_COMMAND_BUFFER) {
+            flags |= vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER;
+        }
+        let create_info = vk::CommandPoolCreateInfo::default()
+            .queue_family_index(self.inner.queues.get(info.queue).family_index)
+            .flags(flags);
+        let raw = unsafe { self.inner.device.create_command_pool(&create_info, None) }
+            .map_err(|error| map_error("create Vulkan command pool", error))?;
+        Ok(VulkanCommandPool {
+            inner: Arc::clone(&self.inner),
+            raw,
+        })
+    }
+
+    fn reset_command_pool(&self, pool: &Self::CommandPool) -> Result<()> {
+        unsafe {
+            self.inner
+                .device
+                .reset_command_pool(pool.raw, vk::CommandPoolResetFlags::RELEASE_RESOURCES)
+        }
+        .map_err(|error| map_error("reset Vulkan command pool", error))
+    }
+
+    fn allocate_command_buffer(
+        &self,
+        pool: &Self::CommandPool,
+        level: CommandBufferLevel,
+    ) -> Result<Self::CommandBuffer> {
+        let level = match level {
+            CommandBufferLevel::Primary => vk::CommandBufferLevel::PRIMARY,
+            CommandBufferLevel::Secondary => {
+                return Err(unsupported(
+                    "Vulkan secondary command buffers require inheritance metadata not represented by the RHI",
+                ));
+            }
+        };
+        let allocate_info = vk::CommandBufferAllocateInfo::default()
+            .command_pool(pool.raw)
+            .level(level)
+            .command_buffer_count(1);
+        let raw = unsafe { self.inner.device.allocate_command_buffers(&allocate_info) }
+            .map_err(|error| map_error("allocate Vulkan command buffer", error))?[0];
+        Ok(VulkanCommandBuffer { raw })
+    }
+
+    fn begin_command_buffer(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        info: &CommandBufferBeginInfo,
+    ) -> Result<()> {
+        let mut flags = vk::CommandBufferUsageFlags::empty();
+        if info.usage.contains(CommandBufferUsage::ONE_TIME_SUBMIT) {
+            flags |= vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT;
+        }
+        if info.usage.contains(CommandBufferUsage::SIMULTANEOUS_USE) {
+            flags |= vk::CommandBufferUsageFlags::SIMULTANEOUS_USE;
+        }
+        let begin_info = vk::CommandBufferBeginInfo::default().flags(flags);
+        unsafe {
+            self.inner
+                .device
+                .begin_command_buffer(command_buffer.raw, &begin_info)
+        }
+        .map_err(|error| map_error("begin Vulkan command buffer", error))
+    }
+
+    fn end_command_buffer(&self, command_buffer: &mut Self::CommandBuffer) -> Result<()> {
+        unsafe { self.inner.device.end_command_buffer(command_buffer.raw) }
+            .map_err(|error| map_error("end Vulkan command buffer", error))
+    }
+
+    fn reset_command_buffer(&self, command_buffer: &mut Self::CommandBuffer) -> Result<()> {
+        unsafe {
+            self.inner.device.reset_command_buffer(
+                command_buffer.raw,
+                vk::CommandBufferResetFlags::RELEASE_RESOURCES,
+            )
+        }
+        .map_err(|error| map_error("reset Vulkan command buffer", error))
+    }
+
+    fn command_barriers(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        image_barriers: &[ImageBarrier<'_, Self>],
+        buffer_barriers: &[BufferBarrier<'_, Self>],
+    ) -> Result<()> {
+        let image_barriers = image_barriers
+            .iter()
+            .map(|barrier| {
+                vk::ImageMemoryBarrier2::default()
+                    .src_stage_mask(mapping::pipeline_stages(barrier.before.stages))
+                    .src_access_mask(mapping::access_types(barrier.before.access))
+                    .dst_stage_mask(mapping::pipeline_stages(barrier.after.stages))
+                    .dst_access_mask(mapping::access_types(barrier.after.access))
+                    .old_layout(mapping::image_layout(barrier.before.layout))
+                    .new_layout(mapping::image_layout(barrier.after.layout))
+                    .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                    .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                    .image(barrier.image.raw.raw())
+                    .subresource_range(mapping::subresource_range(barrier.range))
+            })
+            .collect::<Vec<_>>();
+        let buffer_barriers = buffer_barriers
+            .iter()
+            .map(|barrier| {
+                vk::BufferMemoryBarrier2::default()
+                    .src_stage_mask(mapping::pipeline_stages(barrier.source_stages))
+                    .src_access_mask(mapping::access_types(barrier.source_access))
+                    .dst_stage_mask(mapping::pipeline_stages(barrier.destination_stages))
+                    .dst_access_mask(mapping::access_types(barrier.destination_access))
+                    .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                    .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                    .buffer(barrier.buffer.raw.raw)
+                    .offset(barrier.offset)
+                    .size(barrier.size)
+            })
+            .collect::<Vec<_>>();
+        let dependency_info = vk::DependencyInfo::default()
+            .image_memory_barriers(&image_barriers)
+            .buffer_memory_barriers(&buffer_barriers);
+        unsafe {
+            self.inner
+                .device
+                .cmd_pipeline_barrier2(command_buffer.raw, &dependency_info);
+        }
+        Ok(())
+    }
+
+    fn command_begin_rendering(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        info: &RenderingInfo<'_, Self>,
+    ) -> Result<()> {
+        let colors = info
+            .color_attachments
+            .iter()
+            .map(color_attachment)
+            .collect::<Vec<_>>();
+        let depth = info.depth_stencil_attachment.as_ref().map(depth_attachment);
+        let mut rendering_info = vk::RenderingInfo::default()
+            .render_area(vk::Rect2D {
+                offset: vk::Offset2D {
+                    x: info.render_area.x,
+                    y: info.render_area.y,
+                },
+                extent: vk::Extent2D {
+                    width: info.render_area.width,
+                    height: info.render_area.height,
+                },
+            })
+            .layer_count(info.layer_count)
+            .color_attachments(&colors);
+        if let Some(depth) = &depth {
+            rendering_info = rendering_info.depth_attachment(depth);
+            let view = info
+                .depth_stencil_attachment
+                .as_ref()
+                .expect("depth attachment exists when native attachment exists")
+                .view
+                .raw;
+            if matches!(
+                view.0.format,
+                vk::Format::D24_UNORM_S8_UINT | vk::Format::D32_SFLOAT_S8_UINT
+            ) {
+                rendering_info = rendering_info.stencil_attachment(depth);
+            }
+        }
+        unsafe {
+            self.inner
+                .device
+                .cmd_begin_rendering(command_buffer.raw, &rendering_info);
+        }
+        Ok(())
+    }
+
+    fn command_end_rendering(&self, command_buffer: &mut Self::CommandBuffer) -> Result<()> {
+        unsafe { self.inner.device.cmd_end_rendering(command_buffer.raw) };
+        Ok(())
+    }
+
+    fn command_copy_buffer(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        source: &Self::Buffer,
+        destination: &Self::Buffer,
+        regions: &[BufferCopy],
+    ) -> Result<()> {
+        let regions = regions
+            .iter()
+            .map(|region| vk::BufferCopy {
+                src_offset: region.source_offset,
+                dst_offset: region.destination_offset,
+                size: region.size,
+            })
+            .collect::<Vec<_>>();
+        unsafe {
+            self.inner.device.cmd_copy_buffer(
+                command_buffer.raw,
+                source.raw,
+                destination.raw,
+                &regions,
+            );
+        }
+        Ok(())
+    }
+
+    fn command_copy_buffer_to_image(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        source: &Self::Buffer,
+        destination: &Self::Image,
+        layout: ImageLayout,
+        regions: &[BufferImageCopy],
+    ) -> Result<()> {
+        let regions = regions.iter().map(buffer_image_copy).collect::<Vec<_>>();
+        unsafe {
+            self.inner.device.cmd_copy_buffer_to_image(
+                command_buffer.raw,
+                source.raw,
+                destination.raw(),
+                mapping::image_layout(layout),
+                &regions,
+            );
+        }
+        Ok(())
+    }
+
+    fn command_copy_image(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        source: &Self::Image,
+        source_layout: ImageLayout,
+        destination: &Self::Image,
+        destination_layout: ImageLayout,
+        regions: &[ImageCopy],
+    ) -> Result<()> {
+        let regions = regions.iter().map(image_copy).collect::<Vec<_>>();
+        unsafe {
+            self.inner.device.cmd_copy_image(
+                command_buffer.raw,
+                source.raw(),
+                mapping::image_layout(source_layout),
+                destination.raw(),
+                mapping::image_layout(destination_layout),
+                &regions,
+            );
+        }
+        Ok(())
+    }
+
+    fn command_blit_image(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        source: &Self::Image,
+        source_layout: ImageLayout,
+        destination: &Self::Image,
+        destination_layout: ImageLayout,
+        regions: &[ImageBlit],
+        filter: Filter,
+    ) -> Result<()> {
+        let regions = regions.iter().map(image_blit).collect::<Vec<_>>();
+        unsafe {
+            self.inner.device.cmd_blit_image(
+                command_buffer.raw,
+                source.raw(),
+                mapping::image_layout(source_layout),
+                destination.raw(),
+                mapping::image_layout(destination_layout),
+                &regions,
+                mapping::filter(filter),
+            );
+        }
+        Ok(())
+    }
+
+    fn command_set_viewport(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        viewport: Viewport,
+    ) -> Result<()> {
+        let viewport = vk::Viewport {
+            x: viewport.x,
+            y: viewport.y,
+            width: viewport.width,
+            height: viewport.height,
+            min_depth: viewport.min_depth,
+            max_depth: viewport.max_depth,
+        };
+        unsafe {
+            self.inner.device.cmd_set_viewport(
+                command_buffer.raw,
+                0,
+                std::slice::from_ref(&viewport),
+            );
+        }
+        Ok(())
+    }
+
+    fn command_set_scissor(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        scissor: Rect2D,
+    ) -> Result<()> {
+        let scissor = vk::Rect2D {
+            offset: vk::Offset2D {
+                x: scissor.x,
+                y: scissor.y,
+            },
+            extent: vk::Extent2D {
+                width: scissor.width,
+                height: scissor.height,
+            },
+        };
+        unsafe {
+            self.inner.device.cmd_set_scissor(
+                command_buffer.raw,
+                0,
+                std::slice::from_ref(&scissor),
+            );
+        }
+        Ok(())
+    }
+
+    fn command_bind_graphics_pipeline(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        pipeline: &Self::Pipeline,
+    ) -> Result<()> {
+        unsafe {
+            self.inner.device.cmd_bind_pipeline(
+                command_buffer.raw,
+                vk::PipelineBindPoint::GRAPHICS,
+                pipeline.raw,
+            );
+        }
+        Ok(())
+    }
+
+    fn command_bind_graphics_groups(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        layout: &Self::PipelineLayout,
+        first_group: u32,
+        groups: &[&crate::BindGroup<Self>],
+        dynamic_offsets: &[u32],
+    ) -> Result<()> {
+        if !dynamic_offsets.is_empty() {
+            return Err(unsupported(
+                "Vulkan dynamic descriptor offsets require a dynamic binding type not represented by the RHI",
+            ));
+        }
+        let sets = groups.iter().map(|group| group.raw.set).collect::<Vec<_>>();
+        unsafe {
+            self.inner.device.cmd_bind_descriptor_sets(
+                command_buffer.raw,
+                vk::PipelineBindPoint::GRAPHICS,
+                layout.raw,
+                first_group,
+                &sets,
+                dynamic_offsets,
+            );
+        }
+        Ok(())
+    }
+
+    fn command_bind_vertex_buffers(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        first_binding: u32,
+        buffers: &[VertexBufferBinding<'_, Self>],
+    ) -> Result<()> {
+        let handles = buffers
+            .iter()
+            .map(|binding| binding.buffer.raw.raw)
+            .collect::<Vec<_>>();
+        let offsets = buffers
+            .iter()
+            .map(|binding| binding.offset)
+            .collect::<Vec<_>>();
+        unsafe {
+            self.inner.device.cmd_bind_vertex_buffers(
+                command_buffer.raw,
+                first_binding,
+                &handles,
+                &offsets,
+            );
+        }
+        Ok(())
+    }
+
+    fn command_bind_index_buffer(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        buffer: &Self::Buffer,
+        offset: u64,
+        format: IndexFormat,
+    ) -> Result<()> {
+        unsafe {
+            self.inner.device.cmd_bind_index_buffer(
+                command_buffer.raw,
+                buffer.raw,
+                offset,
+                mapping::index_type(format),
+            );
+        }
+        Ok(())
+    }
+
+    fn command_draw_indexed(
+        &self,
+        command_buffer: &mut Self::CommandBuffer,
+        draw: DrawIndexed,
+    ) -> Result<()> {
+        unsafe {
+            self.inner.device.cmd_draw_indexed(
+                command_buffer.raw,
+                draw.index_count,
+                draw.instance_count,
+                draw.first_index,
+                draw.vertex_offset,
+                draw.first_instance,
+            );
+        }
+        Ok(())
+    }
+
+    fn command_draw(&self, command_buffer: &mut Self::CommandBuffer, draw: Draw) -> Result<()> {
+        unsafe {
+            self.inner.device.cmd_draw(
+                command_buffer.raw,
+                draw.vertex_count,
+                draw.instance_count,
+                draw.first_vertex,
+                draw.first_instance,
+            );
+        }
+        Ok(())
+    }
+
+    fn create_fence(&self, signaled: bool) -> Result<Self::Fence> {
+        let flags = if signaled {
+            vk::FenceCreateFlags::SIGNALED
+        } else {
+            vk::FenceCreateFlags::empty()
+        };
+        let create_info = vk::FenceCreateInfo::default().flags(flags);
+        let raw = unsafe { self.inner.device.create_fence(&create_info, None) }
+            .map_err(|error| map_error("create Vulkan fence", error))?;
+        Ok(VulkanFence {
+            inner: Arc::clone(&self.inner),
+            raw,
+        })
+    }
+
+    fn wait_for_fence(&self, fence: &Self::Fence, timeout_ns: u64) -> Result<()> {
+        unsafe {
+            self.inner
+                .device
+                .wait_for_fences(std::slice::from_ref(&fence.raw), true, timeout_ns)
+        }
+        .map_err(|error| map_error("wait for Vulkan fence", error))
+    }
+
+    fn reset_fence(&self, fence: &mut Self::Fence) -> Result<()> {
+        unsafe {
+            self.inner
+                .device
+                .reset_fences(std::slice::from_ref(&fence.raw))
+        }
+        .map_err(|error| map_error("reset Vulkan fence", error))
+    }
+
+    fn create_semaphore(&self, kind: SemaphoreKind) -> Result<Self::Semaphore> {
+        let raw = match kind {
+            SemaphoreKind::Binary => unsafe {
+                self.inner
+                    .device
+                    .create_semaphore(&vk::SemaphoreCreateInfo::default(), None)
+            },
+            SemaphoreKind::Timeline { initial_value } => {
+                let mut type_info = vk::SemaphoreTypeCreateInfo::default()
+                    .semaphore_type(vk::SemaphoreType::TIMELINE)
+                    .initial_value(initial_value);
+                let create_info = vk::SemaphoreCreateInfo::default().push_next(&mut type_info);
+                unsafe { self.inner.device.create_semaphore(&create_info, None) }
+            }
+        }
+        .map_err(|error| map_error("create Vulkan semaphore", error))?;
+        Ok(VulkanSemaphore {
+            inner: Arc::clone(&self.inner),
+            raw,
+        })
+    }
+
+    fn wait_for_semaphore(
+        &self,
+        semaphore: &Self::Semaphore,
+        value: u64,
+        timeout_ns: u64,
+    ) -> Result<()> {
+        let semaphores = [semaphore.raw];
+        let values = [value];
+        let wait_info = vk::SemaphoreWaitInfo::default()
+            .semaphores(&semaphores)
+            .values(&values);
+        unsafe { self.inner.device.wait_semaphores(&wait_info, timeout_ns) }
+            .map_err(|error| map_error("wait for Vulkan timeline semaphore", error))
+    }
+
+    fn semaphore_value(&self, semaphore: &Self::Semaphore) -> Result<u64> {
+        unsafe { self.inner.device.get_semaphore_counter_value(semaphore.raw) }
+            .map_err(|error| map_error("query Vulkan timeline semaphore", error))
+    }
+
+    fn submit(
+        &self,
+        queue: QueueType,
+        info: &SubmitInfo<'_, Self>,
+        fence: &Fence<Self>,
+    ) -> Result<()> {
+        let waits = info
+            .waits
+            .iter()
+            .map(|wait| {
+                vk::SemaphoreSubmitInfo::default()
+                    .semaphore(wait.semaphore.raw.raw)
+                    .value(wait.value.unwrap_or(0))
+                    .stage_mask(mapping::pipeline_stages(wait.stages))
+            })
+            .collect::<Vec<_>>();
+        let command_buffers = info
+            .command_buffers
+            .iter()
+            .map(|command_buffer| {
+                vk::CommandBufferSubmitInfo::default().command_buffer(command_buffer.raw.raw)
+            })
+            .collect::<Vec<_>>();
+        let signals = info
+            .signals
+            .iter()
+            .map(|signal| {
+                vk::SemaphoreSubmitInfo::default()
+                    .semaphore(signal.semaphore.raw.raw)
+                    .value(signal.value.unwrap_or(0))
+                    .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            })
+            .collect::<Vec<_>>();
+        let submit_info = vk::SubmitInfo2::default()
+            .wait_semaphore_infos(&waits)
+            .command_buffer_infos(&command_buffers)
+            .signal_semaphore_infos(&signals);
+        let _queue_guard = super::lock(&self.inner.queue_lock);
+        unsafe {
+            self.inner.device.queue_submit2(
+                self.inner.queues.get(queue).raw,
+                std::slice::from_ref(&submit_info),
+                fence.raw.raw,
+            )
+        }
+        .map_err(|error| map_error("submit Vulkan queue", error))
+    }
+
+    #[cfg(feature = "presentation")]
+    type SurfaceTarget = dyn super::VulkanSurfaceTarget;
+    #[cfg(feature = "presentation")]
+    type Surface = super::presentation::VulkanSurface;
+    #[cfg(feature = "presentation")]
+    type Swapchain = super::presentation::VulkanSwapchain;
+    #[cfg(feature = "presentation")]
+    type RenderImage = super::presentation::VulkanRenderImage;
+
+    #[cfg(feature = "presentation")]
+    fn create_surface(&self, target: &Self::SurfaceTarget) -> Result<Self::Surface> {
+        super::presentation::create_surface(self, target)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn create_swapchain(
+        &self,
+        surface: &Self::Surface,
+        info: &crate::SwapchainCreateInfo<'_>,
+    ) -> Result<Self::Swapchain> {
+        super::presentation::create_swapchain(self, surface, info)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn recreate_swapchain(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        surface: &Self::Surface,
+        info: &crate::SwapchainCreateInfo<'_>,
+    ) -> Result<()> {
+        super::presentation::recreate_swapchain(self, swapchain, surface, info)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn swapchain_extent(swapchain: &Self::Swapchain) -> crate::Extent2D {
+        super::presentation::swapchain_extent(swapchain)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn swapchain_format(swapchain: &Self::Swapchain) -> crate::Format {
+        super::presentation::swapchain_format(swapchain)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn acquire_render_image(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        timeout_ns: u64,
+        signal: &Self::Semaphore,
+    ) -> Result<Self::RenderImage> {
+        super::presentation::acquire_render_image(self, swapchain, timeout_ns, signal)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn render_image_parts(image: &Self::RenderImage) -> (&Self::Image, &Self::ImageView, u32) {
+        super::presentation::render_image_parts(image)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn present(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        image: Self::RenderImage,
+        waits: &[&Self::Semaphore],
+    ) -> Result<()> {
+        super::presentation::present(self, swapchain, &image, waits)
+    }
+
+    #[cfg(feature = "presentation")]
+    fn abandon_render_image(
+        &self,
+        swapchain: &mut Self::Swapchain,
+        image: Self::RenderImage,
+    ) -> Result<()> {
+        super::presentation::abandon_render_image(self, swapchain, &image)
+    }
+}
+
+fn validate_bind_group_entries(
+    layout: &VulkanBindGroupLayout,
+    info: &BindGroupCreateInfo<'_, VulkanBackend>,
+) -> Result<()> {
+    for entry in info.entries {
+        let layout_entry = layout
+            .entries
+            .iter()
+            .find(|candidate| candidate.binding == entry.binding)
+            .ok_or_else(|| {
+                unsupported(format!(
+                    "Vulkan bind group binding {} is not declared by its layout",
+                    entry.binding
+                ))
+            })?;
+        if entry.array_element >= layout_entry.count {
+            return Err(unsupported(format!(
+                "Vulkan bind group binding {} array element {} exceeds count {}",
+                entry.binding, entry.array_element, layout_entry.count
+            )));
+        }
+        let matches = matches!(
+            (layout_entry.binding_type, entry.resource),
+            (
+                BindingType::UniformBuffer | BindingType::StorageBuffer { .. },
+                BindingResource::Buffer { .. }
+            ) | (
+                BindingType::SampledImage | BindingType::StorageImage { .. },
+                BindingResource::ImageView(_)
+            ) | (BindingType::Sampler, BindingResource::Sampler(_))
+                | (
+                    BindingType::CombinedImageSampler,
+                    BindingResource::CombinedImageSampler { .. }
+                )
+        );
+        if !matches {
+            return Err(unsupported(format!(
+                "Vulkan bind group binding {} has a resource incompatible with {:?}",
+                entry.binding, layout_entry.binding_type
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn write_descriptor(
+    device: &ash::Device,
+    set: vk::DescriptorSet,
+    entry: &crate::BindGroupEntry<'_, VulkanBackend>,
+    layout: &VulkanBindGroupLayout,
+) -> Result<()> {
+    let layout_entry = layout
+        .entries
+        .iter()
+        .find(|candidate| candidate.binding == entry.binding)
+        .expect("bind group entries were validated");
+    let descriptor_type = mapping::descriptor_type(layout_entry.binding_type);
+    match entry.resource {
+        BindingResource::Buffer {
+            buffer,
+            offset,
+            size,
+        } => {
+            let info = [vk::DescriptorBufferInfo {
+                buffer: buffer.raw.raw,
+                offset,
+                range: size,
+            }];
+            let write = vk::WriteDescriptorSet::default()
+                .dst_set(set)
+                .dst_binding(entry.binding)
+                .dst_array_element(entry.array_element)
+                .descriptor_type(descriptor_type)
+                .buffer_info(&info);
+            unsafe { device.update_descriptor_sets(std::slice::from_ref(&write), &[]) };
+        }
+        BindingResource::ImageView(view) => {
+            let image_layout = match layout_entry.binding_type {
+                BindingType::SampledImage => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+                BindingType::StorageImage { .. } => vk::ImageLayout::GENERAL,
+                _ => {
+                    return Err(unsupported(
+                        "Vulkan image descriptor type was not validated",
+                    ));
+                }
+            };
+            let info = [vk::DescriptorImageInfo::default()
+                .image_view(view.as_ref().raw.raw())
+                .image_layout(image_layout)];
+            let write = vk::WriteDescriptorSet::default()
+                .dst_set(set)
+                .dst_binding(entry.binding)
+                .dst_array_element(entry.array_element)
+                .descriptor_type(descriptor_type)
+                .image_info(&info);
+            unsafe { device.update_descriptor_sets(std::slice::from_ref(&write), &[]) };
+        }
+        BindingResource::Sampler(sampler) => {
+            let info = [vk::DescriptorImageInfo::default().sampler(sampler.raw.raw)];
+            let write = vk::WriteDescriptorSet::default()
+                .dst_set(set)
+                .dst_binding(entry.binding)
+                .dst_array_element(entry.array_element)
+                .descriptor_type(descriptor_type)
+                .image_info(&info);
+            unsafe { device.update_descriptor_sets(std::slice::from_ref(&write), &[]) };
+        }
+        BindingResource::CombinedImageSampler { view, sampler } => {
+            let info = [vk::DescriptorImageInfo::default()
+                .sampler(sampler.raw.raw)
+                .image_view(view.as_ref().raw.raw())
+                .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)];
+            let write = vk::WriteDescriptorSet::default()
+                .dst_set(set)
+                .dst_binding(entry.binding)
+                .dst_array_element(entry.array_element)
+                .descriptor_type(descriptor_type)
+                .image_info(&info);
+            unsafe { device.update_descriptor_sets(std::slice::from_ref(&write), &[]) };
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+fn create_graphics_pipeline(
+    backend: &VulkanBackend,
+    info: &GraphicsPipelineCreateInfo<'_, VulkanBackend>,
+) -> Result<VulkanPipeline> {
+    let vertex_name = CString::new(info.vertex.entry_point)
+        .map_err(|_| unsupported("Vulkan vertex entry point contains an interior NUL"))?;
+    let fragment_name = info
+        .fragment
+        .as_ref()
+        .map(|fragment| CString::new(fragment.entry_point))
+        .transpose()
+        .map_err(|_| unsupported("Vulkan fragment entry point contains an interior NUL"))?;
+    let mut stages = vec![
+        vk::PipelineShaderStageCreateInfo::default()
+            .stage(vk::ShaderStageFlags::VERTEX)
+            .module(info.vertex.module.raw.raw)
+            .name(&vertex_name),
+    ];
+    if let (Some(fragment), Some(name)) = (&info.fragment, &fragment_name) {
+        stages.push(
+            vk::PipelineShaderStageCreateInfo::default()
+                .stage(vk::ShaderStageFlags::FRAGMENT)
+                .module(fragment.module.raw.raw)
+                .name(name),
+        );
+    }
+
+    let vertex_bindings = info
+        .vertex
+        .buffers
+        .iter()
+        .enumerate()
+        .map(|(binding, layout)| {
+            Ok(vk::VertexInputBindingDescription {
+                binding: u32::try_from(binding)
+                    .map_err(|_| unsupported("Vulkan vertex binding index exceeds u32"))?,
+                stride: u32::try_from(layout.stride)
+                    .map_err(|_| unsupported("Vulkan vertex stride exceeds u32"))?,
+                input_rate: mapping::vertex_rate(layout.step_mode),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut vertex_attributes = Vec::new();
+    for (binding, layout) in info.vertex.buffers.iter().enumerate() {
+        let binding = u32::try_from(binding)
+            .map_err(|_| unsupported("Vulkan vertex binding index exceeds u32"))?;
+        for attribute in layout.attributes {
+            vertex_attributes.push(vk::VertexInputAttributeDescription {
+                location: attribute.location,
+                binding,
+                format: mapping::vertex_format(attribute.format),
+                offset: u32::try_from(attribute.offset)
+                    .map_err(|_| unsupported("Vulkan vertex attribute offset exceeds u32"))?,
+            });
+        }
+    }
+    let vertex_input = vk::PipelineVertexInputStateCreateInfo::default()
+        .vertex_binding_descriptions(&vertex_bindings)
+        .vertex_attribute_descriptions(&vertex_attributes);
+    let input_assembly = vk::PipelineInputAssemblyStateCreateInfo::default()
+        .topology(mapping::primitive_topology(info.primitive.topology));
+    let viewport_state = vk::PipelineViewportStateCreateInfo::default()
+        .viewport_count(1)
+        .scissor_count(1);
+    let rasterization = vk::PipelineRasterizationStateCreateInfo::default()
+        .polygon_mode(vk::PolygonMode::FILL)
+        .cull_mode(mapping::cull_mode(info.primitive.cull_mode))
+        .front_face(mapping::front_face(info.primitive.front_face))
+        .line_width(1.0);
+    let multisample = vk::PipelineMultisampleStateCreateInfo::default()
+        .rasterization_samples(mapping::sample_count(info.samples));
+    let color_attachments = info
+        .fragment
+        .as_ref()
+        .map_or(&[][..], |fragment| fragment.targets)
+        .iter()
+        .map(|target| {
+            vk::PipelineColorBlendAttachmentState::default()
+                .color_write_mask(mapping::color_writes(target.write_mask))
+        })
+        .collect::<Vec<_>>();
+    let color_blend =
+        vk::PipelineColorBlendStateCreateInfo::default().attachments(&color_attachments);
+    let depth_stencil =
+        info.depth
+            .map_or_else(vk::PipelineDepthStencilStateCreateInfo::default, |depth| {
+                vk::PipelineDepthStencilStateCreateInfo::default()
+                    .depth_test_enable(depth.test_enabled)
+                    .depth_write_enable(depth.write_enabled)
+                    .depth_compare_op(mapping::compare_op(depth.compare))
+            });
+    let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
+    let dynamic = vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+    let color_formats = info
+        .fragment
+        .as_ref()
+        .map_or(&[][..], |fragment| fragment.targets)
+        .iter()
+        .map(|target| mapping::format(target.format))
+        .collect::<Vec<_>>();
+    let (depth_format, stencil_format) =
+        pipeline_depth_stencil_formats(info.depth.map(|d| d.format));
+    let mut rendering = vk::PipelineRenderingCreateInfo::default()
+        .color_attachment_formats(&color_formats)
+        .depth_attachment_format(depth_format)
+        .stencil_attachment_format(stencil_format);
+    let pipeline_info = vk::GraphicsPipelineCreateInfo::default()
+        .stages(&stages)
+        .vertex_input_state(&vertex_input)
+        .input_assembly_state(&input_assembly)
+        .viewport_state(&viewport_state)
+        .rasterization_state(&rasterization)
+        .multisample_state(&multisample)
+        .color_blend_state(&color_blend)
+        .depth_stencil_state(&depth_stencil)
+        .dynamic_state(&dynamic)
+        .layout(info.layout.raw.raw)
+        .push_next(&mut rendering);
+    let raw = unsafe {
+        backend.inner.device.create_graphics_pipelines(
+            vk::PipelineCache::null(),
+            std::slice::from_ref(&pipeline_info),
+            None,
+        )
+    }
+    .map_err(|(_, error)| map_error("create Vulkan graphics pipeline", error))?[0];
+    Ok(VulkanPipeline {
+        inner: Arc::clone(&backend.inner),
+        raw,
+    })
+}
+
+fn image_create_flags(info: &ImageCreateInfo<'_>) -> vk::ImageCreateFlags {
+    if info.dimension == crate::ImageDimension::Two
+        && info.extent.width == info.extent.height
+        && info.array_layers >= 6
+    {
+        vk::ImageCreateFlags::CUBE_COMPATIBLE
+    } else {
+        vk::ImageCreateFlags::empty()
+    }
+}
+
+fn pipeline_depth_stencil_formats(format: Option<crate::Format>) -> (vk::Format, vk::Format) {
+    let depth = format.map_or(vk::Format::UNDEFINED, mapping::format);
+    let stencil = format
+        .filter(|format| format.aspects().contains(crate::ImageAspects::STENCIL))
+        .map_or(vk::Format::UNDEFINED, mapping::format);
+    (depth, stencil)
+}
+
+fn color_attachment(
+    attachment: &ColorAttachment<'_, VulkanBackend>,
+) -> vk::RenderingAttachmentInfo<'static> {
+    let (load_op, clear_value) = match attachment.load {
+        LoadOperation::Load => (vk::AttachmentLoadOp::LOAD, vk::ClearValue::default()),
+        LoadOperation::Clear(color) => (
+            vk::AttachmentLoadOp::CLEAR,
+            vk::ClearValue {
+                color: vk::ClearColorValue { float32: color },
+            },
+        ),
+        LoadOperation::DontCare => (vk::AttachmentLoadOp::DONT_CARE, vk::ClearValue::default()),
+    };
+    let mut info = vk::RenderingAttachmentInfo::default()
+        .image_view(attachment.view.raw.raw())
+        .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+        .load_op(load_op)
+        .store_op(store_op(attachment.store))
+        .clear_value(clear_value);
+    if let Some(resolve) = attachment.resolve_target {
+        info = info
+            .resolve_mode(vk::ResolveModeFlags::AVERAGE)
+            .resolve_image_view(resolve.raw.raw())
+            .resolve_image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL);
+    }
+    info
+}
+
+fn depth_attachment(
+    attachment: &DepthStencilAttachment<'_, VulkanBackend>,
+) -> vk::RenderingAttachmentInfo<'static> {
+    let (load_op, clear_value) = match attachment.load {
+        LoadOperation::Load => (vk::AttachmentLoadOp::LOAD, vk::ClearValue::default()),
+        LoadOperation::Clear(value) => (
+            vk::AttachmentLoadOp::CLEAR,
+            vk::ClearValue {
+                depth_stencil: vk::ClearDepthStencilValue {
+                    depth: value.depth,
+                    stencil: value.stencil,
+                },
+            },
+        ),
+        LoadOperation::DontCare => (vk::AttachmentLoadOp::DONT_CARE, vk::ClearValue::default()),
+    };
+    vk::RenderingAttachmentInfo::default()
+        .image_view(attachment.view.raw.raw())
+        .image_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
+        .load_op(load_op)
+        .store_op(store_op(attachment.store))
+        .clear_value(clear_value)
+}
+
+fn store_op(value: StoreOperation) -> vk::AttachmentStoreOp {
+    match value {
+        StoreOperation::Store => vk::AttachmentStoreOp::STORE,
+        StoreOperation::DontCare => vk::AttachmentStoreOp::DONT_CARE,
+    }
+}
+
+fn buffer_image_copy(value: &BufferImageCopy) -> vk::BufferImageCopy {
+    vk::BufferImageCopy::default()
+        .buffer_offset(value.buffer_offset)
+        .image_subresource(mapping::subresource_layers(value.image_subresource))
+        .image_offset(offset(value.image_offset))
+        .image_extent(extent(value.image_extent))
+}
+
+fn image_copy(value: &ImageCopy) -> vk::ImageCopy {
+    vk::ImageCopy::default()
+        .src_subresource(mapping::subresource_layers(value.source_subresource))
+        .src_offset(offset(value.source_offset))
+        .dst_subresource(mapping::subresource_layers(value.destination_subresource))
+        .dst_offset(offset(value.destination_offset))
+        .extent(extent(value.extent))
+}
+
+fn image_blit(value: &ImageBlit) -> vk::ImageBlit {
+    vk::ImageBlit::default()
+        .src_subresource(mapping::subresource_layers(value.source_subresource))
+        .src_offsets(value.source_offsets.map(offset))
+        .dst_subresource(mapping::subresource_layers(value.destination_subresource))
+        .dst_offsets(value.destination_offsets.map(offset))
+}
+
+fn offset(value: crate::Offset3D) -> vk::Offset3D {
+    vk::Offset3D {
+        x: value.x,
+        y: value.y,
+        z: value.z,
+    }
+}
+
+fn extent(value: crate::Extent3D) -> vk::Extent3D {
+    vk::Extent3D {
+        width: value.width,
+        height: value.height,
+        depth: value.depth,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image_info(width: u32, height: u32, layers: u32) -> ImageCreateInfo<'static> {
+        ImageCreateInfo {
+            dimension: crate::ImageDimension::Two,
+            extent: crate::Extent3D::new(width, height, 1),
+            format: crate::Format::Rgba8Unorm,
+            usage: crate::ImageUsage::SAMPLED,
+            memory: crate::MemoryLocation::Device,
+            mip_levels: 1,
+            array_layers: layers,
+            samples: crate::SampleCount::One,
+            label: None,
+        }
+    }
+
+    #[test]
+    fn cube_compatible_flag_requires_square_2d_array() {
+        assert_eq!(
+            image_create_flags(&image_info(64, 64, 6)),
+            vk::ImageCreateFlags::CUBE_COMPATIBLE
+        );
+        assert!(image_create_flags(&image_info(64, 32, 6)).is_empty());
+        assert!(image_create_flags(&image_info(64, 64, 5)).is_empty());
+    }
+
+    #[test]
+    fn stencil_depth_formats_set_both_dynamic_rendering_formats() {
+        assert_eq!(
+            pipeline_depth_stencil_formats(Some(crate::Format::Depth24UnormStencil8)),
+            (vk::Format::D24_UNORM_S8_UINT, vk::Format::D24_UNORM_S8_UINT)
+        );
+        assert_eq!(
+            pipeline_depth_stencil_formats(Some(crate::Format::Depth32Float)),
+            (vk::Format::D32_SFLOAT, vk::Format::UNDEFINED)
+        );
+    }
+}

--- a/crates/dirk_rhi/src/vulkan/debug.rs
+++ b/crates/dirk_rhi/src/vulkan/debug.rs
@@ -1,0 +1,68 @@
+use std::{ffi::CStr, os::raw::c_void};
+
+use ash::{Entry, vk};
+use tracing::{debug, error, info, trace, warn};
+
+use super::{map_error, unsupported};
+use crate::Result;
+
+pub(super) const VALIDATION_LAYERS: &[*const i8] = &[c"VK_LAYER_KHRONOS_validation".as_ptr()];
+
+unsafe extern "system" fn callback(
+    severity: vk::DebugUtilsMessageSeverityFlagsEXT,
+    _message_type: vk::DebugUtilsMessageTypeFlagsEXT,
+    callback_data: *const vk::DebugUtilsMessengerCallbackDataEXT<'_>,
+    _user_data: *mut c_void,
+) -> vk::Bool32 {
+    let message = unsafe { CStr::from_ptr((*callback_data).p_message) }.to_string_lossy();
+    match severity {
+        vk::DebugUtilsMessageSeverityFlagsEXT::ERROR => {
+            error!(target: "vulkan::validation", "{message}");
+        }
+        vk::DebugUtilsMessageSeverityFlagsEXT::WARNING => {
+            warn!(target: "vulkan::validation", "{message}");
+        }
+        vk::DebugUtilsMessageSeverityFlagsEXT::INFO => {
+            info!(target: "vulkan::validation", "{message}");
+        }
+        vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE => {
+            debug!(target: "vulkan::validation", "{message}");
+        }
+        _ => trace!(target: "vulkan::validation", "{message}"),
+    }
+    vk::FALSE
+}
+
+pub(super) fn create_info() -> vk::DebugUtilsMessengerCreateInfoEXT<'static> {
+    vk::DebugUtilsMessengerCreateInfoEXT::default()
+        .message_severity(
+            vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE
+                | vk::DebugUtilsMessageSeverityFlagsEXT::INFO
+                | vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
+                | vk::DebugUtilsMessageSeverityFlagsEXT::ERROR,
+        )
+        .message_type(
+            vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
+                | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
+        )
+        .pfn_user_callback(Some(callback))
+}
+
+pub(super) fn validate_layers(entry: &Entry) -> Result<()> {
+    let available = unsafe { entry.enumerate_instance_layer_properties() }
+        .map_err(|error| map_error("enumerate Vulkan instance layers", error))?;
+    for &required in VALIDATION_LAYERS {
+        let required = unsafe { CStr::from_ptr(required) };
+        if !available
+            .iter()
+            .any(|layer| (unsafe { CStr::from_ptr(layer.layer_name.as_ptr()) }) == required)
+        {
+            return Err(unsupported(format!(
+                "required Vulkan validation layer {} is unavailable",
+                required.to_string_lossy()
+            )));
+        }
+    }
+    Ok(())
+}

--- a/crates/dirk_rhi/src/vulkan/init.rs
+++ b/crates/dirk_rhi/src/vulkan/init.rs
@@ -1,0 +1,592 @@
+use std::{collections::HashSet, ffi::CStr};
+
+use ash::{Entry, vk};
+use dirk_utils::Version;
+use gpu_allocator::{
+    AllocationSizes, AllocatorDebugSettings,
+    vulkan::{Allocator, AllocatorCreateDesc},
+};
+use tracing::info;
+
+use super::{Inner, Queue, Queues, VulkanBackend, VulkanDevice, map_error, unsupported};
+use crate::{Device, Result};
+
+/// Application metadata used to initialize Vulkan.
+pub struct VulkanCreateInfo {
+    /// Engine name reported to Vulkan tooling.
+    pub engine_name: std::ffi::CString,
+    /// Engine version reported to Vulkan tooling.
+    pub engine_version: Version,
+    /// Application name reported to Vulkan tooling.
+    pub application_name: std::ffi::CString,
+    /// Application version reported to Vulkan tooling.
+    pub application_version: Version,
+}
+
+impl VulkanBackend {
+    /// Creates a headless Vulkan device.
+    pub fn create(info: &VulkanCreateInfo) -> Result<VulkanDevice> {
+        let entry = unsafe { Entry::load() }.map_err(|error| map_error("load Vulkan", error))?;
+        let instance = create_instance(&entry, info, required_headless_extensions())?;
+        let selected = select_physical_device(instance.instance())?;
+        create_backend(entry, instance, selected).map(Device::new)
+    }
+
+    /// Creates a Vulkan device selected for presentation to `window`.
+    #[cfg(feature = "presentation")]
+    pub fn create_for_window(
+        info: &VulkanCreateInfo,
+        window: &(impl super::VulkanSurfaceTarget + ?Sized),
+    ) -> Result<VulkanDevice> {
+        let entry = unsafe { Entry::load() }.map_err(|error| map_error("load Vulkan", error))?;
+        let display = window
+            .display_handle()
+            .map_err(|error| map_error("get display handle", error))?;
+        let mut extensions = ash_window::enumerate_required_extensions(display.as_raw())
+            .map_err(|error| map_error("enumerate window extensions", error))?
+            .to_vec();
+        extensions.extend(required_headless_extensions());
+        deduplicate_extensions(&mut extensions);
+        let instance = create_instance(&entry, info, extensions)?;
+        let surface_loader = ash::khr::surface::Instance::new(&entry, instance.instance());
+        let selected = {
+            let surface = TemporarySurface::new(
+                &surface_loader,
+                super::presentation::create_raw_surface(&entry, instance.instance(), window)?,
+            );
+            select_physical_device_for_surface(instance.instance(), &surface_loader, surface.raw)?
+        };
+        create_backend(entry, instance, selected).map(Device::new)
+    }
+}
+
+impl Device<VulkanBackend> {
+    /// Creates a headless Vulkan-backed RHI device.
+    pub fn new_vulkan(info: &VulkanCreateInfo) -> Result<Self> {
+        VulkanBackend::create(info)
+    }
+
+    /// Creates a presentation-ready Vulkan-backed RHI device.
+    #[cfg(feature = "presentation")]
+    pub fn new_vulkan_for_window(
+        info: &VulkanCreateInfo,
+        window: &(impl super::VulkanSurfaceTarget + ?Sized),
+    ) -> Result<Self> {
+        VulkanBackend::create_for_window(info, window)
+    }
+}
+
+struct InstanceGuard {
+    instance: Option<ash::Instance>,
+    #[cfg(validation)]
+    debug: Option<(ash::ext::debug_utils::Instance, vk::DebugUtilsMessengerEXT)>,
+}
+
+impl InstanceGuard {
+    fn new(instance: ash::Instance) -> Self {
+        Self {
+            instance: Some(instance),
+            #[cfg(validation)]
+            debug: None,
+        }
+    }
+
+    fn instance(&self) -> &ash::Instance {
+        self.instance.as_ref().expect("guard owns Vulkan instance")
+    }
+
+    fn into_parts(mut self) -> InstanceParts {
+        InstanceParts {
+            instance: self.instance.take().expect("guard owns Vulkan instance"),
+            #[cfg(validation)]
+            debug: self.debug.take().expect("validation messenger was created"),
+        }
+    }
+}
+
+impl Drop for InstanceGuard {
+    fn drop(&mut self) {
+        unsafe {
+            #[cfg(validation)]
+            if let Some((loader, messenger)) = self.debug.take() {
+                loader.destroy_debug_utils_messenger(messenger, None);
+            }
+            if let Some(instance) = self.instance.take() {
+                instance.destroy_instance(None);
+            }
+        }
+    }
+}
+
+struct InstanceParts {
+    instance: ash::Instance,
+    #[cfg(validation)]
+    debug: (ash::ext::debug_utils::Instance, vk::DebugUtilsMessengerEXT),
+}
+
+struct DeviceGuard(Option<ash::Device>);
+
+impl DeviceGuard {
+    fn device(&self) -> &ash::Device {
+        self.0.as_ref().expect("guard owns Vulkan device")
+    }
+
+    fn take(mut self) -> ash::Device {
+        self.0.take().expect("guard owns Vulkan device")
+    }
+}
+
+impl Drop for DeviceGuard {
+    fn drop(&mut self) {
+        if let Some(device) = self.0.take() {
+            unsafe { device.destroy_device(None) };
+        }
+    }
+}
+
+#[cfg(feature = "presentation")]
+struct TemporarySurface<'a> {
+    loader: &'a ash::khr::surface::Instance,
+    raw: vk::SurfaceKHR,
+}
+
+#[cfg(feature = "presentation")]
+impl<'a> TemporarySurface<'a> {
+    fn new(loader: &'a ash::khr::surface::Instance, raw: vk::SurfaceKHR) -> Self {
+        Self { loader, raw }
+    }
+}
+
+#[cfg(feature = "presentation")]
+impl Drop for TemporarySurface<'_> {
+    fn drop(&mut self) {
+        unsafe { self.loader.destroy_surface(self.raw, None) };
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SelectedDevice {
+    physical_device: vk::PhysicalDevice,
+    queues: QueueFamilies,
+}
+
+#[derive(Clone, Copy)]
+struct QueueFamilies {
+    graphics: u32,
+    compute: u32,
+    transfer: u32,
+    #[cfg(feature = "presentation")]
+    present: Option<u32>,
+}
+
+fn create_backend(
+    entry: Entry,
+    instance: InstanceGuard,
+    selected: SelectedDevice,
+) -> Result<VulkanBackend> {
+    let properties = unsafe {
+        instance
+            .instance()
+            .get_physical_device_properties(selected.physical_device)
+    };
+    let device = DeviceGuard(Some(create_logical_device(instance.instance(), &selected)?));
+    let queues = Queues {
+        graphics: queue(device.device(), selected.queues.graphics),
+        compute: queue(device.device(), selected.queues.compute),
+        transfer: queue(device.device(), selected.queues.transfer),
+        #[cfg(feature = "presentation")]
+        present: selected
+            .queues
+            .present
+            .map(|family| queue(device.device(), family)),
+    };
+    let allocator = Allocator::new(&AllocatorCreateDesc {
+        instance: instance.instance().clone(),
+        device: device.device().clone(),
+        physical_device: selected.physical_device,
+        debug_settings: AllocatorDebugSettings::default(),
+        buffer_device_address: false,
+        allocation_sizes: AllocationSizes::default(),
+    });
+    let allocator = allocator.map_err(|error| map_error("create Vulkan allocator", error))?;
+
+    let device = device.take();
+    let instance = instance.into_parts();
+
+    #[cfg(feature = "presentation")]
+    let surface_loader = ash::khr::surface::Instance::new(&entry, &instance.instance);
+    #[cfg(feature = "presentation")]
+    let swapchain_loader = ash::khr::swapchain::Device::new(&instance.instance, &device);
+
+    Ok(VulkanBackend {
+        inner: std::sync::Arc::new(Inner {
+            entry,
+            instance: instance.instance,
+            device,
+            physical_device: selected.physical_device,
+            queues,
+            queue_lock: std::sync::Mutex::new(()),
+            max_sampler_anisotropy: properties.limits.max_sampler_anisotropy,
+            allocator: std::sync::Mutex::new(Some(allocator)),
+            deletion_queue: std::sync::Mutex::new(Vec::new()),
+            #[cfg(validation)]
+            debug_loader: instance.debug.0,
+            #[cfg(validation)]
+            debug_messenger: instance.debug.1,
+            #[cfg(feature = "presentation")]
+            surface_loader,
+            #[cfg(feature = "presentation")]
+            swapchain_loader,
+        }),
+    })
+}
+
+fn create_instance(
+    entry: &Entry,
+    info: &VulkanCreateInfo,
+    mut extensions: Vec<*const i8>,
+) -> Result<InstanceGuard> {
+    #[cfg(validation)]
+    extensions.push(ash::ext::debug_utils::NAME.as_ptr());
+    deduplicate_extensions(&mut extensions);
+    validate_instance_extensions(entry, &extensions)?;
+    #[cfg(validation)]
+    super::debug::validate_layers(entry)?;
+
+    let application_info = vk::ApplicationInfo::default()
+        .application_name(info.application_name.as_c_str())
+        .application_version(version(info.application_version))
+        .engine_name(info.engine_name.as_c_str())
+        .engine_version(version(info.engine_version))
+        .api_version(vk::API_VERSION_1_3);
+    #[allow(unused_mut)]
+    let mut create_info = vk::InstanceCreateInfo::default()
+        .application_info(&application_info)
+        .enabled_extension_names(&extensions);
+    #[cfg(validation)]
+    let mut debug_info = super::debug::create_info();
+    #[cfg(validation)]
+    {
+        info!(target: "vulkan::validation", "using validation layers");
+        create_info = create_info
+            .enabled_layer_names(super::debug::VALIDATION_LAYERS)
+            .push_next(&mut debug_info);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        create_info = create_info.flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR);
+    }
+
+    let raw = unsafe { entry.create_instance(&create_info, None) }
+        .map_err(|error| map_error("create Vulkan instance", error))?;
+    let mut instance = InstanceGuard::new(raw);
+    #[cfg(validation)]
+    {
+        let loader = ash::ext::debug_utils::Instance::new(entry, instance.instance());
+        let messenger = unsafe { loader.create_debug_utils_messenger(&debug_info, None) }
+            .map_err(|error| map_error("create Vulkan debug messenger", error))?;
+        instance.debug = Some((loader, messenger));
+    }
+    Ok(instance)
+}
+
+fn required_headless_extensions() -> Vec<*const i8> {
+    let extensions = Vec::new();
+    #[cfg(target_os = "macos")]
+    let extensions = {
+        let mut extensions = extensions;
+        extensions.push(ash::khr::portability_enumeration::NAME.as_ptr());
+        extensions
+    };
+    extensions
+}
+
+fn required_device_extensions(enable_presentation: bool) -> Vec<&'static CStr> {
+    let extensions = Vec::new();
+    #[cfg(feature = "presentation")]
+    let extensions = {
+        let mut extensions = extensions;
+        if enable_presentation {
+            extensions.push(ash::khr::swapchain::NAME);
+        }
+        extensions
+    };
+    #[cfg(not(feature = "presentation"))]
+    let _ = enable_presentation;
+    #[cfg(target_os = "macos")]
+    let extensions = {
+        let mut extensions = extensions;
+        extensions.push(ash::khr::portability_subset::NAME);
+        extensions
+    };
+    extensions
+}
+
+fn validate_instance_extensions(entry: &Entry, required: &[*const i8]) -> Result<()> {
+    let available = unsafe { entry.enumerate_instance_extension_properties(None) }
+        .map_err(|error| map_error("enumerate Vulkan instance extensions", error))?;
+    for &name in required {
+        let name = unsafe { CStr::from_ptr(name) };
+        let found = available.iter().any(|extension| {
+            (unsafe { CStr::from_ptr(extension.extension_name.as_ptr()) }) == name
+        });
+        if !found {
+            return Err(unsupported(format!(
+                "required Vulkan instance extension {} is unavailable",
+                name.to_string_lossy()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn select_physical_device(instance: &ash::Instance) -> Result<SelectedDevice> {
+    select_physical_device_impl(instance, false, |_, _| Ok(None))
+}
+
+#[cfg(feature = "presentation")]
+fn select_physical_device_for_surface(
+    instance: &ash::Instance,
+    surface_loader: &ash::khr::surface::Instance,
+    surface: vk::SurfaceKHR,
+) -> Result<SelectedDevice> {
+    select_physical_device_impl(instance, true, |physical_device, queue_count| {
+        for family in 0..queue_count {
+            let supported = unsafe {
+                surface_loader.get_physical_device_surface_support(physical_device, family, surface)
+            }
+            .map_err(|error| map_error("query Vulkan presentation support", error))?;
+            if supported {
+                return Ok(Some(family));
+            }
+        }
+        Ok(None)
+    })
+}
+
+fn select_physical_device_impl(
+    instance: &ash::Instance,
+    require_present: bool,
+    present_family: impl Fn(vk::PhysicalDevice, u32) -> Result<Option<u32>>,
+) -> Result<SelectedDevice> {
+    let devices = unsafe { instance.enumerate_physical_devices() }
+        .map_err(|error| map_error("enumerate Vulkan physical devices", error))?;
+    let required_extensions = required_device_extensions(require_present);
+    let mut candidates = Vec::new();
+
+    for physical_device in devices {
+        let properties = unsafe { instance.get_physical_device_properties(physical_device) };
+        if properties.api_version < vk::API_VERSION_1_3 {
+            continue;
+        }
+        if !supports_extensions(instance, physical_device, &required_extensions)? {
+            continue;
+        }
+        if !supports_required_features(instance, physical_device) {
+            continue;
+        }
+        let queue_properties =
+            unsafe { instance.get_physical_device_queue_family_properties(physical_device) };
+        let Some(universal) = find_universal_queue(&queue_properties) else {
+            continue;
+        };
+        #[cfg(feature = "presentation")]
+        let present = present_family(
+            physical_device,
+            u32::try_from(queue_properties.len())
+                .map_err(|_| unsupported("Vulkan exposes more than u32::MAX queue families"))?,
+        )?;
+        #[cfg(feature = "presentation")]
+        if require_present && present.is_none() {
+            continue;
+        }
+        #[cfg(not(feature = "presentation"))]
+        let _ = (require_present, &present_family);
+
+        let score = match properties.device_type {
+            vk::PhysicalDeviceType::DISCRETE_GPU => 4,
+            vk::PhysicalDeviceType::INTEGRATED_GPU => 3,
+            vk::PhysicalDeviceType::VIRTUAL_GPU => 2,
+            vk::PhysicalDeviceType::CPU => 1,
+            _ => 0,
+        };
+        candidates.push((
+            score,
+            properties,
+            SelectedDevice {
+                physical_device,
+                queues: QueueFamilies {
+                    graphics: universal,
+                    compute: universal,
+                    transfer: universal,
+                    #[cfg(feature = "presentation")]
+                    present,
+                },
+            },
+        ));
+    }
+
+    let (_, properties, selected) = candidates
+        .into_iter()
+        .max_by_key(|(score, properties, _)| (*score, properties.limits.max_image_dimension2_d))
+        .ok_or_else(|| {
+            unsupported("no Vulkan 1.3 device supports the required features and extensions")
+        })?;
+    let name = unsafe { CStr::from_ptr(properties.device_name.as_ptr()) };
+    info!(device = %name.to_string_lossy(), "selected Vulkan physical device");
+    Ok(selected)
+}
+
+fn supports_extensions(
+    instance: &ash::Instance,
+    physical_device: vk::PhysicalDevice,
+    required: &[&CStr],
+) -> Result<bool> {
+    let available = unsafe { instance.enumerate_device_extension_properties(physical_device) }
+        .map_err(|error| map_error("enumerate Vulkan device extensions", error))?;
+    Ok(required.iter().all(|required| {
+        available.iter().any(|extension| {
+            (unsafe { CStr::from_ptr(extension.extension_name.as_ptr()) }) == *required
+        })
+    }))
+}
+
+fn supports_required_features(
+    instance: &ash::Instance,
+    physical_device: vk::PhysicalDevice,
+) -> bool {
+    let mut vulkan12 = vk::PhysicalDeviceVulkan12Features::default();
+    let mut vulkan13 = vk::PhysicalDeviceVulkan13Features::default();
+    let mut features = vk::PhysicalDeviceFeatures2::default()
+        .push_next(&mut vulkan12)
+        .push_next(&mut vulkan13);
+    unsafe {
+        instance.get_physical_device_features2(physical_device, &mut features);
+    }
+    features.features.sampler_anisotropy == vk::TRUE
+        && vulkan12.timeline_semaphore == vk::TRUE
+        && vulkan13.dynamic_rendering == vk::TRUE
+        && vulkan13.synchronization2 == vk::TRUE
+}
+
+fn create_logical_device(
+    instance: &ash::Instance,
+    selected: &SelectedDevice,
+) -> Result<ash::Device> {
+    #[allow(unused_mut)]
+    let mut unique_families = HashSet::from([
+        selected.queues.graphics,
+        selected.queues.compute,
+        selected.queues.transfer,
+    ]);
+    #[cfg(feature = "presentation")]
+    if let Some(present) = selected.queues.present {
+        unique_families.insert(present);
+    }
+    let priorities = [1.0_f32];
+    let queue_infos = unique_families
+        .into_iter()
+        .map(|family| {
+            vk::DeviceQueueCreateInfo::default()
+                .queue_family_index(family)
+                .queue_priorities(&priorities)
+        })
+        .collect::<Vec<_>>();
+    #[cfg(feature = "presentation")]
+    let enable_presentation = selected.queues.present.is_some();
+    #[cfg(not(feature = "presentation"))]
+    let enable_presentation = false;
+    let extension_names = required_device_extensions(enable_presentation)
+        .into_iter()
+        .map(CStr::as_ptr)
+        .collect::<Vec<_>>();
+    let mut vulkan12 = vk::PhysicalDeviceVulkan12Features::default().timeline_semaphore(true);
+    let mut vulkan13 = vk::PhysicalDeviceVulkan13Features::default()
+        .dynamic_rendering(true)
+        .synchronization2(true);
+    let features = vk::PhysicalDeviceFeatures::default().sampler_anisotropy(true);
+    let create_info = vk::DeviceCreateInfo::default()
+        .queue_create_infos(&queue_infos)
+        .enabled_extension_names(&extension_names)
+        .enabled_features(&features)
+        .push_next(&mut vulkan12)
+        .push_next(&mut vulkan13);
+    unsafe { instance.create_device(selected.physical_device, &create_info, None) }
+        .map_err(|error| map_error("create Vulkan logical device", error))
+}
+
+fn find_queue(
+    properties: &[vk::QueueFamilyProperties],
+    required: vk::QueueFlags,
+    excluded: vk::QueueFlags,
+) -> Option<u32> {
+    properties
+        .iter()
+        .enumerate()
+        .find_map(|(index, properties)| {
+            (properties.queue_count > 0
+                && properties.queue_flags.contains(required)
+                && !properties.queue_flags.intersects(excluded))
+            .then(|| u32::try_from(index).expect("Vulkan queue-family count fits in u32"))
+        })
+}
+
+fn find_universal_queue(properties: &[vk::QueueFamilyProperties]) -> Option<u32> {
+    find_queue(
+        properties,
+        vk::QueueFlags::GRAPHICS | vk::QueueFlags::COMPUTE | vk::QueueFlags::TRANSFER,
+        vk::QueueFlags::empty(),
+    )
+}
+
+fn queue(device: &ash::Device, family_index: u32) -> Queue {
+    Queue {
+        raw: unsafe { device.get_device_queue(family_index, 0) },
+        family_index,
+    }
+}
+
+fn deduplicate_extensions(extensions: &mut Vec<*const i8>) {
+    extensions.sort_unstable_by(|left, right| unsafe {
+        CStr::from_ptr(*left)
+            .to_bytes()
+            .cmp(CStr::from_ptr(*right).to_bytes())
+    });
+    extensions.dedup_by(|left, right| unsafe { CStr::from_ptr(*left) == CStr::from_ptr(*right) });
+}
+
+fn version(version: Version) -> u32 {
+    vk::make_api_version(0, version.major(), version.minor(), version.patch())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn queue_family(flags: vk::QueueFlags) -> vk::QueueFamilyProperties {
+        vk::QueueFamilyProperties {
+            queue_flags: flags,
+            queue_count: 1,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn universal_queue_requires_compute_support() {
+        let properties = [queue_family(
+            vk::QueueFlags::GRAPHICS | vk::QueueFlags::TRANSFER,
+        )];
+        assert_eq!(find_universal_queue(&properties), None);
+    }
+
+    #[test]
+    fn universal_queue_supports_every_rhi_queue_type() {
+        let properties = [
+            queue_family(vk::QueueFlags::TRANSFER),
+            queue_family(
+                vk::QueueFlags::GRAPHICS | vk::QueueFlags::COMPUTE | vk::QueueFlags::TRANSFER,
+            ),
+        ];
+        assert_eq!(find_universal_queue(&properties), Some(1));
+    }
+}

--- a/crates/dirk_rhi/src/vulkan/mapping.rs
+++ b/crates/dirk_rhi/src/vulkan/mapping.rs
@@ -1,0 +1,546 @@
+use ash::vk;
+use gpu_allocator::MemoryLocation as AllocatorMemoryLocation;
+
+#[cfg(feature = "presentation")]
+use crate::PresentMode;
+use crate::{
+    AccessTypes, AddressMode, BindingType, BufferUsage, ColorWrites, CompareOperation, CullMode,
+    Filter, Format, FrontFace, ImageAspects, ImageDimension, ImageLayout, ImageSubresourceLayers,
+    ImageSubresourceRange, ImageUsage, ImageViewDimension, IndexFormat, MemoryLocation,
+    PipelineStages, PrimitiveTopology, SampleCount, ShaderStages, VertexFormat, VertexStepMode,
+};
+
+pub(super) fn buffer_usage(value: BufferUsage) -> vk::BufferUsageFlags {
+    let mut flags = vk::BufferUsageFlags::empty();
+    add_flag(
+        &mut flags,
+        value.contains(BufferUsage::TRANSFER_SRC),
+        vk::BufferUsageFlags::TRANSFER_SRC,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(BufferUsage::TRANSFER_DST),
+        vk::BufferUsageFlags::TRANSFER_DST,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(BufferUsage::UNIFORM),
+        vk::BufferUsageFlags::UNIFORM_BUFFER,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(BufferUsage::STORAGE),
+        vk::BufferUsageFlags::STORAGE_BUFFER,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(BufferUsage::VERTEX),
+        vk::BufferUsageFlags::VERTEX_BUFFER,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(BufferUsage::INDEX),
+        vk::BufferUsageFlags::INDEX_BUFFER,
+    );
+    flags
+}
+
+pub(super) fn image_usage(value: ImageUsage) -> vk::ImageUsageFlags {
+    let mut flags = vk::ImageUsageFlags::empty();
+    add_flag(
+        &mut flags,
+        value.contains(ImageUsage::TRANSFER_SRC),
+        vk::ImageUsageFlags::TRANSFER_SRC,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ImageUsage::TRANSFER_DST),
+        vk::ImageUsageFlags::TRANSFER_DST,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ImageUsage::SAMPLED),
+        vk::ImageUsageFlags::SAMPLED,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ImageUsage::STORAGE),
+        vk::ImageUsageFlags::STORAGE,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ImageUsage::COLOR_ATTACHMENT),
+        vk::ImageUsageFlags::COLOR_ATTACHMENT,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ImageUsage::DEPTH_STENCIL_ATTACHMENT),
+        vk::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ImageUsage::TRANSIENT_ATTACHMENT),
+        vk::ImageUsageFlags::TRANSIENT_ATTACHMENT,
+    );
+    flags
+}
+
+pub(super) fn image_aspects(value: ImageAspects) -> vk::ImageAspectFlags {
+    let mut flags = vk::ImageAspectFlags::empty();
+    add_flag(
+        &mut flags,
+        value.contains(ImageAspects::COLOR),
+        vk::ImageAspectFlags::COLOR,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ImageAspects::DEPTH),
+        vk::ImageAspectFlags::DEPTH,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ImageAspects::STENCIL),
+        vk::ImageAspectFlags::STENCIL,
+    );
+    flags
+}
+
+pub(super) const fn format(value: Format) -> vk::Format {
+    match value {
+        Format::Rgba8Unorm => vk::Format::R8G8B8A8_UNORM,
+        Format::Rgba8Srgb => vk::Format::R8G8B8A8_SRGB,
+        Format::Bgra8Unorm => vk::Format::B8G8R8A8_UNORM,
+        Format::Bgra8Srgb => vk::Format::B8G8R8A8_SRGB,
+        Format::Rg32Float => vk::Format::R32G32_SFLOAT,
+        Format::Rgb32Float => vk::Format::R32G32B32_SFLOAT,
+        Format::Rgba32Float => vk::Format::R32G32B32A32_SFLOAT,
+        Format::Depth16Unorm => vk::Format::D16_UNORM,
+        Format::Depth32Float => vk::Format::D32_SFLOAT,
+        Format::Depth24UnormStencil8 => vk::Format::D24_UNORM_S8_UINT,
+        Format::Depth32FloatStencil8 => vk::Format::D32_SFLOAT_S8_UINT,
+    }
+}
+
+#[cfg(any(feature = "presentation", test))]
+pub(super) fn format_from_vk(value: vk::Format) -> crate::Result<Format> {
+    match value {
+        vk::Format::R8G8B8A8_UNORM => Ok(Format::Rgba8Unorm),
+        vk::Format::R8G8B8A8_SRGB => Ok(Format::Rgba8Srgb),
+        vk::Format::B8G8R8A8_UNORM => Ok(Format::Bgra8Unorm),
+        vk::Format::B8G8R8A8_SRGB => Ok(Format::Bgra8Srgb),
+        vk::Format::R32G32_SFLOAT => Ok(Format::Rg32Float),
+        vk::Format::R32G32B32_SFLOAT => Ok(Format::Rgb32Float),
+        vk::Format::R32G32B32A32_SFLOAT => Ok(Format::Rgba32Float),
+        vk::Format::D16_UNORM => Ok(Format::Depth16Unorm),
+        vk::Format::D32_SFLOAT => Ok(Format::Depth32Float),
+        vk::Format::D24_UNORM_S8_UINT => Ok(Format::Depth24UnormStencil8),
+        vk::Format::D32_SFLOAT_S8_UINT => Ok(Format::Depth32FloatStencil8),
+        _ => Err(super::unsupported(format!(
+            "Vulkan format {value:?} is not represented by the RHI"
+        ))),
+    }
+}
+
+pub(super) const fn sample_count(value: SampleCount) -> vk::SampleCountFlags {
+    match value {
+        SampleCount::One => vk::SampleCountFlags::TYPE_1,
+        SampleCount::Two => vk::SampleCountFlags::TYPE_2,
+        SampleCount::Four => vk::SampleCountFlags::TYPE_4,
+        SampleCount::Eight => vk::SampleCountFlags::TYPE_8,
+        SampleCount::Sixteen => vk::SampleCountFlags::TYPE_16,
+        SampleCount::ThirtyTwo => vk::SampleCountFlags::TYPE_32,
+        SampleCount::SixtyFour => vk::SampleCountFlags::TYPE_64,
+    }
+}
+
+pub(super) const fn image_type(value: ImageDimension) -> vk::ImageType {
+    match value {
+        ImageDimension::One => vk::ImageType::TYPE_1D,
+        ImageDimension::Two => vk::ImageType::TYPE_2D,
+        ImageDimension::Three => vk::ImageType::TYPE_3D,
+    }
+}
+
+pub(super) const fn image_view_type(value: ImageViewDimension) -> vk::ImageViewType {
+    match value {
+        ImageViewDimension::One => vk::ImageViewType::TYPE_1D,
+        ImageViewDimension::Two => vk::ImageViewType::TYPE_2D,
+        ImageViewDimension::Three => vk::ImageViewType::TYPE_3D,
+        ImageViewDimension::Cube => vk::ImageViewType::CUBE,
+        ImageViewDimension::OneArray => vk::ImageViewType::TYPE_1D_ARRAY,
+        ImageViewDimension::TwoArray => vk::ImageViewType::TYPE_2D_ARRAY,
+        ImageViewDimension::CubeArray => vk::ImageViewType::CUBE_ARRAY,
+    }
+}
+
+pub(super) const fn memory_location(value: MemoryLocation) -> AllocatorMemoryLocation {
+    match value {
+        MemoryLocation::Device => AllocatorMemoryLocation::GpuOnly,
+        MemoryLocation::Upload => AllocatorMemoryLocation::CpuToGpu,
+        MemoryLocation::Readback => AllocatorMemoryLocation::GpuToCpu,
+    }
+}
+
+pub(super) const fn filter(value: Filter) -> vk::Filter {
+    match value {
+        Filter::Nearest => vk::Filter::NEAREST,
+        Filter::Linear => vk::Filter::LINEAR,
+    }
+}
+
+pub(super) const fn mipmap_mode(value: Filter) -> vk::SamplerMipmapMode {
+    match value {
+        Filter::Nearest => vk::SamplerMipmapMode::NEAREST,
+        Filter::Linear => vk::SamplerMipmapMode::LINEAR,
+    }
+}
+
+pub(super) const fn address_mode(value: AddressMode) -> vk::SamplerAddressMode {
+    match value {
+        AddressMode::Repeat => vk::SamplerAddressMode::REPEAT,
+        AddressMode::MirrorRepeat => vk::SamplerAddressMode::MIRRORED_REPEAT,
+        AddressMode::ClampToEdge => vk::SamplerAddressMode::CLAMP_TO_EDGE,
+    }
+}
+
+pub(super) fn shader_stages(value: ShaderStages) -> vk::ShaderStageFlags {
+    let mut flags = vk::ShaderStageFlags::empty();
+    add_flag(
+        &mut flags,
+        value.contains(ShaderStages::VERTEX),
+        vk::ShaderStageFlags::VERTEX,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ShaderStages::FRAGMENT),
+        vk::ShaderStageFlags::FRAGMENT,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ShaderStages::COMPUTE),
+        vk::ShaderStageFlags::COMPUTE,
+    );
+    flags
+}
+
+pub(super) const fn descriptor_type(value: BindingType) -> vk::DescriptorType {
+    match value {
+        BindingType::UniformBuffer => vk::DescriptorType::UNIFORM_BUFFER,
+        BindingType::StorageBuffer { .. } => vk::DescriptorType::STORAGE_BUFFER,
+        BindingType::SampledImage => vk::DescriptorType::SAMPLED_IMAGE,
+        BindingType::StorageImage { .. } => vk::DescriptorType::STORAGE_IMAGE,
+        BindingType::Sampler => vk::DescriptorType::SAMPLER,
+        BindingType::CombinedImageSampler => vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
+    }
+}
+
+pub(super) const fn primitive_topology(value: PrimitiveTopology) -> vk::PrimitiveTopology {
+    match value {
+        PrimitiveTopology::TriangleList => vk::PrimitiveTopology::TRIANGLE_LIST,
+        PrimitiveTopology::TriangleStrip => vk::PrimitiveTopology::TRIANGLE_STRIP,
+        PrimitiveTopology::LineList => vk::PrimitiveTopology::LINE_LIST,
+        PrimitiveTopology::LineStrip => vk::PrimitiveTopology::LINE_STRIP,
+        PrimitiveTopology::PointList => vk::PrimitiveTopology::POINT_LIST,
+    }
+}
+
+pub(super) const fn cull_mode(value: CullMode) -> vk::CullModeFlags {
+    match value {
+        CullMode::None => vk::CullModeFlags::NONE,
+        CullMode::Front => vk::CullModeFlags::FRONT,
+        CullMode::Back => vk::CullModeFlags::BACK,
+    }
+}
+
+pub(super) const fn front_face(value: FrontFace) -> vk::FrontFace {
+    match value {
+        FrontFace::Clockwise => vk::FrontFace::CLOCKWISE,
+        FrontFace::CounterClockwise => vk::FrontFace::COUNTER_CLOCKWISE,
+    }
+}
+
+pub(super) const fn compare_op(value: CompareOperation) -> vk::CompareOp {
+    match value {
+        CompareOperation::Never => vk::CompareOp::NEVER,
+        CompareOperation::Less => vk::CompareOp::LESS,
+        CompareOperation::Equal => vk::CompareOp::EQUAL,
+        CompareOperation::LessEqual => vk::CompareOp::LESS_OR_EQUAL,
+        CompareOperation::Greater => vk::CompareOp::GREATER,
+        CompareOperation::NotEqual => vk::CompareOp::NOT_EQUAL,
+        CompareOperation::GreaterEqual => vk::CompareOp::GREATER_OR_EQUAL,
+        CompareOperation::Always => vk::CompareOp::ALWAYS,
+    }
+}
+
+pub(super) const fn vertex_format(value: VertexFormat) -> vk::Format {
+    match value {
+        VertexFormat::Float32x2 => vk::Format::R32G32_SFLOAT,
+        VertexFormat::Float32x3 => vk::Format::R32G32B32_SFLOAT,
+        VertexFormat::Float32x4 => vk::Format::R32G32B32A32_SFLOAT,
+        VertexFormat::Uint32 => vk::Format::R32_UINT,
+    }
+}
+
+pub(super) const fn vertex_rate(value: VertexStepMode) -> vk::VertexInputRate {
+    match value {
+        VertexStepMode::Vertex => vk::VertexInputRate::VERTEX,
+        VertexStepMode::Instance => vk::VertexInputRate::INSTANCE,
+    }
+}
+
+pub(super) fn color_writes(value: ColorWrites) -> vk::ColorComponentFlags {
+    let mut flags = vk::ColorComponentFlags::empty();
+    add_flag(
+        &mut flags,
+        value.contains(ColorWrites::RED),
+        vk::ColorComponentFlags::R,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ColorWrites::GREEN),
+        vk::ColorComponentFlags::G,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ColorWrites::BLUE),
+        vk::ColorComponentFlags::B,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(ColorWrites::ALPHA),
+        vk::ColorComponentFlags::A,
+    );
+    flags
+}
+
+pub(super) const fn image_layout(value: ImageLayout) -> vk::ImageLayout {
+    match value {
+        ImageLayout::Undefined => vk::ImageLayout::UNDEFINED,
+        ImageLayout::General => vk::ImageLayout::GENERAL,
+        ImageLayout::ColorAttachment => vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        ImageLayout::DepthStencilAttachment => vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        ImageLayout::ShaderReadOnly => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+        ImageLayout::TransferSource => vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+        ImageLayout::TransferDestination => vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+        ImageLayout::Present => vk::ImageLayout::PRESENT_SRC_KHR,
+    }
+}
+
+pub(super) fn pipeline_stages(value: PipelineStages) -> vk::PipelineStageFlags2 {
+    let mut flags = vk::PipelineStageFlags2::empty();
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::TOP),
+        vk::PipelineStageFlags2::TOP_OF_PIPE,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::VERTEX_SHADER),
+        vk::PipelineStageFlags2::VERTEX_SHADER,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::FRAGMENT_SHADER),
+        vk::PipelineStageFlags2::FRAGMENT_SHADER,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::COMPUTE_SHADER),
+        vk::PipelineStageFlags2::COMPUTE_SHADER,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::EARLY_DEPTH_STENCIL),
+        vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::LATE_DEPTH_STENCIL),
+        vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::COLOR_OUTPUT),
+        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::TRANSFER),
+        vk::PipelineStageFlags2::TRANSFER,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::BOTTOM),
+        vk::PipelineStageFlags2::BOTTOM_OF_PIPE,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(PipelineStages::ALL_COMMANDS),
+        vk::PipelineStageFlags2::ALL_COMMANDS,
+    );
+    flags
+}
+
+pub(super) fn access_types(value: AccessTypes) -> vk::AccessFlags2 {
+    let mut flags = vk::AccessFlags2::empty();
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::UNIFORM_READ),
+        vk::AccessFlags2::UNIFORM_READ,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::SHADER_READ),
+        vk::AccessFlags2::SHADER_READ,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::SHADER_WRITE),
+        vk::AccessFlags2::SHADER_WRITE,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::COLOR_ATTACHMENT_READ),
+        vk::AccessFlags2::COLOR_ATTACHMENT_READ,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::COLOR_ATTACHMENT_WRITE),
+        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::DEPTH_STENCIL_READ),
+        vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::DEPTH_STENCIL_WRITE),
+        vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::TRANSFER_READ),
+        vk::AccessFlags2::TRANSFER_READ,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::TRANSFER_WRITE),
+        vk::AccessFlags2::TRANSFER_WRITE,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::HOST_READ),
+        vk::AccessFlags2::HOST_READ,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::HOST_WRITE),
+        vk::AccessFlags2::HOST_WRITE,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::MEMORY_READ),
+        vk::AccessFlags2::MEMORY_READ,
+    );
+    add_flag(
+        &mut flags,
+        value.contains(AccessTypes::MEMORY_WRITE),
+        vk::AccessFlags2::MEMORY_WRITE,
+    );
+    flags
+}
+
+pub(super) const fn index_type(value: IndexFormat) -> vk::IndexType {
+    match value {
+        IndexFormat::Uint16 => vk::IndexType::UINT16,
+        IndexFormat::Uint32 => vk::IndexType::UINT32,
+    }
+}
+
+#[cfg(feature = "presentation")]
+pub(super) const fn present_mode(value: PresentMode) -> vk::PresentModeKHR {
+    match value {
+        PresentMode::Fifo => vk::PresentModeKHR::FIFO,
+        PresentMode::Mailbox => vk::PresentModeKHR::MAILBOX,
+        PresentMode::Immediate => vk::PresentModeKHR::IMMEDIATE,
+    }
+}
+
+pub(super) fn subresource_range(value: ImageSubresourceRange) -> vk::ImageSubresourceRange {
+    vk::ImageSubresourceRange {
+        aspect_mask: image_aspects(value.aspects),
+        base_mip_level: value.base_mip_level,
+        level_count: value.mip_level_count,
+        base_array_layer: value.base_array_layer,
+        layer_count: value.array_layer_count,
+    }
+}
+
+pub(super) fn subresource_layers(value: ImageSubresourceLayers) -> vk::ImageSubresourceLayers {
+    vk::ImageSubresourceLayers {
+        aspect_mask: image_aspects(value.aspects),
+        mip_level: value.mip_level,
+        base_array_layer: value.base_array_layer,
+        layer_count: value.array_layer_count,
+    }
+}
+
+fn add_flag<T>(flags: &mut T, condition: bool, flag: T)
+where
+    T: Copy + std::ops::BitOrAssign,
+{
+    if condition {
+        *flags |= flag;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_usage_preserves_every_selected_flag() {
+        let value = BufferUsage::TRANSFER_SRC | BufferUsage::VERTEX | BufferUsage::INDEX;
+        assert_eq!(
+            buffer_usage(value),
+            vk::BufferUsageFlags::TRANSFER_SRC
+                | vk::BufferUsageFlags::VERTEX_BUFFER
+                | vk::BufferUsageFlags::INDEX_BUFFER
+        );
+    }
+
+    #[test]
+    fn resource_state_mappings_preserve_combined_hazards() {
+        let stages = PipelineStages::EARLY_DEPTH_STENCIL | PipelineStages::LATE_DEPTH_STENCIL;
+        let access = AccessTypes::DEPTH_STENCIL_READ | AccessTypes::DEPTH_STENCIL_WRITE;
+        assert_eq!(
+            pipeline_stages(stages),
+            vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
+                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS
+        );
+        assert_eq!(
+            access_types(access),
+            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
+                | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
+        );
+    }
+
+    #[test]
+    fn supported_formats_round_trip() {
+        let formats = [
+            Format::Rgba8Unorm,
+            Format::Rgba8Srgb,
+            Format::Bgra8Unorm,
+            Format::Bgra8Srgb,
+            Format::Depth32Float,
+            Format::Depth24UnormStencil8,
+        ];
+        for value in formats {
+            assert_eq!(
+                format_from_vk(format(value)).expect("format should map"),
+                value
+            );
+        }
+    }
+}

--- a/crates/dirk_rhi/src/vulkan/mod.rs
+++ b/crates/dirk_rhi/src/vulkan/mod.rs
@@ -1,0 +1,449 @@
+//! Vulkan 1.3 implementation of the backend-neutral RHI.
+
+use std::{
+    error, fmt,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use ash::{Entry, Instance, vk};
+use gpu_allocator::vulkan::{Allocation, Allocator};
+
+use crate::{BackendInterop, Device, QueueType};
+
+mod backend;
+#[cfg(validation)]
+mod debug;
+mod init;
+mod mapping;
+#[cfg(feature = "presentation")]
+mod presentation;
+
+pub use ash::vk as raw;
+pub use init::VulkanCreateInfo;
+#[cfg(feature = "presentation")]
+pub use presentation::VulkanSurfaceTarget;
+
+/// A backend-neutral device backed by Vulkan 1.3.
+pub type VulkanDevice = Device<VulkanBackend>;
+
+/// Vulkan implementation of [`crate::Backend`].
+pub struct VulkanBackend {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    #[allow(dead_code)] // Kept alive with the instance for loader ownership.
+    entry: Entry,
+    instance: Instance,
+    device: ash::Device,
+    physical_device: vk::PhysicalDevice,
+    queues: Queues,
+    queue_lock: Mutex<()>,
+    max_sampler_anisotropy: f32,
+    allocator: Mutex<Option<Allocator>>,
+    deletion_queue: Mutex<Vec<Garbage>>,
+    #[cfg(validation)]
+    debug_loader: ash::ext::debug_utils::Instance,
+    #[cfg(validation)]
+    debug_messenger: vk::DebugUtilsMessengerEXT,
+    #[cfg(feature = "presentation")]
+    surface_loader: ash::khr::surface::Instance,
+    #[cfg(feature = "presentation")]
+    swapchain_loader: ash::khr::swapchain::Device,
+}
+
+#[derive(Clone, Copy)]
+struct Queue {
+    raw: vk::Queue,
+    family_index: u32,
+}
+
+struct Queues {
+    graphics: Queue,
+    compute: Queue,
+    transfer: Queue,
+    #[cfg(feature = "presentation")]
+    present: Option<Queue>,
+}
+
+impl Queues {
+    fn get(&self, queue: QueueType) -> Queue {
+        match queue {
+            QueueType::Graphics => self.graphics,
+            QueueType::Compute => self.compute,
+            QueueType::Transfer => self.transfer,
+        }
+    }
+}
+
+impl Inner {
+    fn allocator(&self) -> MutexGuard<'_, Option<Allocator>> {
+        lock(&self.allocator)
+    }
+
+    fn defer(&self, garbage: Garbage) {
+        lock(&self.deletion_queue).push(garbage);
+    }
+
+    fn flush_deletions(&self) {
+        let garbage = std::mem::take(&mut *lock(&self.deletion_queue));
+        for item in garbage {
+            self.destroy(item);
+        }
+    }
+
+    fn destroy(&self, garbage: Garbage) {
+        unsafe {
+            match garbage {
+                Garbage::Buffer { raw, allocation } => {
+                    self.device.destroy_buffer(raw, None);
+                    self.free(allocation);
+                }
+                Garbage::Image { raw, allocation } => {
+                    self.device.destroy_image(raw, None);
+                    self.free(allocation);
+                }
+                Garbage::ImageView(raw) => self.device.destroy_image_view(raw, None),
+                Garbage::Sampler(raw) => self.device.destroy_sampler(raw, None),
+                Garbage::ShaderModule(raw) => self.device.destroy_shader_module(raw, None),
+                Garbage::DescriptorSetLayout(raw) => {
+                    self.device.destroy_descriptor_set_layout(raw, None);
+                }
+                Garbage::DescriptorPool(raw) => self.device.destroy_descriptor_pool(raw, None),
+                Garbage::PipelineLayout(raw) => self.device.destroy_pipeline_layout(raw, None),
+                Garbage::Pipeline(raw) => self.device.destroy_pipeline(raw, None),
+                Garbage::CommandPool(raw) => self.device.destroy_command_pool(raw, None),
+                Garbage::Fence(raw) => self.device.destroy_fence(raw, None),
+                Garbage::Semaphore(raw) => self.device.destroy_semaphore(raw, None),
+                #[cfg(feature = "presentation")]
+                Garbage::Surface(raw) => self.surface_loader.destroy_surface(raw, None),
+                #[cfg(feature = "presentation")]
+                Garbage::Swapchain(raw) => self.swapchain_loader.destroy_swapchain(raw, None),
+            }
+        }
+    }
+
+    fn free(&self, allocation: Allocation) {
+        if let Some(allocator) = self.allocator().as_mut() {
+            allocator
+                .free(allocation)
+                .expect("Vulkan allocation must belong to this allocator");
+        }
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = self.device.device_wait_idle();
+        }
+        self.flush_deletions();
+        drop(lock(&self.allocator).take());
+        unsafe {
+            self.device.destroy_device(None);
+            #[cfg(validation)]
+            self.debug_loader
+                .destroy_debug_utils_messenger(self.debug_messenger, None);
+            self.instance.destroy_instance(None);
+        }
+    }
+}
+
+enum Garbage {
+    Buffer {
+        raw: vk::Buffer,
+        allocation: Allocation,
+    },
+    Image {
+        raw: vk::Image,
+        allocation: Allocation,
+    },
+    ImageView(vk::ImageView),
+    Sampler(vk::Sampler),
+    ShaderModule(vk::ShaderModule),
+    DescriptorSetLayout(vk::DescriptorSetLayout),
+    DescriptorPool(vk::DescriptorPool),
+    PipelineLayout(vk::PipelineLayout),
+    Pipeline(vk::Pipeline),
+    CommandPool(vk::CommandPool),
+    Fence(vk::Fence),
+    Semaphore(vk::Semaphore),
+    #[cfg(feature = "presentation")]
+    Surface(vk::SurfaceKHR),
+    #[cfg(feature = "presentation")]
+    Swapchain(vk::SwapchainKHR),
+}
+
+#[doc(hidden)]
+pub struct VulkanBuffer {
+    inner: Arc<Inner>,
+    raw: vk::Buffer,
+    allocation: Mutex<Option<Allocation>>,
+    size: u64,
+}
+
+impl Drop for VulkanBuffer {
+    fn drop(&mut self) {
+        if let Some(allocation) = lock(&self.allocation).take() {
+            self.inner.defer(Garbage::Buffer {
+                raw: self.raw,
+                allocation,
+            });
+        }
+    }
+}
+
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct VulkanImage(Arc<VulkanImageInner>);
+
+struct VulkanImageInner {
+    device: Arc<Inner>,
+    raw: vk::Image,
+    format: vk::Format,
+    allocation: Option<Allocation>,
+}
+
+impl Drop for VulkanImageInner {
+    fn drop(&mut self) {
+        if let Some(allocation) = self.allocation.take() {
+            self.device.defer(Garbage::Image {
+                raw: self.raw,
+                allocation,
+            });
+        }
+    }
+}
+
+impl VulkanImage {
+    fn raw(&self) -> vk::Image {
+        self.0.raw
+    }
+
+    fn format(&self) -> vk::Format {
+        self.0.format
+    }
+
+    #[cfg(feature = "presentation")]
+    fn borrowed(device: Arc<Inner>, raw: vk::Image, format: vk::Format) -> Self {
+        Self(Arc::new(VulkanImageInner {
+            device,
+            raw,
+            format,
+            allocation: None,
+        }))
+    }
+}
+
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct VulkanImageView(Arc<VulkanImageViewInner>);
+
+struct VulkanImageViewInner {
+    device: Arc<Inner>,
+    raw: vk::ImageView,
+    format: vk::Format,
+}
+
+impl Drop for VulkanImageViewInner {
+    fn drop(&mut self) {
+        self.device.defer(Garbage::ImageView(self.raw));
+    }
+}
+
+impl VulkanImageView {
+    fn raw(&self) -> vk::ImageView {
+        self.0.raw
+    }
+}
+
+macro_rules! deferred_resource {
+    ($name:ident, $raw:ty, $garbage:ident) => {
+        #[doc(hidden)]
+        pub struct $name {
+            inner: Arc<Inner>,
+            raw: $raw,
+        }
+
+        impl Drop for $name {
+            fn drop(&mut self) {
+                self.inner.defer(Garbage::$garbage(self.raw));
+            }
+        }
+    };
+}
+
+deferred_resource!(VulkanSampler, vk::Sampler, Sampler);
+deferred_resource!(VulkanShaderModule, vk::ShaderModule, ShaderModule);
+deferred_resource!(VulkanPipelineLayout, vk::PipelineLayout, PipelineLayout);
+deferred_resource!(VulkanPipeline, vk::Pipeline, Pipeline);
+deferred_resource!(VulkanCommandPool, vk::CommandPool, CommandPool);
+deferred_resource!(VulkanFence, vk::Fence, Fence);
+deferred_resource!(VulkanSemaphore, vk::Semaphore, Semaphore);
+
+#[doc(hidden)]
+pub struct VulkanBindGroupLayout {
+    inner: Arc<Inner>,
+    raw: vk::DescriptorSetLayout,
+    entries: Vec<crate::BindGroupLayoutEntry>,
+}
+
+impl Drop for VulkanBindGroupLayout {
+    fn drop(&mut self) {
+        self.inner.defer(Garbage::DescriptorSetLayout(self.raw));
+    }
+}
+
+#[doc(hidden)]
+pub struct VulkanBindGroup {
+    inner: Arc<Inner>,
+    pool: vk::DescriptorPool,
+    set: vk::DescriptorSet,
+}
+
+impl Drop for VulkanBindGroup {
+    fn drop(&mut self) {
+        self.inner.defer(Garbage::DescriptorPool(self.pool));
+    }
+}
+
+#[doc(hidden)]
+pub struct VulkanCommandBuffer {
+    raw: vk::CommandBuffer,
+}
+
+/// Narrow Vulkan handle adapter for integrations that cannot use generic RHI APIs.
+pub struct VulkanInterop<'a> {
+    backend: &'a Arc<VulkanBackend>,
+}
+
+impl VulkanInterop<'_> {
+    /// Returns the Ash instance.
+    #[must_use]
+    pub fn instance(&self) -> &ash::Instance {
+        &self.backend.inner.instance
+    }
+
+    /// Returns the selected physical-device handle.
+    #[must_use]
+    pub fn physical_device(&self) -> vk::PhysicalDevice {
+        self.backend.inner.physical_device
+    }
+
+    /// Returns the Ash logical device.
+    #[must_use]
+    pub fn device(&self) -> &ash::Device {
+        &self.backend.inner.device
+    }
+
+    /// Runs an operation while holding the Vulkan queue serialization lock.
+    /// The queue handle is valid only for the duration of `operation`.
+    pub fn with_queue(
+        &self,
+        queue: QueueType,
+        operation: impl FnOnce(vk::Queue) -> crate::Result<()>,
+    ) -> crate::Result<()> {
+        let _guard = lock(&self.backend.inner.queue_lock);
+        operation(self.backend.inner.queues.get(queue).raw)
+    }
+
+    /// Returns the native family index for a queue type.
+    #[must_use]
+    pub fn queue_family_index(&self, queue: QueueType) -> u32 {
+        self.backend.inner.queues.get(queue).family_index
+    }
+
+    /// Returns the native handle for an explicit RHI command pool.
+    pub fn command_pool(
+        &self,
+        pool: &crate::CommandPool<VulkanBackend>,
+    ) -> crate::Result<vk::CommandPool> {
+        ensure_same_device(self.backend, &pool.backend, "Vulkan command-pool interop")?;
+        Ok(pool.raw.raw)
+    }
+
+    /// Returns the native handle for an RHI command buffer.
+    pub fn command_buffer(
+        &self,
+        command_buffer: &crate::CommandBuffer<VulkanBackend>,
+    ) -> crate::Result<vk::CommandBuffer> {
+        ensure_same_device(
+            self.backend,
+            &command_buffer.backend,
+            "Vulkan command-buffer interop",
+        )?;
+        Ok(command_buffer.raw.raw)
+    }
+}
+
+fn ensure_same_device<T>(
+    expected: &Arc<T>,
+    actual: &Arc<T>,
+    operation: &'static str,
+) -> crate::Result<()> {
+    if Arc::ptr_eq(expected, actual) {
+        Ok(())
+    } else {
+        Err(crate::Error::DeviceMismatch { operation })
+    }
+}
+
+impl crate::backend::sealed::InteropSealed for Device<VulkanBackend> {}
+
+impl BackendInterop for Device<VulkanBackend> {
+    type Adapter<'a> = VulkanInterop<'a>;
+
+    fn interop(&self) -> Self::Adapter<'_> {
+        VulkanInterop {
+            backend: &self.backend,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct VulkanError(String);
+
+impl fmt::Display for VulkanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl error::Error for VulkanError {}
+
+pub(super) fn unsupported(message: impl Into<String>) -> crate::Error {
+    crate::Error::backend(VulkanError(message.into()))
+}
+
+pub(super) fn map_error(context: &'static str, error: impl fmt::Display) -> crate::Error {
+    unsupported(format!("{context}: {error}"))
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interop_identity_rejects_another_device() {
+        let first = Arc::new(());
+        let second = Arc::new(());
+
+        assert!(ensure_same_device(&first, &first, "test").is_ok());
+        assert!(matches!(
+            ensure_same_device(&first, &second, "test"),
+            Err(crate::Error::DeviceMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn vulkan_device_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<VulkanDevice>();
+    }
+}

--- a/crates/dirk_rhi/src/vulkan/presentation.rs
+++ b/crates/dirk_rhi/src/vulkan/presentation.rs
@@ -1,0 +1,501 @@
+use std::sync::Arc;
+
+use ash::{Entry, vk};
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+use tracing::warn;
+
+use super::{
+    Garbage, Inner, VulkanBackend, VulkanImage, VulkanImageView, VulkanImageViewInner, map_error,
+    mapping, unsupported,
+};
+use crate::{Format, ImageAspects, ImageSubresourceRange, Result, SwapchainCreateInfo};
+
+/// Window-handle contract accepted by Vulkan surface creation.
+pub trait VulkanSurfaceTarget: HasDisplayHandle + HasWindowHandle {}
+
+impl<T> VulkanSurfaceTarget for T where T: HasDisplayHandle + HasWindowHandle + ?Sized {}
+
+#[doc(hidden)]
+pub struct VulkanSurface {
+    inner: Arc<Inner>,
+    raw: vk::SurfaceKHR,
+}
+
+impl Drop for VulkanSurface {
+    fn drop(&mut self) {
+        self.inner.defer(Garbage::Surface(self.raw));
+    }
+}
+
+struct SwapchainImage {
+    image: VulkanImage,
+    view: VulkanImageView,
+}
+
+#[doc(hidden)]
+pub struct VulkanSwapchain {
+    inner: Arc<Inner>,
+    raw: vk::SwapchainKHR,
+    images: Vec<SwapchainImage>,
+    extent: crate::Extent2D,
+    format: Format,
+}
+
+impl Drop for VulkanSwapchain {
+    fn drop(&mut self) {
+        self.images.clear();
+        self.inner.defer(Garbage::Swapchain(self.raw));
+    }
+}
+
+#[doc(hidden)]
+pub struct VulkanRenderImage {
+    image: VulkanImage,
+    view: VulkanImageView,
+    index: u32,
+    acquire_semaphore: vk::Semaphore,
+}
+
+pub(super) fn create_raw_surface(
+    entry: &Entry,
+    instance: &ash::Instance,
+    target: &(impl VulkanSurfaceTarget + ?Sized),
+) -> Result<vk::SurfaceKHR> {
+    let display = target
+        .display_handle()
+        .map_err(|error| map_error("get Vulkan display handle", error))?;
+    let window = target
+        .window_handle()
+        .map_err(|error| map_error("get Vulkan window handle", error))?;
+    unsafe { ash_window::create_surface(entry, instance, display.as_raw(), window.as_raw(), None) }
+        .map_err(|error| map_error("create Vulkan surface", error))
+}
+
+pub(super) fn create_surface(
+    backend: &VulkanBackend,
+    target: &dyn VulkanSurfaceTarget,
+) -> Result<VulkanSurface> {
+    let Some(present) = backend.inner.queues.present else {
+        return Err(unsupported(
+            "Vulkan device was created headlessly; use new_vulkan_for_window before creating a surface",
+        ));
+    };
+    let raw = create_raw_surface(&backend.inner.entry, &backend.inner.instance, target)?;
+    let supported = unsafe {
+        backend
+            .inner
+            .surface_loader
+            .get_physical_device_surface_support(
+                backend.inner.physical_device,
+                present.family_index,
+                raw,
+            )
+    };
+    let supported = match supported {
+        Ok(supported) => supported,
+        Err(error) => {
+            unsafe { backend.inner.surface_loader.destroy_surface(raw, None) };
+            return Err(map_error("query Vulkan surface support", error));
+        }
+    };
+    if !supported {
+        unsafe { backend.inner.surface_loader.destroy_surface(raw, None) };
+        return Err(unsupported(
+            "selected Vulkan present queue does not support this surface",
+        ));
+    }
+    Ok(VulkanSurface {
+        inner: Arc::clone(&backend.inner),
+        raw,
+    })
+}
+
+pub(super) fn create_swapchain(
+    backend: &VulkanBackend,
+    surface: &VulkanSurface,
+    info: &SwapchainCreateInfo<'_>,
+) -> Result<VulkanSwapchain> {
+    let built = build_swapchain(backend, surface.raw, info, vk::SwapchainKHR::null())?;
+    Ok(VulkanSwapchain {
+        inner: Arc::clone(&backend.inner),
+        raw: built.raw,
+        images: built.images,
+        extent: built.extent,
+        format: built.format,
+    })
+}
+
+pub(super) fn recreate_swapchain(
+    backend: &VulkanBackend,
+    swapchain: &mut VulkanSwapchain,
+    surface: &VulkanSurface,
+    info: &SwapchainCreateInfo<'_>,
+) -> Result<()> {
+    let built = build_swapchain(backend, surface.raw, info, swapchain.raw)?;
+    let old_raw = std::mem::replace(&mut swapchain.raw, built.raw);
+    let old_images = std::mem::replace(&mut swapchain.images, built.images);
+    swapchain.extent = built.extent;
+    swapchain.format = built.format;
+    drop(old_images);
+    backend.inner.defer(Garbage::Swapchain(old_raw));
+    Ok(())
+}
+
+struct BuiltSwapchain {
+    raw: vk::SwapchainKHR,
+    images: Vec<SwapchainImage>,
+    extent: crate::Extent2D,
+    format: Format,
+}
+
+#[allow(clippy::too_many_lines)]
+fn build_swapchain(
+    backend: &VulkanBackend,
+    surface: vk::SurfaceKHR,
+    info: &SwapchainCreateInfo<'_>,
+    old_swapchain: vk::SwapchainKHR,
+) -> Result<BuiltSwapchain> {
+    let present = backend
+        .inner
+        .queues
+        .present
+        .ok_or_else(|| unsupported("Vulkan device has no presentation queue"))?;
+    let capabilities = unsafe {
+        backend
+            .inner
+            .surface_loader
+            .get_physical_device_surface_capabilities(backend.inner.physical_device, surface)
+    }
+    .map_err(|error| map_error("query Vulkan surface capabilities", error))?;
+    let formats = unsafe {
+        backend
+            .inner
+            .surface_loader
+            .get_physical_device_surface_formats(backend.inner.physical_device, surface)
+    }
+    .map_err(|error| map_error("query Vulkan surface formats", error))?;
+    let modes = unsafe {
+        backend
+            .inner
+            .surface_loader
+            .get_physical_device_surface_present_modes(backend.inner.physical_device, surface)
+    }
+    .map_err(|error| map_error("query Vulkan present modes", error))?;
+
+    let (surface_format, format) = choose_surface_format(&formats, info.preferred_formats)?;
+    let requested_mode = mapping::present_mode(info.present_mode);
+    let present_mode = if modes.contains(&requested_mode) {
+        requested_mode
+    } else {
+        warn!(
+            ?requested_mode,
+            "requested Vulkan present mode unavailable; using FIFO"
+        );
+        vk::PresentModeKHR::FIFO
+    };
+    let extent = if capabilities.current_extent.width == u32::MAX {
+        vk::Extent2D {
+            width: info.extent.width.clamp(
+                capabilities.min_image_extent.width,
+                capabilities.max_image_extent.width,
+            ),
+            height: info.extent.height.clamp(
+                capabilities.min_image_extent.height,
+                capabilities.max_image_extent.height,
+            ),
+        }
+    } else {
+        capabilities.current_extent
+    };
+    let usage = mapping::image_usage(info.image_usage);
+    if !capabilities.supported_usage_flags.contains(usage) {
+        return Err(unsupported(format!(
+            "Vulkan surface supports {:?}, but swapchain requires {:?}",
+            capabilities.supported_usage_flags, usage
+        )));
+    }
+    let mut image_count = capabilities.min_image_count.saturating_add(1);
+    if capabilities.max_image_count != 0 {
+        image_count = image_count.min(capabilities.max_image_count);
+    }
+    let mut families = vec![
+        backend.inner.queues.graphics.family_index,
+        backend.inner.queues.transfer.family_index,
+        present.family_index,
+    ];
+    families.sort_unstable();
+    families.dedup();
+    let (sharing_mode, family_indices) = if families.len() > 1 {
+        (vk::SharingMode::CONCURRENT, families.as_slice())
+    } else {
+        (vk::SharingMode::EXCLUSIVE, &[][..])
+    };
+    let composite_alpha = choose_composite_alpha(capabilities.supported_composite_alpha)?;
+    let create_info = vk::SwapchainCreateInfoKHR::default()
+        .surface(surface)
+        .min_image_count(image_count)
+        .image_format(surface_format.format)
+        .image_color_space(surface_format.color_space)
+        .image_extent(extent)
+        .image_array_layers(1)
+        .image_usage(usage)
+        .image_sharing_mode(sharing_mode)
+        .queue_family_indices(family_indices)
+        .pre_transform(capabilities.current_transform)
+        .composite_alpha(composite_alpha)
+        .present_mode(present_mode)
+        .clipped(true)
+        .old_swapchain(old_swapchain);
+    let raw = unsafe {
+        backend
+            .inner
+            .swapchain_loader
+            .create_swapchain(&create_info, None)
+    }
+    .map_err(|error| map_error("create Vulkan swapchain", error))?;
+    let raw_images = match unsafe { backend.inner.swapchain_loader.get_swapchain_images(raw) } {
+        Ok(images) => images,
+        Err(error) => {
+            unsafe { backend.inner.swapchain_loader.destroy_swapchain(raw, None) };
+            return Err(map_error("get Vulkan swapchain images", error));
+        }
+    };
+    let mut raw_views = Vec::with_capacity(raw_images.len());
+    for &image in &raw_images {
+        let view_info = vk::ImageViewCreateInfo::default()
+            .image(image)
+            .view_type(vk::ImageViewType::TYPE_2D)
+            .format(surface_format.format)
+            .subresource_range(mapping::subresource_range(ImageSubresourceRange::all(
+                ImageAspects::COLOR,
+                1,
+                1,
+            )));
+        match unsafe { backend.inner.device.create_image_view(&view_info, None) } {
+            Ok(view) => raw_views.push(view),
+            Err(error) => {
+                unsafe {
+                    for view in raw_views {
+                        backend.inner.device.destroy_image_view(view, None);
+                    }
+                    backend.inner.swapchain_loader.destroy_swapchain(raw, None);
+                }
+                return Err(map_error("create Vulkan swapchain image view", error));
+            }
+        }
+    }
+    let images = raw_images
+        .into_iter()
+        .zip(raw_views)
+        .map(|(image, view)| SwapchainImage {
+            image: VulkanImage::borrowed(Arc::clone(&backend.inner), image, surface_format.format),
+            view: VulkanImageView(Arc::new(VulkanImageViewInner {
+                device: Arc::clone(&backend.inner),
+                raw: view,
+                format: surface_format.format,
+            })),
+        })
+        .collect();
+    Ok(BuiltSwapchain {
+        raw,
+        images,
+        extent: crate::Extent2D::new(extent.width, extent.height),
+        format,
+    })
+}
+
+fn choose_surface_format(
+    available: &[vk::SurfaceFormatKHR],
+    preferred: &[Format],
+) -> Result<(vk::SurfaceFormatKHR, Format)> {
+    if let [undefined] = available
+        && undefined.format == vk::Format::UNDEFINED
+    {
+        let format = preferred.first().copied().unwrap_or(Format::Bgra8Srgb);
+        return Ok((
+            vk::SurfaceFormatKHR {
+                format: mapping::format(format),
+                color_space: undefined.color_space,
+            },
+            format,
+        ));
+    }
+    let find = |format: Format| {
+        available.iter().copied().find(|candidate| {
+            candidate.format == mapping::format(format)
+                && candidate.color_space == vk::ColorSpaceKHR::SRGB_NONLINEAR
+        })
+    };
+    for &format in preferred {
+        if let Some(surface_format) = find(format) {
+            return Ok((surface_format, format));
+        }
+    }
+    if !preferred.is_empty() {
+        return Err(unsupported(format!(
+            "none of the preferred Vulkan swapchain formats {preferred:?} are supported"
+        )));
+    }
+    for &surface_format in available {
+        if surface_format.color_space == vk::ColorSpaceKHR::SRGB_NONLINEAR
+            && let Ok(format) = mapping::format_from_vk(surface_format.format)
+        {
+            return Ok((surface_format, format));
+        }
+    }
+    Err(unsupported(
+        "Vulkan surface exposes no swapchain format represented by the RHI",
+    ))
+}
+
+fn choose_composite_alpha(
+    supported: vk::CompositeAlphaFlagsKHR,
+) -> Result<vk::CompositeAlphaFlagsKHR> {
+    [
+        vk::CompositeAlphaFlagsKHR::OPAQUE,
+        vk::CompositeAlphaFlagsKHR::PRE_MULTIPLIED,
+        vk::CompositeAlphaFlagsKHR::POST_MULTIPLIED,
+        vk::CompositeAlphaFlagsKHR::INHERIT,
+    ]
+    .into_iter()
+    .find(|flag| supported.contains(*flag))
+    .ok_or_else(|| unsupported("Vulkan surface exposes no supported composite-alpha mode"))
+}
+
+pub(super) fn acquire_render_image(
+    backend: &VulkanBackend,
+    swapchain: &mut VulkanSwapchain,
+    timeout_ns: u64,
+    signal: &super::VulkanSemaphore,
+) -> Result<VulkanRenderImage> {
+    let (index, suboptimal) = unsafe {
+        backend.inner.swapchain_loader.acquire_next_image(
+            swapchain.raw,
+            timeout_ns,
+            signal.raw,
+            vk::Fence::null(),
+        )
+    }
+    .map_err(|error| map_error("acquire Vulkan swapchain image", error))?;
+    let image = swapchain
+        .images
+        .get(index as usize)
+        .ok_or_else(|| unsupported("Vulkan returned an out-of-range swapchain image index"))?;
+    if suboptimal {
+        present_raw(backend, swapchain, index, std::slice::from_ref(&signal.raw))?;
+        return Err(unsupported(
+            "Vulkan swapchain is suboptimal and must be recreated",
+        ));
+    }
+    Ok(VulkanRenderImage {
+        image: image.image.clone(),
+        view: image.view.clone(),
+        index,
+        acquire_semaphore: signal.raw,
+    })
+}
+
+pub(super) fn swapchain_extent(swapchain: &VulkanSwapchain) -> crate::Extent2D {
+    swapchain.extent
+}
+
+pub(super) fn swapchain_format(swapchain: &VulkanSwapchain) -> Format {
+    swapchain.format
+}
+
+pub(super) fn render_image_parts(
+    image: &VulkanRenderImage,
+) -> (&VulkanImage, &VulkanImageView, u32) {
+    (&image.image, &image.view, image.index)
+}
+
+pub(super) fn present(
+    backend: &VulkanBackend,
+    swapchain: &mut VulkanSwapchain,
+    image: &VulkanRenderImage,
+    waits: &[&super::VulkanSemaphore],
+) -> Result<()> {
+    let wait_semaphores = waits.iter().map(|wait| wait.raw).collect::<Vec<_>>();
+    present_raw(backend, swapchain, image.index, &wait_semaphores)
+}
+
+pub(super) fn abandon_render_image(
+    backend: &VulkanBackend,
+    swapchain: &mut VulkanSwapchain,
+    image: &VulkanRenderImage,
+) -> Result<()> {
+    // This path is valid only before queue work consumes the acquire semaphore.
+    present_raw(
+        backend,
+        swapchain,
+        image.index,
+        std::slice::from_ref(&image.acquire_semaphore),
+    )
+}
+
+fn present_raw(
+    backend: &VulkanBackend,
+    swapchain: &VulkanSwapchain,
+    index: u32,
+    waits: &[vk::Semaphore],
+) -> Result<()> {
+    let _queue_guard = super::lock(&backend.inner.queue_lock);
+    let present = backend
+        .inner
+        .queues
+        .present
+        .ok_or_else(|| unsupported("Vulkan device has no presentation queue"))?;
+    let swapchains = [swapchain.raw];
+    let indices = [index];
+    let present_info = vk::PresentInfoKHR::default()
+        .wait_semaphores(waits)
+        .swapchains(&swapchains)
+        .image_indices(&indices);
+    let suboptimal = unsafe {
+        backend
+            .inner
+            .swapchain_loader
+            .queue_present(present.raw, &present_info)
+    }
+    .map_err(|error| map_error("present Vulkan swapchain image", error))?;
+    if suboptimal {
+        Err(unsupported(
+            "Vulkan swapchain is suboptimal and must be recreated",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn undefined_surface_format_accepts_the_first_preference() {
+        let available = [vk::SurfaceFormatKHR {
+            format: vk::Format::UNDEFINED,
+            color_space: vk::ColorSpaceKHR::SRGB_NONLINEAR,
+        }];
+        let preferred = [Format::Rgba8Srgb, Format::Bgra8Srgb];
+
+        let (selected, format) =
+            choose_surface_format(&available, &preferred).expect("surface format should map");
+
+        assert_eq!(selected.format, vk::Format::R8G8B8A8_SRGB);
+        assert_eq!(format, Format::Rgba8Srgb);
+    }
+
+    #[test]
+    fn unsupported_explicit_surface_preferences_are_rejected() {
+        let available = [vk::SurfaceFormatKHR {
+            format: vk::Format::B8G8R8A8_SRGB,
+            color_space: vk::ColorSpaceKHR::SRGB_NONLINEAR,
+        }];
+
+        assert!(
+            choose_surface_format(&available, &[Format::Rgba8Srgb]).is_err(),
+            "an explicit unsupported preference must not be substituted",
+        );
+    }
+}


### PR DESCRIPTION
The backend-neutral RHI needs a concrete implementation before the renderer can migrate away from its Vulkan-owned resources.

This adds the Vulkan 1.3 backend inside `dirk_rhi`. It owns instance/device/queues/allocation/deferred deletion, implements resource creation and command recording, supports headless and window presentation setup, and preserves validation layers, macOS portability, anisotropy, synchronization2, dynamic rendering, and timeline semaphores.

The backend currently uses one graphics+compute+transfer queue family and serializes queue operations. This is deliberate until the neutral RHI models queue-family ownership transfers. Vulkan-specific egui compatibility is exposed through a narrow checked interop adapter.

Validation:
- `cargo fmt --all -- --check`
- `cargo check -p dirk_rhi --no-default-features`
- `cargo check -p dirk_rhi --all-features`
- `cargo clippy -p dirk_rhi --no-default-features -- -D warnings`
- `cargo clippy -p dirk_rhi --all-features -- -D warnings`
- `cargo nextest run -p dirk_rhi --no-default-features` (12 passed)
- `cargo nextest run -p dirk_rhi --all-features` (25 passed)
- Additional presentation-only, Vulkan-only, and Vulkan-plus-presentation matrices passed.

Stacked on #75.

Built with GPT-5.6 in the Codex harness through T3 Code.